### PR TITLE
updated anndata dependency version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-anndata
+anndata==0.6.10
 Flask==0.12.4
 Flask-Caching==1.4.0
 Flask-Compress==1.4.0


### PR DESCRIPTION
pin anndata version requirement to match current scanpy expectations.

fixes #269 