### PR TITLE
fixed brush behavior when zooming + panning

### DIFF
--- a/src/components/graph/graph.js
+++ b/src/components/graph/graph.js
@@ -204,7 +204,7 @@ class Graph extends React.Component {
         2 *
           (1 - pin[1] / (this.props.responsive.height - this.graphPaddingTop)) -
         1;
-      const pout = [x + inverse[12], y + inverse[13]];
+      const pout = [x * inverse[14] + inverse[12], y * inverse[14] + inverse[13]];
       return [(pout[0] + 1) / 2, (pout[1] + 1) / 2];
     };
 


### PR DESCRIPTION
Previously, brushing did not select the expected cells when zooming or panning. This fixes that by incorporating the inverse of the camera distance into the conversion from screen coordinates to cell coordinates. See the animation below for the correct behavior provided by this PR.

![zoom](https://user-images.githubusercontent.com/3387500/41196355-e12a6938-6bf2-11e8-882c-51223f4a35b1.gif)
 