### PR TITLE
Cleanup Tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ script:
   - set -eo pipefail
   - flake8 server/app/
   - pytest -s server/test/test_filter.py server/test/test_scanpy_engine.py
+  - cellxgene scanpy example-dataset/ &
+  - for i in {1..90}; do if http :5005/api/v0.1/initialize > /dev/null; then break; else echo "Waiting for server..."; sleep 1; fi; done
+  - pytest server/test/test_api.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,4 @@ install:
 script:
   - set -eo pipefail
   - flake8 server/app/
-  - pytest -s server/test/test_filter.py server/test/test_scanpy_engine.py
-  - cellxgene scanpy example-dataset/ &
-  - for i in {1..90}; do if http :5005/api/v0.1/initialize > /dev/null; then break; else echo "Waiting for server..."; sleep 1; fi; done
-  - pytest server/test/test_api.py
+  - pytest -s server/test

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -9,11 +9,13 @@ from flask_cors import CORS
 from flask_restful_swagger_2 import get_swagger_blueprint
 
 from .rest_api.rest import get_api_resources
+from .util.utils import Float32JSONEncoder
 from .web import webapp
 
 REACTIVE_LIMIT = 1_000_000
 
 app = Flask(__name__, static_folder="web/static")
+app.json_encoder = Float32JSONEncoder
 cache = Cache(app, config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 860000})
 Compress(app)
 CORS(app)

--- a/server/app/util/utils.py
+++ b/server/app/util/utils.py
@@ -1,7 +1,6 @@
 import json
 
 from numpy import float32, integer
-from flask import make_response, Response
 
 
 class Float32JSONEncoder(json.JSONEncoder):
@@ -11,20 +10,3 @@ class Float32JSONEncoder(json.JSONEncoder):
         elif isinstance(obj, integer):
             return int(obj)
         return json.JSONEncoder.default(self, obj)
-
-
-def make_payload(data, errorcode=200):
-    """
-    Creates JSON respons for requests
-    :param data: json data
-    :param errorcode: http error code
-    :return: flask json repsonse
-    """
-    # Questionable
-    data = json.loads(json.dumps(data, cls=Float32JSONEncoder))
-    return make_response(data, errorcode)
-
-
-def make_streaming_response(data_generator, errorcode=200, content_type="application/json"):
-    # TODO headers
-    return Response(data_generator, status=errorcode, content_type=content_type)

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -1,19 +1,39 @@
 import unittest
 import requests
+from subprocess import Popen
+import time
+
+LOCAL_URL = "http://127.0.0.1:5005/"
+VERSION = "v0.2"
+URL_BASE = f"{LOCAL_URL}api/{VERSION}/"
 
 
 class EndPoints(unittest.TestCase):
     """Test Case for endpoints"""
 
+    @classmethod
+    def setUpClass(cls):
+        cls.ps = Popen(["cellxgene", "scanpy", "example-dataset/"])
+        session = requests.Session()
+        for i in range(90):
+            try:
+                session.get(f"{URL_BASE}schema")
+            except requests.exceptions.ConnectionError:
+                time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.ps.terminate()
+        except ProcessLookupError:
+            pass
+
     def setUp(self):
-        # Local
-        self.local_url = "http://127.0.0.1:5005/"
-        self.version = "v0.2"
-        self.url_base = "{local_url}api/{version}/".format(local_url=self.local_url, version=self.version)
         self.session = requests.Session()
 
     def test_initialize(self):
-        url = "{base}{endpoint}".format(base=self.url_base, endpoint="schema")
+        endpoint = "schema"
+        url = f"{URL_BASE}{endpoint}"
         result = self.session.get(url)
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
@@ -21,7 +41,8 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(len(result_data["schema"]["annotations"]["obs"]), 5)
 
     def test_config(self):
-        url = "{base}{endpoint}".format(base=self.url_base, endpoint="config")
+        endpoint = "config"
+        url = f"{URL_BASE}{endpoint}"
         result = self.session.get(url)
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
@@ -29,7 +50,8 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(len(result_data["config"]["features"]), 4)
 
     def test_get_layout(self):
