### PR TITLE
add --obs-names and --var-names CLI params

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -57,7 +57,9 @@ def run_scanpy(args):
     )
 
     from .scanpy_engine.scanpy_engine import ScanpyEngine
-    app.data = ScanpyEngine(args.data_directory, layout_method=args.layout, diffexp_method=args.diffexp)
+    app.data = ScanpyEngine(args.data_directory,
+                            layout_method=args.layout, diffexp_method=args.diffexp,
+                            obs_names=args.obs_names, var_names=args.var_names)
     if args.listen_all:
         host = "0.0.0.0"
     else:

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -143,9 +143,7 @@ def run_scanpy(args):
         log.setLevel(logging.ERROR)
     from .scanpy_engine.scanpy_engine import ScanpyEngine
     print(f"Loading data from {args.data} (this may take a while)")
-    app.data = ScanpyEngine(args.data, layout_method=args.layout, diffexp_method=args.diffexp,
-                            obs_names=args.obs_names, var_names=args.var_names,
-                            max_category_items=args.max_category_items)
+    app.data = ScanpyEngine(args.data, args)
     print(f"Launching cellxgene")
     if args.open_browser:
         webbrowser.open(cellxgene_url)

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -144,7 +144,7 @@ def run_scanpy(args):
     from .scanpy_engine.scanpy_engine import ScanpyEngine
     print(f"Loading data from {args.data} (this may take a while)")
     app.data = ScanpyEngine(args.data, layout_method=args.layout, diffexp_method=args.diffexp,
-                            obs_names=args.obs_names, var_names=args.var_names
+                            obs_names=args.obs_names, var_names=args.var_names,
                             max_category_items=args.max_category_items)
     print(f"Launching cellxgene")
     if args.open_browser:

--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -44,14 +44,6 @@ class CXGDriver(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def cells(self):
-        pass
-
-    @abstractmethod
-    def genes(self):
-        pass
-
-    @abstractmethod
     def filter_dataframe(self, filter):
         """
         Filter cells from data and return a subset of the data. They can operate on both obs and var dimension with

--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -12,11 +12,11 @@ Sort order for methods
 
 class CXGDriver(metaclass=ABCMeta):
 
-    def __init__(self, data, layout_method=None, diffexp_method=None, max_category_items=100):
+    def __init__(self, data, args):
         self.data = self._load_data(data)
-        self.layout_method = layout_method
-        self.diffexp_method = diffexp_method
-        self.max_category_items = max_category_items
+        self.layout_method = args.layout
+        self.diffexp_method = args.diffexp
+        self.max_category_items = args.max_category_items
         self.cluster = None
 
     @property

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -35,7 +35,7 @@ class ScanpyEngine(CXGDriver):
 
     def _alias_annotation_names(self, axis, name):
         """
-        Do all user-specified annotaiton aliasing.
+        Do all user-specified annotation aliasing.
 
         As a *critical* side-effect, ensure the indices are simple number ranges
         (accomplished by calling pandas.DataFrame.reset_index())

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -22,7 +22,8 @@ Sort order for methods
 
 class ScanpyEngine(CXGDriver):
 
-    def __init__(self, data, layout_method=None, diffexp_method=None, obs_names=None, var_names=None, max_category_items=100):
+    def __init__(self, data, layout_method=None, diffexp_method=None,
+                 obs_names=None, var_names=None, max_category_items=100):
         super().__init__(data, layout_method=layout_method, diffexp_method=diffexp_method,
                          max_category_items=max_category_items)
         self._alias_annotation_names(obs_names, var_names)
@@ -56,7 +57,7 @@ class ScanpyEngine(CXGDriver):
                     raise KeyError(f"Annotation name {name}, specified in --{ax_name}-name does not exist.")
                 if not df_axis[name].is_unique:
                     raise KeyError(f"Values in -{ax_name}-name must be unique. "
-                                    "Please prepare data to contain unique values.")
+                                   "Please prepare data to contain unique values.")
                 # reset index to simple range; alias user-specified annotation to 'name'
                 df_axis = df_axis.reset_index(drop=True).rename(columns={name: 'name'})
             else:
@@ -225,7 +226,7 @@ class ScanpyEngine(CXGDriver):
 
         https://docs.scipy.org/doc/scipy/reference/sparse.html
         """
-        prefer_column_access = sparse.isspmatrix_csc(data.X)
+        # prefer_column_access = sparse.isspmatrix_csc(data.X)
         prefer_row_access = sparse.isspmatrix_lil(data.X) or sparse.isspmatrix_bsr(data.X)
         if prefer_row_access:
             # Row-major slicing

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -222,7 +222,8 @@ class ScanpyEngine(CXGDriver):
                     index = np.logical_and(index, key_idx)
         return index
 
-    def _slice(self, data, obs_selector=None, vars_selector=None):
+    @staticmethod
+    def _slice(data, obs_selector=None, vars_selector=None):
         """
         Slice date using any selector that the AnnData object
         supprots for slicing.  If selector is None, will not slice

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -2,7 +2,7 @@ import os
 import warnings
 
 import numpy as np
