### PR TITLE
Option to bind to all interfaces

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -57,7 +57,11 @@ def run_scanpy(args):
 
     from .scanpy_engine.scanpy_engine import ScanpyEngine
     app.data = ScanpyEngine(args.data_directory, layout_method=args.layout, diffexp_method=args.diffexp)
-    app.run(host="127.0.0.1", debug=True, port=args.port)
+    if args.bind_all:
+        host = "0.0.0.0"
+    else:
+        host = "127.0.0.1"
+    app.run(host=host, debug=True, port=args.port)
 
 
 def main():
@@ -65,6 +69,10 @@ def main():
     parser.add_argument("--title", "-t", help="Title to display -- if this is omitted the title will be the name "
                                               "of the directory from the data_directory arg")
     parser.add_argument("--port", help="Port to run server on.", type=int, default=5005)
+    parser.add_argument(
+        "--bind-all",
+        help="Bind to all interfaces (this makes the server accessible beyond this computer)",
+        action="store_true")
     subparsers = parser.add_subparsers(dest="cellxgene_command")
     try:
         from .scanpy_engine.scanpy_engine import ScanpyEngine


### PR DESCRIPTION
app.run("0.0.0.0") instead of app.run("127.0.0.1") binds to all interfaces.

Note: There are comments on the internet that says that the flask server is not up to the task of production serving.  I don't think that such scalability concerns apply here, but I was able to get cellxgene working with twistd relatively easily, and we could switch to that if there are scalability concerns.

Test plan: browsed to <ip>:5005/api/v0.2/config on a different host.

Fixes https://github.com/chanzuckerberg/cellxgene/issues/184