### PR TITLE
PUT Layout

### DIFF
--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -158,7 +158,6 @@ class LayoutObsAPI(Resource):
         }
     })
     def put(self):
-        print(request.get_json())
         df = current_app.data.filter_dataframe(request.get_json())
         return make_response((jsonify({"layout": current_app.data.layout(df)})))
 

--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -158,7 +158,7 @@ class LayoutObsAPI(Resource):
         }
     })
     def put(self):
-        df = current_app.data.filter_dataframe(request.get_json())
+        df = current_app.data.filter_dataframe(request.get_json()["filter"])
         return make_response((jsonify({"layout": current_app.data.layout(df)})))
 
 

--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -157,7 +157,8 @@ class LayoutObsAPI(Resource):
             }
         }
     })
-    def post(self):
+    def put(self):
+        print(request.get_json())
         df = current_app.data.filter_dataframe(request.get_json())
         return make_response((jsonify({"layout": current_app.data.layout(df)})))
 

--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -1,9 +1,11 @@
 import pkg_resources
 
 from flask import (
-    Blueprint, current_app, jsonify, make_response
+    Blueprint, current_app, jsonify, make_response, request
 )
 from flask_restful_swagger_2 import Api, swagger, Resource
+
+from server.app.util.models import FilterModel
 
 
 class SchemaAPI(Resource):
@@ -126,6 +128,38 @@ class LayoutObsAPI(Resource):
     })
     def get(self):
         return make_response((jsonify({"layout": current_app.data.layout(current_app.data.data)})))