-from pandas import DataFrame, Series
+from pandas import DataFrame
 import scanpy.api as sc
 from scipy import stats
 
@@ -52,7 +52,8 @@ class ScanpyEngine(CXGDriver):
                 if name not in df_axis.columns:
                     raise KeyError(f"Annotation name {name}, specified in --{ax_name}-name does not exist.")
                 if not df_axis[name].is_unique:
-                    raise KeyError(f"Values in -{ax_name}-name must be unique. Please prepare data to contain unique values.")
+                    raise KeyError(f"Values in -{ax_name}-name must be unique. "
+                                    "Please prepare data to contain unique values.")
                 # reset index to simple range; alias user-specified annotation to 'name'
                 df_axis = df_axis.reset_index(drop=True).rename(columns={name: 'name'})
             else:
@@ -282,13 +283,13 @@ class ScanpyEngine(CXGDriver):
         elif df_shape[1] == 1:
             values = values[:, None]
         if axis == Axis.OBS:
-            expression = DataFrame(values, index=df.obs.index)
+            expression = DataFrame(values, index=obs_idx)
             result = {
                 "var": var_idx,
                 "obs": expression.reset_index().values.tolist()
             }
         else:
-            expression = DataFrame(values.T, index=df.var.index)
+            expression = DataFrame(values.T, index=var_idx)
             result = {
                 "obs": obs_idx,
                 "var": expression.reset_index().values.tolist(),

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -335,11 +335,14 @@ class ScanpyEngine(CXGDriver):
                 top_n = DEFAULT_TOP_N
 
         genes_idx = df1.var.index
-        diffexp_result = stats.ttest_ind(df1.X, df2.X)
+
+        X1 = df1.X.toarray() if sparse.issparse(df1.X) else df1.X
+        X2 = df2.X.toarray() if sparse.issparse(df2.X) else df2.X
+        diffexp_result = stats.ttest_ind(X1, X2)
         pval = self._nan_to_one(diffexp_result.pvalue)
         bonferroni_pval = 1 - (1 - pval) ** self.gene_count
-        ave_exp_set1 = np.mean(df1.X, axis=0)
-        ave_exp_set2 = np.mean(df2.X, axis=0)
+        ave_exp_set1 = np.mean(X1, axis=0)
+        ave_exp_set2 = np.mean(X2, axis=0)
         ave_diff = ave_exp_set1 - ave_exp_set2
         if mode == DiffExpMode.TOP_N:
             sort_order = np.argsort(np.abs(diffexp_result.statistic))[::-1]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.6.11
+anndata>=0.6.12
 click==6.7
 Flask==0.12.4
 Flask-Caching==1.4.0

--- a/server/test/schema.json
+++ b/server/test/schema.json
@@ -7,6 +7,10 @@
   "annotations": {
     "obs": [
       {
+        "name": "name",
+        "type": "string"
+      },
+      {
         "name": "n_genes",
         "type": "int32"
       },
@@ -31,20 +35,16 @@
           "Dendritic cells",
           "Megakaryocytes"
         ]
-      },
-      {
-        "name": "name",
-        "type": "string"
       }
     ],
     "var": [
       {
-        "name": "n_cells",
-        "type": "int32"
-      },
-      {
         "name": "name",
         "type": "string"
+      },
+      {
+        "name": "n_cells",
+        "type": "int32"
       }
     ]
   }

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -102,7 +102,7 @@ class EndPoints(unittest.TestCase):
         result = self.session.get(url)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
+        self.assertEqual(result_data["names"], ["name", "n_genes", "percent_mito", "n_counts", "louvain"])
         self.assertEqual(len(result_data["data"]), 2638)
         self.assertEqual(len(result_data["data"][0]), 6)
 
@@ -140,7 +140,7 @@ class EndPoints(unittest.TestCase):
         result = self.session.put(url, json=obs_filter)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
+        self.assertEqual(result_data["names"], ["name", "n_genes", "percent_mito", "n_counts", "louvain"])
         self.assertEqual(len(result_data["data"]), 15)
 
     def test_filter_put_annotations_obs(self):
@@ -224,7 +224,7 @@ class EndPoints(unittest.TestCase):
         result = self.session.get(url)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_cells", "name"])
+        self.assertEqual(result_data["names"], ["name", "n_cells"])
         self.assertEqual(len(result_data["data"]), 1838)
         self.assertEqual(len(result_data["data"][0]), 3)
 
@@ -260,7 +260,7 @@ class EndPoints(unittest.TestCase):
         result = self.session.put(url, json=var_filter)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         result_data = result.json()
-        self.assertEqual(result_data["names"], ["n_cells", "name"])
+        self.assertEqual(result_data["names"], ["name", "n_cells"])
         self.assertEqual(len(result_data["data"]), 2)
 
     def test_filter_put_annotations_var(self):

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -3,6 +3,7 @@ from os import path
 import pytest
 import time
 import unittest
