### PR TITLE
CLI improvements

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,0 +1,12 @@
+# Work around bug https://github.com/pallets/werkzeug/issues/461
+if __package__ is None:
+    import sys
+    from pathlib import Path
+    PKG_PATH = Path(__file__).parent
+    sys.path.insert(0, str(PKG_PATH.parent))
+    import server
+    __package__ = PKG_PATH.name
+
+# Main thing
+from .app.app import main
+main()

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -64,12 +64,15 @@ def main():
     parser.add_argument("--title", "-t", help="Title to display -- if this is omitted the title will be the name "
                                               "of the directory from the data_directory arg")
     parser.add_argument("--port", help="Port to run server on.", type=int, default=5005)
-    subparsers = parser.add_subparsers(dest="cellxgene_command")
+    subparsers = parser.add_subparsers(dest="engine", required=True)
     try:
         from .scanpy_engine.scanpy_engine import ScanpyEngine
     except ImportError:
+        warnings.simplefilter('default', ImportWarning)  # Enable ImportWarning
         warnings.warn("Scanpy engine not available", ImportWarning)
     else:
         ScanpyEngine.add_to_parser(subparsers, run_scanpy)
+    if len(subparsers.choices) == 0:
+        raise ImportError('Could not import any engines, see warnings above')
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
This adds a `__main__.py` that still works with werkzeug’s bugged reloading behavior. This way one can run cellxgene via `python -m server` from the working directory without installing the package.

This PR also improves the error reporting of the CLI:

1. There‘s now a helpful error if you don’t provide a subcommand (like when not providing any arguments).
2. Python disables ImportWarnings by default, so I reenabled them them to see the scanpy warning!
3. If none of the engines could be loaded, it now fails with a nicer error message.