### PR TITLE
performance - graph, scatterplot and brush select

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -72,21 +72,17 @@ export const graphMargin = { top: 20, right: 10, bottom: 30, left: 40 };
 export const graphWidth = 960;
 export const graphHeight = 960;
 
-export const graphXScale = d3
-  .scaleLinear()
-  .domain([
-    0,
-    1
-  ]) /* while this is the default for d3, our data is normalized so better to be explicit */
-  .range([0 + graphMargin.left, graphWidth - graphMargin.right]);
-
-export const graphYScale = d3
-  .scaleLinear()
-  .domain([
-    0,
-    1
-  ]) /* while this is the default for d3, our data is normalized so better to be explicit */
-  .range([graphHeight - graphMargin.bottom, 0 + graphMargin.top]);
+import { scaleLinear } from "./util/scaleLinear";
+// d3.scaleLinear().domain([0,1]).range([0 + graphMargin.left, graphWidth - graphMargin.right])
+export const graphXScale = scaleLinear(
+  [0, 1],
+  [0 + graphMargin.left, graphWidth - graphMargin.right]
+);
+// d3.scaleLinear().domain([0,1]).range([graphHeight - graphMargin.bottom, 0 + graphMargin.top])
+export const graphYScale = scaleLinear(
+  [0, 1],
+  [graphHeight - graphMargin.bottom, 0 + graphMargin.top]
+);
 
 export const ordinalColors = [
   "#0ac115",

--- a/src/globals.js
+++ b/src/globals.js
@@ -78,10 +78,18 @@ export const graphXScale = scaleLinear(
   [0, 1],
   [0 + graphMargin.left, graphWidth - graphMargin.right]
 );
+graphXScale.invert = scaleLinear(
+  [0 + graphMargin.left, graphWidth - graphMargin.right],
+  [0, 1]
+);
 // d3.scaleLinear().domain([0,1]).range([graphHeight - graphMargin.bottom, 0 + graphMargin.top])
 export const graphYScale = scaleLinear(
   [0, 1],
   [graphHeight - graphMargin.bottom, 0 + graphMargin.top]
+);
+graphYScale.invert = scaleLinear(
+  [graphHeight - graphMargin.bottom, 0 + graphMargin.top],
+  [0, 1]
 );
 
 export const ordinalColors = [

--- a/src/middleware/updateCellColors.js
+++ b/src/middleware/updateCellColors.js
@@ -54,11 +54,12 @@ const updateCellSelectionMiddleware = store => {
       if (action.type === "color by categorical metadata") {
         colorScale = d3.scaleOrdinal().range(globals.ordinalColors);
 
-        _.each(currentSelectionWithUpdatedColors, (cell, i) => {
+        for (let i = 0; i < currentSelectionWithUpdatedColors.length; i++) {
+          const cell = currentSelectionWithUpdatedColors[i];
           let c = colorScale(cell[action.colorAccessor]);
-          currentSelectionWithUpdatedColors[i]["__color__"] = c;
-          currentSelectionWithUpdatedColors[i]["__colorRGB__"] = parseRGB(c);
-        });
+          cell.__color__ = c;
+          cell.__colorRGB__ = parseRGB(c);
+        }
       }
 
       if (action.type === "color by continuous metadata") {

--- a/src/middleware/updateCellSelectionMiddleware.js
+++ b/src/middleware/updateCellSelectionMiddleware.js
@@ -37,7 +37,7 @@ const updateCellSelectionMiddleware = store => {
       if (
         !filterJustChanged ||
         !s.controls.allCellsOnClient
-        /* graphMap is set at the same time as allCells, so we assume it exists */
+        /* graph is set at the same time as allCells, so we assume it exists */
       ) {
         return next(
           action
@@ -46,12 +46,11 @@ const updateCellSelectionMiddleware = store => {
 
       /*
         - make a FRESH copy of all of the cells
-        - metadata has cellname, and that's all we ever need (is a key to graphMap)
+        - metadata has cellname and index, and that's all we ever need to reference cell info
       */
       let newSelection = s.controls.currentCellSelection.slice(0);
-      _.each(newSelection, cell => {
-        cell["__selected__"] = true;
-      });
+      _.forEach(newSelection, cell => (cell.__selected__ = true));
+
       /*
          in plain language...
 
@@ -74,26 +73,23 @@ const updateCellSelectionMiddleware = store => {
             ? action.brushCoords
             : s.controls.graphBrushSelection;
 
-        _.each(newSelection, (cell, i) => {
-          if (!s.controls.graphMap[cell["CellName"]]) {
-            newSelection[i][
-              "__selected__"
-            ] = false; /* make a toggle in future */
-            return;
-          }
-
-          const coords = s.controls.graphMap[cell["CellName"]]; // [0.08005009151334168, 0.6907652173913044]
+        const graphVec = s.controls.graphVec;
+        for (let i = 0; i < newSelection.length; i++) {
+          const cell = newSelection[i];
+          const cellId = cell.__cellIndex__;
+          const x = globals.graphXScale(graphVec[2 * cellId]);
+          const y = globals.graphYScale(graphVec[2 * cellId + 1]);
 
           const pointIsInsideBrushBounds =
-            globals.graphXScale(coords[0]) >= graphBrushSelection.northwestX &&
-            globals.graphXScale(coords[0]) <= graphBrushSelection.southeastX &&
-            globals.graphYScale(coords[1]) >= graphBrushSelection.northwestY &&
-            globals.graphYScale(coords[1]) <= graphBrushSelection.southeastY;
+            x >= graphBrushSelection.northwestX &&
+            x <= graphBrushSelection.southeastX &&
+            y >= graphBrushSelection.northwestY &&
+            y <= graphBrushSelection.southeastY;
 
           if (!pointIsInsideBrushBounds) {
-            newSelection[i]["__selected__"] = false;
+            cell.__selected__ = false;
           }
-        });
+        }
       }
       if (
         (action.type ===

--- a/src/middleware/updateCellSelectionMiddleware.js
+++ b/src/middleware/updateCellSelectionMiddleware.js
@@ -73,18 +73,31 @@ const updateCellSelectionMiddleware = store => {
             ? action.brushCoords
             : s.controls.graphBrushSelection;
 
+        const northwestX = globals.graphXScale.invert(
+          graphBrushSelection.northwestX
+        );
+        const southeastX = globals.graphXScale.invert(
+          graphBrushSelection.southeastX
+        );
+        const northwestY = globals.graphYScale.invert(
+          graphBrushSelection.northwestY
+        );
+        const southeastY = globals.graphYScale.invert(
+          graphBrushSelection.southeastY
+        );
+
         const graphVec = s.controls.graphVec;
         for (let i = 0; i < newSelection.length; i++) {
           const cell = newSelection[i];
           const cellId = cell.__cellIndex__;
-          const x = globals.graphXScale(graphVec[2 * cellId]);
-          const y = globals.graphYScale(graphVec[2 * cellId + 1]);
+          const x = graphVec[2 * cellId];
+          const y = graphVec[2 * cellId + 1];
 
           const pointIsInsideBrushBounds =
-            x >= graphBrushSelection.northwestX &&
-            x <= graphBrushSelection.southeastX &&
-            y >= graphBrushSelection.northwestY &&
-            y <= graphBrushSelection.southeastY;
+            x >= northwestX &&
+            x <= southeastX &&
+            y <= northwestY &&
+            y >= southeastY;
 
           if (!pointIsInsideBrushBounds) {
             cell.__selected__ = false;

--- a/src/util/scaleLinear.js
+++ b/src/util/scaleLinear.js
@@ -1,0 +1,18 @@
+// jshint esversion: 6
+
+// Substitute for a d3 linear scale - less flexible, more performant.
+// Returns a function which will scale a value.
+//
+// Example will scale [0,1] to [-1,1]
+//     var myScale = scaleLinear([0, 1], [-1, 1]);
+//     myScale(0) === -1
+// this is is equivalent to d3.scaleLinear().domain([0,1]).range([-1,1])
+
+export const scaleLinear = (domain, range) => {
+  const offsetD = domain[0];
+  const scale = (range[1] - range[0]) / (domain[1] - domain[0]);
+  const offsetR = range[0];
+  return function(v) {
+    return (v - offsetD) * scale + offsetR;
+  };
+};


### PR DESCRIPTION
Performance work:
* improved performance on scatterplot and graph REGL buffer generation
* introduced optimized state storage for the graph (used to be graphMap, now graphVec a typed array)
* optimizations of brush selection
* optimization of linear scaling (replacement for `d3.scaleLinear()`)

Bug fix:
* small bug fix in scatterplot SVG axis generation code - there was a race condition not protected against which would cause a stack crawl periodically.