+
+    @swagger.doc({
+        "summary": "Observation layout for filtered subset.",
+        "tags": ["layout"],
+        "parameters": [
+            {
+                'name': 'filter',
+                'description': 'Complex Filter',
+                'in': 'body',
+                'schema': FilterModel
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "layout",
+                "examples": {
+                    "application/json": {
+                        "layout": {
+                            "ndims": 2,
+                            "coordinates": [
+                                [0, 0.284483, 0.983744],
+                                [1, 0.038844, 0.739444]
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    })
+    def post(self):
+        df = current_app.data.filter_dataframe(request.get_json())
+        return make_response((jsonify({"layout": current_app.data.layout(df)})))
 
 
 def get_api_resources():

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -126,8 +126,10 @@ class ScanpyEngine(CXGDriver):
             if "annotation_value" in filter["var"]:
                 genes_idx = self._filter_annotation(filter["var"]["annotation_value"], genes_idx, Axis.VAR)
         # Due to anndata issues we can't index into cells and genes at the same time
-        data = self.data[cells_idx, :]
-        return data[:, genes_idx]
+        cell_data = self.data[cells_idx, :]
+        data = cell_data[:, genes_idx]
+        data.uns = cell_data.uns
+        return data
 
     def _filter_index(self, filter, index, axis):
         """
@@ -214,6 +216,9 @@ class ScanpyEngine(CXGDriver):
         :param df: from filter_cells, dataframe
         :return:  [cellid, x, y, ...]
         """
+        # TODO Filtering cells is fine, but filtering genes does nothing because the neighbors are
+        # calculated using the original vars (geneset) and this doesn’t get updated when you use less.
+        # Need to recalculate neighbors (long) if user requests new layout filtered by var
         getattr(sc.tl, self.layout_method)(df, random_state=123)
         df_layout = df.obsm[f"X_{self.layout_method}"]
         normalized_layout = DataFrame((df_layout - df_layout.min()) / (df_layout.max() - df_layout.min()),

--- a/server/app/util/models.py
+++ b/server/app/util/models.py
@@ -3,6 +3,7 @@ from flask_restful_swagger_2 import Schema
 
 class AnnotationModel(Schema):
     type = "object"
+    description = "Filter by annotation key: value"
     properties = {
         "name": {
             "type": "string"
@@ -28,6 +29,7 @@ class AnnotationModel(Schema):
 
 class IndexModel(Schema):
     type = "object"
+    description = "Filter by index of observation/variable ex. [0, 5, 15]"
     properties = {
         "index": {
             "type": "array",
@@ -42,6 +44,7 @@ class IndexModel(Schema):
 
 class AxisModel(Schema):
     type = "object"
+    description = "Axis of data -- obs or var"
     properties = {
         "index": IndexModel,
         "annotation_value": AnnotationModel.array()
@@ -50,6 +53,7 @@ class AxisModel(Schema):
 
 class FilterModel(Schema):
     type = "object"
+    description = "Complex filter"
     properties = {
         "filter": {
             "type": "object",

--- a/server/app/util/models.py
+++ b/server/app/util/models.py
@@ -1,0 +1,61 @@
+from flask_restful_swagger_2 import Schema
+
+
+class AnnotationModel(Schema):
+    type = "object"
+    properties = {
+        "name": {
+            "type": "string"
+        },
+        # TODO update to OpenAPI v3.0 when a library is available that supports it
+        # Unfortunately 2.0 doesn't have a way to have a schema that accepts multiple types
+        # Overloading the type key with a list seems to work ok and makes it to the page
+        "values": {
+            "type": "array",
+            "items": {
+                "type": ["float32", "string", "int32", "bool"]
+            }
+        },
+        "min": {
+            "type": ["int32", "float32"],
+        },
+        "max": {
+            "type": ["int32", "float32"],
+        }
+    }
+    required = ["name"]
+
+
+class IndexModel(Schema):
+    type = "object"
+    properties = {
+        "index": {
+            "type": "array",
+            "items": {
+                "format": "int32",
+                "type": "integer"
+            }
+
+        }
+    }
+
+
+class AxisModel(Schema):
+    type = "object"
+    properties = {
+        "index": IndexModel,
+        "annotation_value": AnnotationModel.array()
+    }
+
+
+class FilterModel(Schema):
+    type = "object"
+    properties = {
+        "filter": {
+            "type": "object",
+            "properties": {
+                "obs": AxisModel,
+                "var": AxisModel
+            }
+        }
+    }

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -53,7 +53,6 @@ class EndPoints(unittest.TestCase):
         result = self.session.put(url, json=obs_filter)
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
-        print(result_data)
 
     def test_static(self):
         url = "{url}{endpoint}/{file}".format(url=self.local_url, endpoint="static", file="js/service-worker.js")

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -1,5 +1,6 @@
-import unittest
+import json
 import requests
+import unittest
 
 
 class EndPoints(unittest.TestCase):
@@ -35,6 +36,24 @@ class EndPoints(unittest.TestCase):
         result_data = result.json()
         self.assertEqual(result_data["layout"]["ndims"], 2)
         self.assertEqual(len(result_data["layout"]["coordinates"]), 2638)
+
+    def test_put_layout(self):
+        url = "{base}{endpoint}".format(base=self.url_base, endpoint="layout/obs")
+        obs_filter = {
+            "filter": {
+                "obs": {
+                    "annotation_value": [
+                        {"name": "louvain", "values": ["NK cells", "CD8 T cells"]},
+                        {"name": "n_counts", "min": 3000},
+                    ],
+                    "index": [1, 99, [1000, 2000]]
+                }
+            }
+        }
+        result = self.session.put(url, json=obs_filter)
+        self.assertEqual(result.status_code, 200)
+        result_data = result.json()
+        print(result_data)
 
     def test_static(self):
         url = "{url}{endpoint}/{file}".format(url=self.local_url, endpoint="static", file="js/service-worker.js")

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -53,6 +53,7 @@ class EndPoints(unittest.TestCase):
         result = self.session.put(url, json=obs_filter)
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
+        self.assertEqual(len(result_data["layout"]["coordinates"]), 15)
 
     def test_static(self):
         url = "{url}{endpoint}/{file}".format(url=self.local_url, endpoint="static", file="js/service-worker.js")

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -115,5 +115,19 @@ class UtilTest(unittest.TestCase):
             self.assertLessEqual(val[1], 1)
             self.assertLessEqual(val[2], 1)
 
+    def test_filtered_layout(self):
+        filter_ = {
+            "filter": {
+                "obs": {
+                    "annotation_value": [
+                        {"name": "n_counts", "min": 3000},
+                    ]
+                }
+            }
+        }
+        data = self.data.filter_dataframe(filter_["filter"])
+        layout = self.data.layout(data)
+        self.assertEqual(len(layout["coordinates"]), 497)
+
     if __name__ == '__main__':
         unittest.main()


### PR DESCRIPTION
Request a recalculated graph layout via PUT using a complex filter.

There are some issues with this:
- Swagger 2.0 doesn't allow params that can be of mixed types. My hacky solution was to put the types allowed in the type key. They show up as: "Unknown Type: int32,float32", which is good enough until connexion or something provides OpenAPI 3.0 support
- There is an issue where if a user filters by var (gene) the layout will not actually layout based on the subset. This is because layout is calculated using a precalucalted intermediary (neighbors in umap's case) and this is no longer relevant when you reduce the number of genes. Discussing how to handle this but I want to put the post endpoint up before the discussion gets resolved.

