### PR TITLE
Cache fix

### DIFF
--- a/server/app/util/utils.py
+++ b/server/app/util/utils.py
@@ -31,3 +31,11 @@ def get_mime_type(default="application/json", acceptable_types=["application/jso
         if not mime_type:
             raise MimeTypeError(f"Unsupported mime type(s) {header} in HTTP Accept header")
     return mime_type
+
+
+def var_index(df):
+    return df.var.index.tolist()
+
+
+def obs_index(df):
+    return df.obs.index.tolist()

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -10,14 +10,14 @@ VERSION = "v0.2"
 URL_BASE = f"{LOCAL_URL}api/{VERSION}/"
 
 BAD_FILTER = {
-            "filter": {
-                "obs": {
-                    "annotation_value": [
-                        {"name": "xyz"},
-                    ],
-                }
-            }
+    "filter": {
+        "obs": {
+            "annotation_value": [
+                {"name": "xyz"},
+            ],
         }
+    }
+}
 
 
 class EndPoints(unittest.TestCase):
@@ -42,6 +42,39 @@ class EndPoints(unittest.TestCase):
 
     def setUp(self):
         self.session = requests.Session()
+
+    def test_cache(self):
+        endpoint = "annotations/var"
+        url = f"{URL_BASE}{endpoint}"
+        f1 = {"filter": {"var": {"annotation_value": [{"name": "name",
+                                                       "values": ["HLA-DRB1", "HLA-DQA1", "HLA-DQB1", "HLA-DPA1",
+                                                                  "HLA-DPB1", "MS4A1", "IL32", "CCL5", "CD79B",
+                                                                  "CD79A"]}]}}}
+        result = self.session.put(url, json=f1)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        result_data1 = result.json()
+        f2 = {"filter": {"var": {"annotation_value": [{"name": "name",
+                                                       "values": ["FGFBP2", "GZMA", "LTB", "PRF1", "CTSW", "GZMH",
+                                                                  "CCL5", "CCL4", "CST7", "NKG7"]}]}}}
+        result = self.session.put(url, json=f2)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        result_data2 = result.json()
+        self.assertNotEqual(result_data1, result_data2)
+
+    def test_cache_nofilter(self):
+        endpoint = "annotations/var"
+        url = f"{URL_BASE}{endpoint}"
+        f1 = {"filter": {}}
+        result = self.session.put(url, json=f1)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        result_data1 = result.json()
+        f2 = {"filter": {"var": {"annotation_value": [{"name": "name",
+                                                       "values": ["FGFBP2", "GZMA", "LTB", "PRF1", "CTSW", "GZMH",
+                                                                  "CCL5", "CCL4", "CST7", "NKG7"]}]}}}
+        result = self.session.put(url, json=f2)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        result_data2 = result.json()
+        self.assertNotEqual(result_data1, result_data2)
 
     def test_initialize(self):
         endpoint = "schema"

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -137,10 +137,10 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(len(annotations["data"]), 1838)
 
     def test_annotation_fields(self):
-        annotations = self.data.annotation(self.data.data, "obs", ["n_genes", "n_counts"])
+        annotations = self.data.annotation(self.data.data, "obs", fields=["n_genes", "n_counts"])
         self.assertEqual(annotations["names"], ["n_genes", "n_counts"])
         self.assertEqual(len(annotations["data"]), 2638)
-        annotations = self.data.annotation(self.data.data, "var", ["name"])
+        annotations = self.data.annotation(self.data.data, "var", fields=["name"])
         self.assertEqual(annotations["names"], ["name"])
         self.assertEqual(len(annotations["data"]), 1838)
 
@@ -160,10 +160,12 @@ class UtilTest(unittest.TestCase):
             }
         }
         data = self.data.filter_dataframe(filter_["filter"])
-        annotations = self.data.annotation(data, "obs")
+        annotations = self.data.annotation(data, "obs", var_index=data.var.index.tolist(),
+                                           obs_index=data.obs.index.tolist())
         self.assertEqual(annotations["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
         self.assertEqual(len(annotations["data"]), 497)
-        annotations = self.data.annotation(data, "var")
+        annotations = self.data.annotation(data, "var", var_index=data.var.index.tolist(),
+                                           obs_index=data.obs.index.tolist())
         self.assertEqual(annotations["names"], ["n_cells", "name"])
         self.assertEqual(len(annotations["data"]), 2)
 
@@ -178,7 +180,7 @@ class UtilTest(unittest.TestCase):
             }
         }
         data = self.data.filter_dataframe(filter_["filter"])
-        layout = self.data.layout(data)
+        layout = self.data.layout(data, var_index=data.var.index.tolist(), obs_index=data.obs.index.tolist())
         self.assertEqual(len(layout["coordinates"]), 497)
 
     def test_diffexp(self):
@@ -198,11 +200,13 @@ class UtilTest(unittest.TestCase):
             }
         }
         df2 = self.data.filter_dataframe(f2["filter"])
-        result = self.data.diffexp(df1, df2)
+        result = self.data.diffexp(df1, df2, var_index1=df1.var.index.tolist(), obs_index1=df1.obs.index.tolist(),
+                                   var_index2=df2.var.index.tolist(), obs_index2=df2.obs.index.tolist())
         self.assertEqual(len(result), 10)
         var_idx = [i[0] for i in result]
         self.assertEqual(var_idx, sorted(var_idx))
-        result = self.data.diffexp(df1, df2, 20)
+        result = self.data.diffexp(df1, df2, var_index1=df1.var.index.tolist(), obs_index1=df1.obs.index.tolist(),
+                                   var_index2=df2.var.index.tolist(), obs_index2=df2.obs.index.tolist(), top_n=20)
         self.assertEqual(len(result), 20)
 
     def test_data_frame(self):
@@ -224,12 +228,14 @@ class UtilTest(unittest.TestCase):
             }
         }
         data = self.data.filter_dataframe(filter_["filter"])
-        data_frame_obs = self.data.data_frame(data, "obs")
+        data_frame_obs = self.data.data_frame(data, "obs", var_index=data.var.index.tolist(),
+                                              obs_index=data.obs.index.tolist())
         self.assertEqual(len(data_frame_obs["var"]), 1838)
         self.assertEqual(len(data_frame_obs["obs"]), 497)
         self.assertEqual(type(data_frame_obs["obs"][0]), list)
         self.assertEqual(type(data_frame_obs["var"][0]), int)
-        data_frame_var = self.data.data_frame(data, "var")
+        data_frame_var = self.data.data_frame(data, "var", var_index=data.var.index.tolist(),
+                                              obs_index=data.obs.index.tolist())
         self.assertEqual(len(data_frame_var["var"]), 1838)
         self.assertEqual(len(data_frame_var["obs"]), 497)
         self.assertEqual(type(data_frame_var["var"][0]), list)
@@ -247,7 +253,8 @@ class UtilTest(unittest.TestCase):
                 }
             }
             data = self.data.filter_dataframe(filter_["filter"], include_uns=False)
-            data_frame_var = self.data.data_frame(data, axis)
+            data_frame_var = self.data.data_frame(data, axis, var_index=data.var.index.tolist(),
+                                                  obs_index=data.obs.index.tolist())
             if axis == "obs":
                 self.assertEqual(type(data_frame_var["var"][0]), int)
                 self.assertEqual(type(data_frame_var["obs"][0]), list)


### PR DESCRIPTION
Caching was broken because the method is calling the cached version if the df is any view of the same original data. Fixed by adding the var and obs indices as parameters to the memoized functions.