+import argparse
 
 import numpy as np
 from pandas import Series
@@ -12,7 +13,14 @@ from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
 
 class UtilTest(unittest.TestCase):
     def setUp(self):
-        self.data = ScanpyEngine("example-dataset/pbmc3k.h5ad", layout_method="umap", diffexp_method="ttest")
+        args = argparse.Namespace()
+        args.layout = "umap"
+        args.diffexp = "ttest"
+        args.max_category_items = 100
+        args.obs_names = None
+        args.var_names = None
+
+        self.data = ScanpyEngine("example-dataset/pbmc3k.h5ad", args)
         self.data._create_schema()
 
     def test_init(self):

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -30,7 +30,7 @@ class UtilTest(unittest.TestCase):
     @pytest.mark.filterwarnings("ignore:Scanpy data matrix")
     def test_data_type(self):
         self.data.data.X = self.data.data.X.astype("float64")
-        self.assertWarns(UserWarning, self.data._validatate_data_types())
+        self.assertWarns(UserWarning, self.data._validate_data_types())
 
     def test_filter_idx(self):
         filter_ = {
@@ -130,10 +130,10 @@ class UtilTest(unittest.TestCase):
 
     def test_annotations(self):
         annotations = self.data.annotation(None, "obs")
-        self.assertEqual(annotations["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
+        self.assertEqual(annotations["names"], ["name", "n_genes", "percent_mito", "n_counts", "louvain"])
         self.assertEqual(len(annotations["data"]), 2638)
         annotations = self.data.annotation(None, "var")
-        self.assertEqual(annotations["names"], ["n_cells", "name"])
+        self.assertEqual(annotations["names"], ["name", "n_cells"])
         self.assertEqual(len(annotations["data"]), 1838)
 
     def test_annotation_fields(self):
@@ -160,10 +160,10 @@ class UtilTest(unittest.TestCase):
             }
         }
         annotations = self.data.annotation(filter_["filter"], "obs")
-        self.assertEqual(annotations["names"], ["n_genes", "percent_mito", "n_counts", "louvain", "name"])
+        self.assertEqual(annotations["names"], ["name", "n_genes", "percent_mito", "n_counts", "louvain"])
         self.assertEqual(len(annotations["data"]), 497)
         annotations = self.data.annotation(filter_["filter"], "var")
-        self.assertEqual(annotations["names"], ["n_cells", "name"])
+        self.assertEqual(annotations["names"], ["name", "n_cells"])
         self.assertEqual(len(annotations["data"]), 2)
 
     def test_filtered_layout(self):

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -222,12 +222,12 @@ class UtilTest(unittest.TestCase):
         data_frame_obs = self.data.data_frame(filter_["filter"], "obs")
         self.assertEqual(len(data_frame_obs["var"]), 1838)
         self.assertEqual(len(data_frame_obs["obs"]), 497)
-        self.assertEqual(type(data_frame_obs["obs"][0]), list)
+        self.assertIsInstance(data_frame_obs["obs"][0], (list, tuple))
         self.assertEqual(type(data_frame_obs["var"][0]), int)
         data_frame_var = self.data.data_frame(filter_["filter"], "var")
         self.assertEqual(len(data_frame_var["var"]), 1838)
         self.assertEqual(len(data_frame_var["obs"]), 497)
-        self.assertEqual(type(data_frame_var["var"][0]), list)
+        self.assertIsInstance(data_frame_var["var"][0], (list, tuple))
         self.assertEqual(type(data_frame_var["obs"][0]), int)
 
     def test_data_single_gene(self):
@@ -244,10 +244,10 @@ class UtilTest(unittest.TestCase):
             data_frame_var = self.data.data_frame(filter_["filter"], axis)
             if axis == "obs":
                 self.assertEqual(type(data_frame_var["var"][0]), int)
-                self.assertEqual(type(data_frame_var["obs"][0]), list)
+                self.assertIsInstance(data_frame_var["obs"][0], (list, tuple))
             elif axis == "var":
                 self.assertEqual(type(data_frame_var["obs"][0]), int)
-                self.assertEqual(type(data_frame_var["var"][0]), list)
+                self.assertIsInstance(data_frame_var["var"][0], (list, tuple))
 
     if __name__ == '__main__':
         unittest.main()


### PR DESCRIPTION
Changes:
* add CLI params: --obs-names, --var-names
* name aliasing in scanpy engine wrapper, in support of --obs-names and --var-names
* reworked annotation indexing to improve startup performance
* implement slicing that is aware of col vs row performance preferences
* remove redundant need to `reset_index()` when creating REST response, by using to_records()
* remove dead code (genes(), cells()) in the driver.py framework
* updated scanpy_engine tests to allow for either list or tuple return values
* correctly handle sparse data types for AnnData::X (must call toarray() to get an NP array)
* update required AnnData version to incorporate fix for https://github.com/theislab/scanpy/issues/332
* Change driver framework __init__ args to just pass entire args dict

Fixes #309 #355 #347 #348