### PR TITLE
handle case of excessively large number of options in categorical met…

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -5,18 +5,27 @@ import { connect } from "react-redux";
 
 import Category from "./category";
 
-@connect(state => {
-  const ranges = _.get(state.controls.world, "summary.obs", null);
-  return {
-    ranges
-  };
-})
-class Categories extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
+/* Cap the max number of displayed categories */
+const truncateCategories = options => {
+  const maxOptionsToDisplay = 100; // could be a property if helpful....
+  const numOptions = _.size(options);
+  if (numOptions <= maxOptionsToDisplay) {
+    return options;
   }
+  return _(options)
+    .map((v, k) => ({ name: k, val: v }))
+    .sortBy("val")
+    .slice(numOptions - maxOptionsToDisplay)
+    .transform((r, v) => {
+      r[v.name] = v.val;
+    }, {})
+    .value();
+};
 
+@connect(state => ({
+  ranges: _.get(state.controls.world, "summary.obs", null)
+}))
+class Categories extends React.Component {
   render() {
     const { ranges } = this.props;
     if (!ranges) return null;
@@ -28,16 +37,20 @@ class Categories extends React.Component {
           marginRight: 40,
           paddingRight: 20,
           flexShrink: 0
-          // height: 700,
-          // overflow: "auto",
         }}
       >
         <p> Categorical Metadata </p>
         {_.map(ranges, (value, key) => {
           const isColorField = key.includes("color") || key.includes("Color");
           if (value.options && !isColorField && key !== "name") {
+            const categoryOptions = truncateCategories(value.options);
             return (
-              <Category key={key} metadataField={key} values={value.options} />
+              <Category
+                key={key}
+                metadataField={key}
+                values={categoryOptions}
+                isTruncated={categoryOptions !== value.options}
+              />
             );
           }
           return undefined;

--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -3,19 +3,19 @@ import React from "react";
 import _ from "lodash";
 import { connect } from "react-redux";
 
+import * as globals from "../../globals";
 import Category from "./category";
 
 /* Cap the max number of displayed categories */
 const truncateCategories = options => {
-  const maxOptionsToDisplay = 100; // could be a property if helpful....
   const numOptions = _.size(options);
-  if (numOptions <= maxOptionsToDisplay) {
+  if (numOptions <= globals.maxCategoricalOptionsToDisplay) {
     return options;
   }
   return _(options)
     .map((v, k) => ({ name: k, val: v }))
     .sortBy("val")
-    .slice(numOptions - maxOptionsToDisplay)
+    .slice(numOptions - globals.maxCategoricalOptionsToDisplay)
     .transform((r, v) => {
       r[v.name] = v.val;
     }, {})

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -91,7 +91,7 @@ class Category extends React.Component {
 
   render() {
     const { isExpanded, isChecked } = this.state;
-    const { metadataField, colorAccessor } = this.props;
+    const { metadataField, colorAccessor, isTruncated } = this.props;
     return (
       <div
         style={{
@@ -163,6 +163,11 @@ class Category extends React.Component {
           </p>
         </div>
         <div>{isExpanded ? this.renderCategoryItems() : null}</div>
+        <div>
+          {isExpanded && isTruncated ? (
+            <p style={{ paddingLeft: 15 }}>... truncated list ...</p>
+          ) : null}
+        </div>
       </div>
     );
   }

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -28,6 +28,8 @@ export const continuous = [
   "Unmapped_short"
 ];
 
+export const maxCategoricalOptionsToDisplay = 100;
+
 /* colors */
 export const blue = "#4a90e2";
 export const hcaBlue = "#1c7cc7";


### PR DESCRIPTION
This change caps the maximum number of categorical metadata values displayed in the categorical metadata selection UI (pick list of values).  It picks up to 100 values, and selects those that have the maximum number of cells annotated with that category value.    When the number of options is capped, an "... truncated list ..." annotation is added to the bottom of the selection list.

The '100' value is hard-coded, but could be parameterized if there is future need.

Fixes #349 