### PR TITLE
Allow build-client to run anywhere

### DIFF
--- a/bin/build-client
+++ b/bin/build-client
@@ -1,4 +1,8 @@
 #!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+CELLXGENE_DIR=$(dirname $DIR)
+
+cd $CELLXGENE_DIR
 
 npm install --prefix client/ client
 npm run  --prefix client build


### PR DESCRIPTION
Detect where the build-client script lives and then use that to determine where the cellxgene folder is so that we can build the client no matter what directory we are in.