### PR TITLE
fix scale inversion for brushing

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -47,8 +47,8 @@ export const bolder = 700;
 
 export let API = {
   // prefix: "http://api.clustering.czi.technology/api/",
-  prefix: "http://tabulamuris.cxg.czi.technology/api/",
-  // prefix: "http://pbmc3k.cxg.czi.technology/api/",
+  //prefix: "http://tabulamuris.cxg.czi.technology/api/",
+   prefix: "http://pbmc3k.cxg.czi.technology/api/",
   // prefix: "http://pbmc33k.cxg.czi.technology/api/",
 
   // prefix: "http://api-staging.clustering.czi.technology/api/",
@@ -71,26 +71,6 @@ export const graphMargin = { top: 20, right: 10, bottom: 30, left: 40 };
 // export const graphHeight = 500;
 export const graphWidth = 700;
 export const graphHeight = 700;
-
-import { scaleLinear } from "./util/scaleLinear";
-// d3.scaleLinear().domain([0,1]).range([0 + graphMargin.left, graphWidth - graphMargin.right])
-export const graphXScale = scaleLinear(
-  [0, 1],
-  [0 + graphMargin.left, graphWidth - graphMargin.right]
-);
-graphXScale.invert = scaleLinear(
-  [0 + graphMargin.left, graphWidth - graphMargin.right],
-  [0, 1]
-);
-// d3.scaleLinear().domain([0,1]).range([graphHeight - graphMargin.bottom, 0 + graphMargin.top])
-export const graphYScale = scaleLinear(
-  [0, 1],
-  [graphHeight - graphMargin.bottom, 0 + graphMargin.top]
-);
-graphYScale.invert = scaleLinear(
-  [graphHeight - graphMargin.bottom, 0 + graphMargin.top],
-  [0, 1]
-);
 
 export const ordinalColors = [
   "#0ac115",

--- a/src/middleware/updateCellSelectionMiddleware.js
+++ b/src/middleware/updateCellSelectionMiddleware.js
@@ -73,19 +73,6 @@ const updateCellSelectionMiddleware = store => {
             ? action.brushCoords
             : s.controls.graphBrushSelection;
 
-        const northwestX = globals.graphXScale.invert(
-          graphBrushSelection.northwestX
-        );
-        const southeastX = globals.graphXScale.invert(
-          graphBrushSelection.southeastX
-        );
-        const northwestY = globals.graphYScale.invert(
-          graphBrushSelection.northwestY
-        );
-        const southeastY = globals.graphYScale.invert(
-          graphBrushSelection.southeastY
-        );
-
         const graphVec = s.controls.graphVec;
         for (let i = 0; i < newSelection.length; i++) {
           const cell = newSelection[i];
@@ -94,10 +81,10 @@ const updateCellSelectionMiddleware = store => {
           const y = graphVec[2 * cellId + 1];
 
           const pointIsInsideBrushBounds =
-            x >= northwestX &&
-            x <= southeastX &&
-            y <= northwestY &&
-            y >= southeastY;
+            x >= graphBrushSelection.northwest[0] &&
+            x <= graphBrushSelection.southeast[0] &&
+            y <= graphBrushSelection.northwest[1] &&
+            y >= graphBrushSelection.southeast[1];
 
           if (!pointIsInsideBrushBounds) {
             cell.__selected__ = false;


### PR DESCRIPTION
This is the first step in fixing the brushing behavior since moving to webgl. With this fix, the brushing now works at the default zoom, and with panning. The key is using the `camera.view()` to get the current translation and then inverting it when mapping from brush (i.e. screen) coordinates to normalized cell coordinates. In the process, I removed some scaling functions we no longer need.

![brush-fix](https://user-images.githubusercontent.com/3387500/39861905-f78a4c52-53f6-11e8-97c3-2dc1dc85cf15.gif)

Still working on the analogous fix for handling zoom level (needs be incorporated into the inverse transform), but wanted to get this in first.