-        url = "{base}{endpoint}".format(base=self.url_base, endpoint="layout/obs")
+        endpoint = "layout/obs"
+        url = f"{URL_BASE}{endpoint}"
         result = self.session.get(url)
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
@@ -37,6 +59,9 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(len(result_data["layout"]["coordinates"]), 2638)
 
     def test_static(self):
-        url = "{url}{endpoint}/{file}".format(url=self.local_url, endpoint="static", file="js/service-worker.js")
+        endpoint = "static"
+        file = "js/service-worker.js"
+        url = f"{LOCAL_URL}{endpoint}/{file}"
         result = self.session.get(url)
+        print(result.status_code)
         self.assertEqual(result.status_code, 200)

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -59,32 +59,9 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(result_data["layout"]["ndims"], 2)
         self.assertEqual(len(result_data["layout"]["coordinates"]), 2638)
 
-    def test_get_annotations(self):
-        url = "{base}{endpoint}".format(base=self.url_base, endpoint="annotations/obs")
-        result = self.session.get(url)
-        self.assertEqual(result.status_code, 200)
-        result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
-        self.assertEqual(len(result_data["data"]), 2638)
-        self.assertEqual(len(result_data["data"][0]), 6)
-
-    def test_get_annotations_keys(self):
-        url = "{base}{endpoint}?{query}".format(base=self.url_base, endpoint="annotations/obs",
-                                                query="annotation-name=n_genes&annotation-name=percent_mito")
-        result = self.session.get(url)
-        self.assertEqual(result.status_code, 200)
-        result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_genes", "percent_mito"])
-        self.assertEqual(len(result_data["data"][0]), 3)
-
-    def test_get_annotations_error(self):
-        url = "{base}{endpoint}?{query}".format(base=self.url_base, endpoint="annotations/obs",
-                                                query="annotation-name=notakey")
-        result = self.session.get(url)
-        self.assertEqual(result.status_code, 404)
-
     def test_put_layout(self):
-        url = "{base}{endpoint}".format(base=self.url_base, endpoint="layout/obs")
+        endpoint = "layout/obs"
+        url = f"{URL_BASE}{endpoint}"
         obs_filter = {
             "filter": {
                 "obs": {
@@ -100,6 +77,33 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
         self.assertEqual(len(result_data["layout"]["coordinates"]), 15)
+
+    def test_get_annotations(self):
+        endpoint = "annotations/obs"
+        url = f"{URL_BASE}{endpoint}"
+        result = self.session.get(url)
+        self.assertEqual(result.status_code, 200)
+        result_data = result.json()
+        self.assertEqual(result_data["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
+        self.assertEqual(len(result_data["data"]), 2638)
+        self.assertEqual(len(result_data["data"][0]), 6)
+
+    def test_get_annotations_keys(self):
+        endpoint = "annotations/obs"
+        query = "annotation-name=n_genes&annotation-name=percent_mito"
+        url = f"{URL_BASE}{endpoint}?{query}"
+        result = self.session.get(url)
+        self.assertEqual(result.status_code, 200)
+        result_data = result.json()
+        self.assertEqual(result_data["names"], ["n_genes", "percent_mito"])
+        self.assertEqual(len(result_data["data"][0]), 3)
+
+    def test_get_annotations_error(self):
+        endpoint = "annotations/obs"
+        query = "annotation-name=notakey"
+        url = f"{URL_BASE}{endpoint}?{query}"
+        result = self.session.get(url)
+        self.assertEqual(result.status_code, 404)
 
     def test_static(self):
         endpoint = "static"


### PR DESCRIPTION
Minor cleanup tasks
- add the API tests back in (😨 can't believe they weren't already in...)
- Use a custom JSON encoder for responses so I don't have to do weird stuff when making JSON encoded responses with the API. This eliminates the need for a custom response making function.