### PR TITLE
Added clean script for cellxgene

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,16 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+CELLXGENE_DIR=$(dirname $DIR)
+
+echo "Uninstalling cellxgene"
+yes | pip uninstall cellxgene
+echo "removing node_modules"
+rm -rf $CELLXGENE_DIR/client/node_modules
+echo "removing client_build"
+rm -rf $CELLXGENE_DIR/client/build
+echo "removing egg-info"
+rm -rf $CELLXGENE_DIR/cellxgene.egg-info
+echo "removing static files"
+rm $CELLXGENE_DIR/server/app/web/templates/index.html
+rm -rf $CELLXGENE_DIR/server/app/web/static
+echo "cellxgene cleanup complete"
+


### PR DESCRIPTION
This script allows you to start fresh when installing. Cleans up node modules, builds, and uninstalls cellxgene from python.