### PR TITLE
Csweaver/filter

### DIFF
--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -21,15 +21,13 @@ class CXGDriver(metaclass=ABCMeta):
     @abstractmethod
     def filter_dataframe(self, filter):
         """
-        Filter cells from data and return a subset of the data
-        A filter is a dictionary where the key is a metadatata category
-        Value is dictionary
-            value_type: int, float, string
-            variable_type: continuous, categorical
-            query: filter value, for categorical [val1, val2], for continuous {min: x, max:y}
-        Filters are combined with the and operator
-        :param filter:
-        :return: filtered dataframe
+         Filter cells from data and return a subset of the data. They can operate on both obs and var dimension with
+         indexing and filtering by annotation value. Filters are combined with the and operator.
+         See REST specs for info on filter format:
+         https://docs.google.com/document/d/1Fxjp1SKtCk7l8QP9-7KAjGXL0eldi_qEnNT0NmlGzXI/edit#heading=h.8qc9q57amldx
+
+        :param filter: dictionary with filter parames
+        :return: View into scanpy object with cells/genes filtered
         """
         pass
 

--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -19,7 +19,7 @@ class CXGDriver(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def filter_cells(self, filter):
+    def filter_dataframe(self, filter):
         """
         Filter cells from data and return a subset of the data
         A filter is a dictionary where the key is a metadatata category

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -118,7 +118,7 @@ class ScanpyEngine(CXGDriver):
         """
         d_axis = getattr(self.data, axis.value)
         for v in filter:
-            if d_axis[v["name"]].dtype.name in ["category", "string"]:
+            if d_axis[v["name"]].dtype.name in ["boolean", "category", "string"]:
                 key_idx = np.in1d(getattr(d_axis, v["name"]), v["values"])
                 index = np.logical_and(index, key_idx)
             else:

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -85,17 +85,17 @@ class ScanpyEngine(CXGDriver):
                 cells_idx = np.logical_and(cells_idx, idx_filter_cell)
             if "annotation_value" in filter["obs"]:
                 for v in filter["obs"]["annotation_value"]:
-                    if self.data.obs[v["name"]].dtype in ["category", "string"]:
-                        key_idx = np.in1d(getattr(self.data.obs, v["name"]), v["query"])
+                    if self.data.obs[v["name"]].dtype.name in ["category", "string"]:
+                        key_idx = np.in1d(getattr(self.data.obs, v["name"]), v["values"])
                         cells_idx = np.logical_and(cells_idx, key_idx)
                     else:
                         min_ = v.get("min", None)
                         max_ = v.get("max", None)
                         if min_ is not None:
-                            key_idx = np.array((getattr(self.data.obs, v["name"]) >= min_).data)
+                            key_idx = (getattr(self.data.obs, v["name"]) >= min_).ravel()
                             cells_idx = np.logical_and(cells_idx, key_idx)
                         if max_ is not None:
-                            key_idx = np.array((getattr(self.data.obs, v["name"]) <= max_).data)
+                            key_idx = (getattr(self.data.obs, v["name"]) <= max_).ravel()
                             cells_idx = np.logical_and(cells_idx, key_idx)
 
         if "var" in filter:
@@ -116,12 +116,12 @@ class ScanpyEngine(CXGDriver):
                         min_ = v.get("min", None)
                         max_ = v.get("max", None)
                         if min_ is not None:
-                            key_idx = np.array((getattr(self.data.var, v["name"]) >= min_).data)
+                            key_idx = (getattr(self.data.var, v["name"]) >= min_).ravel()
                             genes_idx = np.logical_and(genes_idx, key_idx)
                         if max_ is not None:
-                            key_idx = np.array((getattr(self.data.var, v["name"]) <= max_).data)
+                            key_idx = (getattr(self.data.var, v["name"]) <= max_).ravel()
                             genes_idx = np.logical_and(genes_idx, key_idx)
-        # Due to anndata issues we can't index indo cells and genes at the same time
+        # Due to anndata issues we can't index into cells and genes at the same time
         data = self.data[cells_idx,:]
         return data[:,genes_idx]
 

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -8,6 +8,7 @@ from scipy import stats
 
 from server.app.app import cache
 from server.app.driver.driver import CXGDriver
+from server.app.util.axis import Axis
 
 
 class ScanpyEngine(CXGDriver):
@@ -65,6 +66,7 @@ class ScanpyEngine(CXGDriver):
          Filter cells from data and return a subset of the data. They can operate on both obs and var dimension with
          indexing and filtering by annotation value. Filters are combined with the and operator.
          See REST specs for info on filter format:
+         # TODO update this link to swagger when it's done
          https://docs.google.com/document/d/1Fxjp1SKtCk7l8QP9-7KAjGXL0eldi_qEnNT0NmlGzXI/edit#heading=h.8qc9q57amldx
 
         :param filter: dictionary with filter parames
@@ -74,14 +76,14 @@ class ScanpyEngine(CXGDriver):
         genes_idx = np.ones((self.gene_count,), dtype=bool)
         if "obs" in filter:
             if "index" in filter["obs"]:
-                cells_idx = self._filter_index(filter["obs"]["index"], cells_idx, "obs")
+                cells_idx = self._filter_index(filter["obs"]["index"], cells_idx,  Axis.OBS)
             if "annotation_value" in filter["obs"]:
-                cells_idx = self._filter_annotation(filter["obs"]["annotation_value"], cells_idx, "obs")
+                cells_idx = self._filter_annotation(filter["obs"]["annotation_value"], cells_idx, Axis.OBS)
         if "var" in filter:
             if "index" in filter["var"]:
-                genes_idx = self._filter_index(filter["var"]["index"], genes_idx, "var")
+                genes_idx = self._filter_index(filter["var"]["index"], genes_idx, Axis.VAR)
             if "annotation_value" in filter["var"]:
-                genes_idx = self._filter_annotation(filter["var"]["annotation_value"], genes_idx, "var")
+                genes_idx = self._filter_annotation(filter["var"]["annotation_value"], genes_idx, Axis.VAR)
         # Due to anndata issues we can't index into cells and genes at the same time
         data = self.data[cells_idx, :]
         return data[:, genes_idx]
@@ -91,12 +93,12 @@ class ScanpyEngine(CXGDriver):
         Filter data based on index. ex. [1, 3, [111:200]]
         :param filter: subset of filter dict for obs/var:index
         :param index: np logical vector containing true for passing false for failing filter
-        :param axis: string obs or var
+        :param axis: Axis
         :return: np logical vector containing true for passing false for failing filter
         """
-        if axis == "obs":
+        if axis == Axis.OBS:
             count_ = self.cell_count
-        elif axis == "var":
+        elif axis == Axis.VAR:
             count_ = self.gene_count
         idx_filter = np.zeros((count_,), dtype=bool)
         for i in filter:
@@ -114,7 +116,7 @@ class ScanpyEngine(CXGDriver):
         :param axis: string obs or var
         :return: np logical vector containing true for passing false for failing filter
         """
-        d_axis = getattr(self.data, axis)
+        d_axis = getattr(self.data, axis.value)
         for v in filter:
             if d_axis[v["name"]].dtype.name in ["category", "string"]:
                 key_idx = np.in1d(getattr(d_axis, v["name"]), v["values"])

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -8,7 +8,7 @@ from scipy import stats
 
 from server.app.app import cache
 from server.app.driver.driver import CXGDriver
-from server.app.util.axis import Axis
+from server.app.util.constants import Axis
 
 
 class ScanpyEngine(CXGDriver):
@@ -74,12 +74,12 @@ class ScanpyEngine(CXGDriver):
         """
         cells_idx = np.ones((self.cell_count,), dtype=bool)
         genes_idx = np.ones((self.gene_count,), dtype=bool)
-        if "obs" in filter:
+        if Axis.OBS in filter:
             if "index" in filter["obs"]:
                 cells_idx = self._filter_index(filter["obs"]["index"], cells_idx, Axis.OBS)
             if "annotation_value" in filter["obs"]:
                 cells_idx = self._filter_annotation(filter["obs"]["annotation_value"], cells_idx, Axis.OBS)
-        if "var" in filter:
+        if Axis.VAR in filter:
             if "index" in filter["var"]:
                 genes_idx = self._filter_index(filter["var"]["index"], genes_idx, Axis.VAR)
             if "annotation_value" in filter["var"]:

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -60,7 +60,7 @@ class ScanpyEngine(CXGDriver):
         return self.data.var.index.tolist()
 
     # Can't seem to cache a view of a dataframe, need to investigate why
-    def filter_cells(self, filter):
+    def filter_dataframe(self, filter):
         """
         Filter cells from data and return a subset of the data
         A filter is a dictionary where the key is a metadatata category
@@ -72,21 +72,44 @@ class ScanpyEngine(CXGDriver):
         :param filter:
         :return: filtered dataframe
         """
-        cell_idx = np.ones((self.cell_count,), dtype=bool)
-        for key, value in filter.items():
-            if value["variable_type"] == "categorical":
-                key_idx = np.in1d(getattr(self.data.obs, key), value["query"])
-                cell_idx = np.logical_and(cell_idx, key_idx)
-            else:
-                min_ = value["query"]["min"]
-                max_ = value["query"]["max"]
-                if min_ is not None:
-                    key_idx = np.array((getattr(self.data.obs, key) >= min_).data)
-                    cell_idx = np.logical_and(cell_idx, key_idx)
-                if max_ is not None:
-                    key_idx = np.array((getattr(self.data.obs, key) <= max_).data)
-                    cell_idx = np.logical_and(cell_idx, key_idx)
-        return self.data[cell_idx, :]
+        cells_idx = np.ones((self.cell_count,), dtype=bool)
+        genes_idx = np.ones((self.gene_count,), dtype=bool)
+        if "obs" in filter:
+            if "index" in filter["obs"]:
+                idx_filter_cell = np.zeros((self.cell_count,), dtype=bool)
+                for i in filter["obs"]["index"]:
+                    if type(i) == list:
+                        cells_idx[i[0]:i[1]] = True
+                    else:
+                        cells_idx[i] = True
+                cells_idx = np.logical_and(cells_idx, idx_filter_cell)
+        if "var" in filter:
+            if "index" in filter["obs"]:
+                idx_filter_gene = np.zeros((self.gene_count,), dtype=bool)
+                for i in filter["obs"]["index"]:
+                    if type(i) == list:
+                        genes_idx[i[0]:i[1]] = True
+                    else:
+                        genes_idx[i] = True
+                genes_idx = np.logical_and(genes_idx, idx_filter_gene)
+        #
+        # for key, value in filter.items():
+        #     if value["variable_type"] == "categorical":
+        #         key_idx = np.in1d(getattr(self.data.obs, key), value["query"])
+        #         cell_idx = np.logical_and(cell_idx, key_idx)
+        #     else:
+        #         min_ = value["query"]["min"]
+        #         max_ = value["query"]["max"]
+        #         if min_ is not None:
+        #             key_idx = np.array((getattr(self.data.obs, key) >= min_).data)
+        #             cell_idx = np.logical_and(cell_idx, key_idx)
+        #         if max_ is not None:
+        #             key_idx = np.array((getattr(self.data.obs, key) <= max_).data)
+        #             cell_idx = np.logical_and(cell_idx, key_idx)
+
+        # Scanpy doesn't support indexing both cells and genes at the same time
+        index = np.ix_(cells_idx, genes_idx)
+        return self.data[index]
 
     @cache.memoize()
     def metadata_ranges(self, df=None):

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -76,7 +76,7 @@ class ScanpyEngine(CXGDriver):
         genes_idx = np.ones((self.gene_count,), dtype=bool)
         if "obs" in filter:
             if "index" in filter["obs"]:
-                cells_idx = self._filter_index(filter["obs"]["index"], cells_idx,  Axis.OBS)
+                cells_idx = self._filter_index(filter["obs"]["index"], cells_idx, Axis.OBS)
             if "annotation_value" in filter["obs"]:
                 cells_idx = self._filter_annotation(filter["obs"]["annotation_value"], cells_idx, Axis.OBS)
         if "var" in filter:
@@ -94,7 +94,7 @@ class ScanpyEngine(CXGDriver):
         :param filter: subset of filter dict for obs/var:index
         :param index: np logical vector containing true for passing false for failing filter
         :param axis: Axis
-        :return: np logical vector containing true for passing false for failing filter
+        :return: np logical vector for whether the data passes the filter
         """
         if axis == Axis.OBS:
             count_ = self.cell_count
@@ -114,7 +114,7 @@ class ScanpyEngine(CXGDriver):
         :param filter: subset of filter dict for obs/var:annotation_value
         :param index: np logical vector containing true for passing false for failing filter
         :param axis: string obs or var
-        :return: np logical vector containing true for passing false for failing filter
+        :return: np logical vector for whether the data passes the filter
         """
         d_axis = getattr(self.data, axis.value)
         for v in filter:

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -43,10 +43,10 @@ class ScanpyEngine(CXGDriver):
     def _add_mandatory_annotations(self):
         # ensure gene
         self.data.var["name"] = list(self.data.var.index)
-        self.data.var.index = Series(list(range(self.data.var.shape[0])), dtype="int32")
+        self.data.var.index = Series(list(range(self.data.var.shape[0])), dtype="category")
         # ensure cell name
         self.data.obs["name"] = list(self.data.obs.index)
-        self.data.obs.index = Series(list(range(self.data.obs.shape[0])), dtype="int32")
+        self.data.obs.index = Series(list(range(self.data.obs.shape[0])), dtype="category")
 
     def _validatate_data_types(self):
         if self.data.X.dtype != "float32":
@@ -79,37 +79,51 @@ class ScanpyEngine(CXGDriver):
                 idx_filter_cell = np.zeros((self.cell_count,), dtype=bool)
                 for i in filter["obs"]["index"]:
                     if type(i) == list:
-                        cells_idx[i[0]:i[1]] = True
+                        idx_filter_cell[i[0]:i[1]] = True
                     else:
-                        cells_idx[i] = True
+                        idx_filter_cell[i] = True
                 cells_idx = np.logical_and(cells_idx, idx_filter_cell)
-        if "var" in filter:
-            if "index" in filter["obs"]:
-                idx_filter_gene = np.zeros((self.gene_count,), dtype=bool)
-                for i in filter["obs"]["index"]:
-                    if type(i) == list:
-                        genes_idx[i[0]:i[1]] = True
+            if "annotation_value" in filter["obs"]:
+                for v in filter["obs"]["annotation_value"]:
+                    if self.data.obs[v["name"]].dtype in ["category", "string"]:
+                        key_idx = np.in1d(getattr(self.data.obs, v["name"]), v["query"])
+                        cells_idx = np.logical_and(cells_idx, key_idx)
                     else:
-                        genes_idx[i] = True
-                genes_idx = np.logical_and(genes_idx, idx_filter_gene)
-        #
-        # for key, value in filter.items():
-        #     if value["variable_type"] == "categorical":
-        #         key_idx = np.in1d(getattr(self.data.obs, key), value["query"])
-        #         cell_idx = np.logical_and(cell_idx, key_idx)
-        #     else:
-        #         min_ = value["query"]["min"]
-        #         max_ = value["query"]["max"]
-        #         if min_ is not None:
-        #             key_idx = np.array((getattr(self.data.obs, key) >= min_).data)
-        #             cell_idx = np.logical_and(cell_idx, key_idx)
-        #         if max_ is not None:
-        #             key_idx = np.array((getattr(self.data.obs, key) <= max_).data)
-        #             cell_idx = np.logical_and(cell_idx, key_idx)
+                        min_ = v.get("min", None)
+                        max_ = v.get("max", None)
+                        if min_ is not None:
+                            key_idx = np.array((getattr(self.data.obs, v["name"]) >= min_).data)
+                            cells_idx = np.logical_and(cells_idx, key_idx)
+                        if max_ is not None:
+                            key_idx = np.array((getattr(self.data.obs, v["name"]) <= max_).data)
+                            cells_idx = np.logical_and(cells_idx, key_idx)
 
-        # Scanpy doesn't support indexing both cells and genes at the same time
-        index = np.ix_(cells_idx, genes_idx)
-        return self.data[index]
+        if "var" in filter:
+            if "index" in filter["var"]:
+                idx_filter_gene = np.zeros((self.gene_count,), dtype=bool)
+                for i in filter["var"]["index"]:
+                    if type(i) == list:
+                        idx_filter_gene[i[0]:i[1]] = True
+                    else:
+                        idx_filter_gene[i] = True
+                genes_idx = np.logical_and(genes_idx, idx_filter_gene)
+            if "annotation_value" in filter["var"]:
+                for v in filter["var"]["annotation_value"]:
+                    if self.data.var[v["name"]].dtype in ["category", "string"]:
+                        key_idx = np.in1d(getattr(self.data.var, v["name"]), v["query"])
+                        genes_idx = np.logical_and(genes_idx, key_idx)
+                    else:
+                        min_ = v.get("min", None)
+                        max_ = v.get("max", None)
+                        if min_ is not None:
+                            key_idx = np.array((getattr(self.data.var, v["name"]) >= min_).data)
+                            genes_idx = np.logical_and(genes_idx, key_idx)
+                        if max_ is not None:
+                            key_idx = np.array((getattr(self.data.var, v["name"]) <= max_).data)
+                            genes_idx = np.logical_and(genes_idx, key_idx)
+        # Due to anndata issues we can't index indo cells and genes at the same time
+        data = self.data[cells_idx,:]
+        return data[:,genes_idx]
 
     @cache.memoize()
     def metadata_ranges(self, df=None):

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -76,54 +76,47 @@ class ScanpyEngine(CXGDriver):
         genes_idx = np.ones((self.gene_count,), dtype=bool)
         if "obs" in filter:
             if "index" in filter["obs"]:
-                idx_filter_cell = np.zeros((self.cell_count,), dtype=bool)
-                for i in filter["obs"]["index"]:
-                    if type(i) == list:
-                        idx_filter_cell[i[0]:i[1]] = True
-                    else:
-                        idx_filter_cell[i] = True
-                cells_idx = np.logical_and(cells_idx, idx_filter_cell)
+                cells_idx = self._filter_index(cells_idx, filter["obs"]["index"], "obs")
             if "annotation_value" in filter["obs"]:
-                for v in filter["obs"]["annotation_value"]:
-                    if self.data.obs[v["name"]].dtype.name in ["category", "string"]:
-                        key_idx = np.in1d(getattr(self.data.obs, v["name"]), v["values"])
-                        cells_idx = np.logical_and(cells_idx, key_idx)
-                    else:
-                        min_ = v.get("min", None)
-                        max_ = v.get("max", None)
-                        if min_ is not None:
-                            key_idx = (getattr(self.data.obs, v["name"]) >= min_).ravel()
-                            cells_idx = np.logical_and(cells_idx, key_idx)
-                        if max_ is not None:
-                            key_idx = (getattr(self.data.obs, v["name"]) <= max_).ravel()
-                            cells_idx = np.logical_and(cells_idx, key_idx)
-
+                cells_idx = self._filter_annotation(cells_idx, filter["obs"]["annotation_value"], "obs")
         if "var" in filter:
             if "index" in filter["var"]:
-                idx_filter_gene = np.zeros((self.gene_count,), dtype=bool)
-                for i in filter["var"]["index"]:
-                    if type(i) == list:
-                        idx_filter_gene[i[0]:i[1]] = True
-                    else:
-                        idx_filter_gene[i] = True
-                genes_idx = np.logical_and(genes_idx, idx_filter_gene)
+                genes_idx = self._filter_index(genes_idx, filter["var"]["index"], "var")
             if "annotation_value" in filter["var"]:
-                for v in filter["var"]["annotation_value"]:
-                    if self.data.var[v["name"]].dtype in ["category", "string"]:
-                        key_idx = np.in1d(getattr(self.data.var, v["name"]), v["query"])
-                        genes_idx = np.logical_and(genes_idx, key_idx)
-                    else:
-                        min_ = v.get("min", None)
-                        max_ = v.get("max", None)
-                        if min_ is not None:
-                            key_idx = (getattr(self.data.var, v["name"]) >= min_).ravel()
-                            genes_idx = np.logical_and(genes_idx, key_idx)
-                        if max_ is not None:
-                            key_idx = (getattr(self.data.var, v["name"]) <= max_).ravel()
-                            genes_idx = np.logical_and(genes_idx, key_idx)
+                genes_idx = self._filter_annotation(genes_idx, filter["var"]["annotation_value"], "var")
         # Due to anndata issues we can't index into cells and genes at the same time
         data = self.data[cells_idx,:]
         return data[:,genes_idx]
+
+    def _filter_index(self, index, filter, axis):
+        if axis == "obs":
+            count_ = self.cell_count
+        elif axis == "var":
+            count_ = self.gene_count
+        idx_filter= np.zeros((count_,), dtype=bool)
+        for i in filter:
+            if type(i) == list:
+                idx_filter[i[0]:i[1]] = True
+            else:
+                idx_filter[i] = True
+        return np.logical_and(index, idx_filter)
+
+    def _filter_annotation(self, index, filter, axis):
+        d_axis = getattr(self.data, axis)
+        for v in filter:
+            if d_axis[v["name"]].dtype.name in ["category", "string"]:
+                key_idx = np.in1d(getattr(d_axis, v["name"]), v["values"])
+                index = np.logical_and(index, key_idx)
+            else:
+                min_ = v.get("min", None)
+                max_ = v.get("max", None)
+                if min_ is not None:
+                    key_idx = (getattr(d_axis, v["name"]) >= min_).ravel()
+                    index = np.logical_and(index, key_idx)
+                if max_ is not None:
+                    key_idx = (getattr(d_axis, v["name"]) <= max_).ravel()
+                    index = np.logical_and(index, key_idx)
+        return index
 
     @cache.memoize()
     def metadata_ranges(self, df=None):

--- a/server/app/util/axis.py
+++ b/server/app/util/axis.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Axis(Enum):
+    OBS = "obs"
+    VAR = "var"

--- a/server/app/util/axis.py
+++ b/server/app/util/axis.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class Axis(Enum):
-    OBS = "obs"
-    VAR = "var"

--- a/server/app/util/constants.py
+++ b/server/app/util/constants.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class AugmentedEnum(Enum):
+    def __hash__(self):
+        return self.value.__hash__()
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)) or isinstance(other, str):
+            return self.value == other
+        return False
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class Axis(AugmentedEnum):
+    OBS = "obs"
+    VAR = "var"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.6.1
+anndata
 Flask==0.12.4
 Flask-Caching==1.4.0
 Flask-Compress==1.4.0

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -26,7 +26,7 @@ class UtilTest(unittest.TestCase):
         self.assertWarns(UserWarning, self.data._validatate_data_types())
 
     def test_filter_idx(self):
-        filter = {
+        filter_ = {
             "filter": {
                 "var": {
                     "index": [1, 99, [200, 300]]
@@ -36,9 +36,50 @@ class UtilTest(unittest.TestCase):
                 }
             }
         }
-        data = self.data.filter_dataframe(filter["filter"])
+        data = self.data.filter_dataframe(filter_["filter"])
         self.assertEqual(data.shape, (1002, 102))
 
+    def test_filter_annotation(self):
+        filter_ = {
+            "filter": {
+                "obs": {
+                    "annotation_value": [
+                        {"name": "louvain", "values": ["NK cells", "CD8 T cells"]},
+                    ]
+                }
+            }
+        }
+        data = self.data.filter_dataframe(filter_["filter"])
+        self.assertEqual(data.shape, (470, 1838))
+        filter_ = {
+            "filter": {
+                "obs": {
+                    "annotation_value": [
+                        {"name": "n_counts", "min": 3000},
+                    ]
+                }
+            }
+        }
+        data = self.data.filter_dataframe(filter_["filter"])
+        self.assertEqual(data.shape, (497, 1838))
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_filter_complex(self):
+        filter_ = {
+            "filter": {
+                "var": {
+                    "index": [1, 99, [200, 300]]
+                },
+                "obs": {
+                    "annotation_value": [
+                        {"name": "louvain", "values": ["NK cells", "CD8 T cells"]},
+                        {"name": "n_counts", "min": 3000},
+                    ],
+                    "index": [1, 99, [1000, 2000]]
+                }
+            }
+        }
+        data = self.data.filter_dataframe(filter_["filter"])
+        self.assertEqual(data.shape, (15, 102))
+
+        if __name__ == '__main__':
+            unittest.main()

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -81,5 +81,5 @@ class UtilTest(unittest.TestCase):
         data = self.data.filter_dataframe(filter_["filter"])
         self.assertEqual(data.shape, (15, 102))
 
-        if __name__ == '__main__':
-            unittest.main()
+    if __name__ == '__main__':
+        unittest.main()

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -12,7 +12,7 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(self.data.cell_count, 2638)
         self.assertEqual(self.data.gene_count, 1838)
         epsilon = 0.000005
-        self.assertTrue(self.data.data.X[0,0] - -0.17146951 < epsilon)
+        self.assertTrue(self.data.data.X[0, 0] - -0.17146951 < epsilon)
 
     def test_mandatory_annotations(self):
         self.assertIn("name", self.data.data.obs)
@@ -24,6 +24,20 @@ class UtilTest(unittest.TestCase):
     def test_data_type(self):
         self.data.data.X = self.data.data.X.astype("float64")
         self.assertWarns(UserWarning, self.data._validatate_data_types())
+
+    def test_filter_idx(self):
+        filter = {
+            "filter": {
+                "var": {
+                    "index": [1, 99, [200, 300]]
+                },
+                "obs": {
+                    "index": [1, 99, [1000, 2000]]
+                }
+            }
+        }
+        data = self.data.filter_dataframe(filter["filter"])
+        self.assertEqual(data.shape, (1002, 102))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rewriting filtering to match the REST V0.2 spec: https://docs.google.com/document/d/1Fxjp1SKtCk7l8QP9-7KAjGXL0eldi_qEnNT0NmlGzXI/edit#heading=h.8qc9q57amldx

Adding filtering for both genes and cells (thus renamed filter_cells-> filter_dataframe)
I've spun off the functions for filter index and filter by annotations since they are doing different things at the scanpy level. 

Scanpy (really anndata) still has a few strange things that I had to work around
- the indexes can't be integers -> made them categories
- can't index by both var and obs at the same time -> used temp variable to index by one at a time.
