### PR TITLE
Fixed bug where names were NaNs

### DIFF
--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -73,10 +73,10 @@ class ScanpyEngine(CXGDriver):
 
     def _add_mandatory_annotations(self):
         # ensure gene
-        self.data.var["name"] = Series(list(self.data.var.index), dtype="unicode_")
+        self.data.var["name"] = Series(list(self.data.var.index), dtype="unicode_", index=self.data.var.index)
         self.data.var.index = Series(list(range(self.data.var.shape[0])), dtype="category")
         # ensure cell name
-        self.data.obs["name"] = Series(list(self.data.obs.index), dtype="unicode_")
+        self.data.obs["name"] = Series(list(self.data.obs.index), dtype="unicode_", index=self.data.obs.index)
         self.data.obs.index = Series(list(range(self.data.obs.shape[0])), dtype="category")
 
     def _validatate_data_types(self):

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -4,6 +4,7 @@ import pytest
 import time
 import unittest
 
+import numpy as np
 from pandas import Series
 
 from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
@@ -86,6 +87,10 @@ class UtilTest(unittest.TestCase):
         }
         data = self.data.filter_dataframe(filter_["filter"])
         self.assertEqual(data.shape, (15, 102))
+
+    def test_obs_and_var_names(self):
+        self.assertEqual(np.sum(self.data.data.var["name"].isna()), 0)
+        self.assertEqual(np.sum(self.data.data.obs["name"].isna()), 0)
 
     def test_schema(self):
         with open(path.join(path.dirname(__file__), "schema.json")) as fh:


### PR DESCRIPTION
The names for obs and var were being set to NaNs since the indices of obs and var start as names instead of sequential integers. Had to add the dataframe's index to the series.