### PR TITLE
categorical metadata performance work

### DIFF
--- a/client/__tests__/util/stateManager/world.test.js
+++ b/client/__tests__/util/stateManager/world.test.js
@@ -64,10 +64,15 @@ describe("createWorldFromEntireUniverse", () => {
 
         summary: expect.objectContaining({
           obs: _(REST.schema.schema.annotations.obs)
+            .filter(v => v.name !== "name")
             .keyBy("name")
             .mapValues(() => expect.any(Object))
             .value(),
-          var: {} // TODO: currently unimplemneted
+          var: _(REST.schema.schema.annotations.var)
+            .filter(v => v.name !== "name")
+            .keyBy("name")
+            .mapValues(() => expect.any(Object))
+            .value()
         }),
 
         varDataCache: expect.any(Object),

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -30,10 +30,21 @@ const doInitialDataLoad = () =>
         .map(url => doJsonRequest(url))
         .value();
       const results = await Promise.all(requests);
-      const universe = Universe.createUniverseFromRestV02Response(...results);
+
+      /* set config defaults */
+      const config = { ...globals.configDefaults, ...results[0].config };
+      const [, schema, obsAnno, varAnno, obsLayout] = [...results];
+      const universe = Universe.createUniverseFromRestV02Response(
+        config,
+        schema,
+        obsAnno,
+        varAnno,
+        obsLayout
+      );
+
       dispatch({
         type: "configuration load complete",
-        config: results[0].config
+        config
       });
       dispatch({
         type: "initial data load complete (universe exists)",

--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -23,11 +23,16 @@ const truncateCategories = options => {
 };
 
 @connect(state => ({
-  ranges: _.get(state.controls.world, "summary.obs", null)
+  ranges: _.get(state.controls.world, "summary.obs", null),
+  categorySelectionLimit: _.get(
+    state.config,
+    "parameters.category-selection-limit",
+    globals.configDefaults.parameters["category-selection-limit"]
+  )
 }))
 class Categories extends React.Component {
   render() {
-    const { ranges } = this.props;
+    const { ranges, categorySelectionLimit } = this.props;
     if (!ranges) return null;
 
     return (
@@ -42,7 +47,13 @@ class Categories extends React.Component {
         <p> Categorical Metadata </p>
         {_.map(ranges, (value, key) => {
           const isColorField = key.includes("color") || key.includes("Color");
-          if (value.options && !isColorField && key !== "name") {
+          const isSelectableCategory =
+            value.options &&
+            !isColorField &&
+            key !== "name" &&
+            value.numOptions < categorySelectionLimit;
+
+          if (isSelectableCategory) {
             const categoryOptions = truncateCategories(value.options);
             return (
               <Category

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -28,7 +28,20 @@ export const continuous = [
   "Unmapped_short"
 ];
 
+/* if a categorical metadata field has more options than this, truncate */
 export const maxCategoricalOptionsToDisplay = 100;
+
+/*
+these are default values for configuration  the CLI may supply.
+See the REST API and CLI specs for more info.
+*/
+export const configDefaults = {
+  features: {},
+  displayNames: {},
+  parameters: {
+    "category-selection-limit": 1000
+  }
+};
 
 /* colors */
 export const blue = "#4a90e2";

--- a/client/src/reducers/config.js
+++ b/client/src/reducers/config.js
@@ -2,7 +2,8 @@
 const Config = (
   state = {
     displayNames: null,
-    features: null
+    features: null,
+    parameters: null
   },
   action
 ) => {

--- a/client/src/reducers/controls.js
+++ b/client/src/reducers/controls.js
@@ -16,7 +16,7 @@ import {
 function createCategoricalAsBooleansMap(world) {
   const res = {};
   _.each(world.summary.obs, (value, key) => {
-    if (value.options) {
+    if (value.options && key !== "name") {
       const optionsAsBooleans = {};
       _.each(value.options, (_value, _key) => {
         optionsAsBooleans[_key] = true;

--- a/client/src/util/stateManager/summarizeAnnotations.js
+++ b/client/src/util/stateManager/summarizeAnnotations.js
@@ -1,0 +1,94 @@
+import _ from "lodash";
+
+/*
+Build and return obs/var summary using any annotation in the schema
+
+Summary information for each annotation, keyed by annotation name.
+Value will be an object, containing summary information.
+
+For continuous annotations (int, float, etc):
+  <annotation_name>: {
+    range {
+      min: <number>,
+      max: <number>
+    }
+  }
+
+For categorical annotations (boolean, string, category):
+  <annotatoin_name>: {
+    options: {
+      <option1>: <number>,
+      ...
+    },
+    numOptions: <number>
+  }
+
+Summarize will be returned for BOTH obs and var annotations.
+
+Example:
+  {
+    "Splice_sites_Annotated": {
+      "range": {
+        "min": 26,
+        "max": 1075869
+      }
+    },
+    "Selection": {
+      numOptions, 6,
+      "options": {
+        "Astrocytes(HEPACAM)": 714,
+        "Endothelial(BSC)": 123,
+        "Oligodendrocytes(GC)": 294,
+        "Neurons(Thy1)": 685,
+        "Microglia(CD45)": 1108,
+        "Unpanned": 665
+      }
+    }
+  }
+
+NOTE: will not summarize the required 'name' annotation, as that is
+specified as unique per element.
+*/
+function summarizeDimension(schema, annotations) {
+  return _(schema)
+    .filter(v => v.name !== "name")
+    .keyBy("name")
+    .mapValues(anno => {
+      const { name, type } = anno;
+      const continuous = type === "int32" || type === "float32";
+
+      if (!continuous) {
+        const options = _.countBy(annotations, name);
+        const numOptions = _.size(options);
+        return {
+          numOptions,
+          options
+        };
+      }
+
+      if (continuous) {
+        let min = Number.POSITIVE_INFINITY;
+        let max = Number.NEGATIVE_INFINITY;
+        _.forEach(annotations, obs => {
+          const val = Number(obs[name]);
+          min = val < min ? val : min;
+          max = val > max ? val : max;
+        });
+        return { range: { min, max } };
+      }
+
+      throw new Error("incomprehensible schema");
+    })
+    .value();
+}
+
+export default function summarizeAnnotations(
+  schema,
+  obsAnnotations,
+  varAnnotations
+) {
+  return {
+    obs: summarizeDimension(schema.annotations.obs, obsAnnotations),
+    var: summarizeDimension(schema.annotations.var, varAnnotations)
+  };
+}

--- a/client/src/util/stateManager/universe.js
+++ b/client/src/util/stateManager/universe.js
@@ -2,6 +2,7 @@
 
 import _ from "lodash";
 import * as kvCache from "./keyvalcache";
+import summarizeAnnotations from "./summarizeAnnotations";
 
 /*
 Private helper function - create and return a template Universe
@@ -28,6 +29,7 @@ function templateUniverse() {
     varAnnotations: [] /* all var annotations, by var index */,
     obsNameToIndexMap: {} /* reverse map 'name' to index */,
     varNameToIndexMap: {} /* reverse map 'name' to index */,
+    summary: null /* derived data summaries XXX: consider exploding in place */,
 
     obsLayout: { X: [], Y: [] } /* xy layout */,
 
@@ -190,6 +192,12 @@ export function createUniverseFromRestV02Response(
 
   /* layout */
   universe.obsLayout = RESTv02LayoutResponseToInternal(layoutObsResponse);
+
+  universe.summary = summarizeAnnotations(
+    universe.schema,
+    universe.obsAnnotations,
+    universe.varAnnotations
+  );
 
   return finalize(universe);
 }


### PR DESCRIPTION
Changes are related to performance of categorical metadata selection UI:

* added memoization of the category option counting used to handle category-wide selection state (all selected, some selected, none selected)
* split annotation summarization into separate file within util/stateManager
* summarize Universe annotations - removes need to perform this operation on every world reset
* added summarization of variable annotations (and made corresponding changes to the tests
* add suppression of categorical metadata picker UI whenever total number of metadata options exceeds a configurable limit.  Configuration currently defaulted in front end to 1000, but plan is to pass this from the CLI so the user can control it.
 