### PR TITLE
Csweaver/rest diffexp

### DIFF
--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -76,12 +76,15 @@ class CXGDriver(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def diffexp(self, df1, df2):
+    def diffexp(self, df1, df2, genes):
         """
-        Computes the top differentially expressed genes between two clusters
-        :param df1: from filter_cells, dataframe containing first set of cells
-        :param df2: from filter_cells, dataframe containing second set of cells
-        :return: top genes, stats and expression values for top genes
+        Computes the top differentially expressed variables between two observation sets. If dataframes
+        contain a subset of variables, then statistics for all variables will be returned, otherwise
+        only the top N vars will be returned.
+        :param df1: from filter_cells, dataframe containing first set of observations
+        :param df2: from filter_cells, dataframe containing second set of observations
+        :param topN: Limit results to top N (Top var mode only)
+        :return: top genes, stats and expression values for variables
         """
         pass
 

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -241,11 +241,11 @@ class ScanpyEngine(CXGDriver):
 
         # If not all genes, they used a var filter
         if df1.var.shape[0] < self.gene_count:
-            mode = DiffExpMode("var filter")
+            mode = DiffExpMode.VAR_FILTER
             if top_n:
                 raise Warning("Top N was specified but will not be used in 'Var Filter' mode")
         else:
-            mode = DiffExpMode("top var")
+            mode = DiffExpMode.TOP_N
             if not top_n:
                 top_n = DEFAULT_TOP_N
 
@@ -256,7 +256,7 @@ class ScanpyEngine(CXGDriver):
         ave_exp_set1 = np.mean(df1.X, axis=0)
         ave_exp_set2 = np.mean(df2.X, axis=0)
         ave_diff = ave_exp_set1 - ave_exp_set2
-        if mode == DiffExpMode.TOP_VAR:
+        if mode == DiffExpMode.TOP_N:
             sort_order = np.argsort(np.abs(diffexp_result.statistic))[::-1]
             # If top_n > length it will just return length
             genes = self._top_sort(genes_idx, sort_order, top_n)

--- a/server/app/util/constants.py
+++ b/server/app/util/constants.py
@@ -1,6 +1,9 @@
 from enum import Enum
 
 
+DEFAULT_TOP_N = 10
+
+
 class AugmentedEnum(Enum):
     def __hash__(self):
         return self.value.__hash__()
@@ -17,3 +20,8 @@ class AugmentedEnum(Enum):
 class Axis(AugmentedEnum):
     OBS = "obs"
     VAR = "var"
+
+
+class DiffExpMode(AugmentedEnum):
+    TOP_VAR = "top var"
+    VAR_FILTER = "var filter"

--- a/server/app/util/constants.py
+++ b/server/app/util/constants.py
@@ -23,5 +23,5 @@ class Axis(AugmentedEnum):
 
 
 class DiffExpMode(AugmentedEnum):
-    TOP_VAR = "top var"
-    VAR_FILTER = "var filter"
+    TOP_N = "topN"
+    VAR_FILTER = "varFilter"

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -294,5 +294,4 @@ class EndPoints(unittest.TestCase):
         file = "js/service-worker.js"
         url = f"{LOCAL_URL}{endpoint}/{file}"
         result = self.session.get(url)
-        print(result.status_code)
         self.assertEqual(result.status_code, 200)

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -105,7 +105,6 @@ class EndPoints(unittest.TestCase):
         result = self.session.get(url)
         self.assertEqual(result.status_code, 404)
 
-
     def test_put_annotations(self):
         endpoint = "annotations/obs"
         url = f"{URL_BASE}{endpoint}"
@@ -147,6 +146,34 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(result_data["names"], ["n_genes", "percent_mito"])
         self.assertEqual(len(result_data["data"][0]), 3)
         self.assertEqual(len(result_data["data"]), 15)
+
+    def test_diff_exp(self):
+        endpoint = "diffexp/obs"
+        url = f"{URL_BASE}{endpoint}"
+        params = {
+            "mode": "topN",
+            "set1": {
+                "filter": {
+                    "obs": {"annotation_value": [
+                        {"name": "louvain", "values": ["NK cells"]}
+                    ]
+                    }
+                }
+            },
+            "set2": {
+                "filter": {
+                    "obs": {"annotation_value": [
+                        {"name": "louvain", "values": ["CD8 T cells"]}
+                    ]
+                    }
+                }
+            },
+            "count": 7
+        }
+        result = self.session.post(url, json=params)
+        self.assertEqual(result.status_code, 200)
+        result_data = result.json()
+        self.assertEqual(len(result_data), 7)
 
     def test_static(self):
         endpoint = "static"

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -8,7 +8,6 @@ VERSION = "v0.2"
 URL_BASE = f"{LOCAL_URL}api/{VERSION}/"
 
 
-
 class EndPoints(unittest.TestCase):
     """Test Case for endpoints"""
 
@@ -174,6 +173,31 @@ class EndPoints(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         result_data = result.json()
         self.assertEqual(len(result_data), 7)
+
+    def test_diff_exp(self):
+        endpoint = "diffexp/obs"
+        url = f"{URL_BASE}{endpoint}"
+        params = {
+            "mode": "topN",
+            "set1": {
+                "filter": {
+                    "obs": {
+                        "index": [[0, 500]]
+                    }
+                }
+            },
+            "set2": {
+                "filter": {
+                    "obs": {
+                        "index": [[500, 1000]]
+                    }
+                }
+            }
+        }
+        result = self.session.post(url, json=params)
+        self.assertEqual(result.status_code, 200)
+        result_data = result.json()
+        self.assertEqual(len(result_data), 10)
 
     def test_get_annotations_var(self):
         endpoint = "annotations/var"

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -147,7 +147,6 @@ class UtilTest(unittest.TestCase):
             }
         }
         data = self.data.filter_dataframe(filter_["filter"])
-        print(data.shape)
         annotations = self.data.annotation(data, "obs")
         self.assertEqual(annotations["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
         self.assertEqual(len(annotations["data"]), 497)

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -134,5 +134,30 @@ class UtilTest(unittest.TestCase):
         layout = self.data.layout(data)
         self.assertEqual(len(layout["coordinates"]), 497)
 
+    def test_diffexp(self):
+        f1 = {
+            "filter": {
+                "obs": {
+                    "index": [[0, 500]]
+                }
+            }
+        }
+        df1 = self.data.filter_dataframe(f1["filter"])
+        f2 = {
+            "filter": {
+                "obs": {
+                    "index": [[500, 1000]]
+                }
+            }
+        }
+        df2 = self.data.filter_dataframe(f2["filter"])
+        result = self.data.diffexp(df1, df2)
+        self.assertEqual(len(result), 10)
+        var_idx = [i[0] for i in result]
+        self.assertEqual(var_idx, sorted(var_idx))
+        result = self.data.diffexp(df1, df2, 20)
+        self.assertEqual(len(result), 20)
+
+
     if __name__ == '__main__':
         unittest.main()


### PR DESCRIPTION
added t-test diffexp for scanpy engine. This is the quick and dirty version of /diffexp/obs. Anything not absolutely necessary for getting the FE running has been ignored.

a little unsure about Bonferroni correction (@freeman-lab can you please check that the stats make sense?) Bonferroni not at right sigfig currently for sure.
@ttung wasn't sure if the _top_sort method should be in the engine or utils. Went with engine since I didn't imagine using it elsewhere