### PR TITLE
Speed up help

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -110,13 +110,13 @@ cellxgene is a local web application for exploring single cell expression.
         help="Limit for the cardinality of a categorical annotation, beyond which the"
              " annotation will not be available for user selection in the front-end",
         default=100)
-    try:
-        from .scanpy_engine.scanpy_engine import ScanpyEngine
-    except ImportError as e:
-        # We will handle more engines when they come
-        raise ImportError('Scanpy is required for cellxgene, please install scanpy and try again', e) from e
-    else:
-        ScanpyEngine.add_to_parser(launch_group)
+    # TODO scanpy specific; rethink when we add another engine
+    computation_group = launch_group.add_argument_group('computational arguments')
+    # TODO these choices should be generated from the actual available methods see GH issue #94
+    computation_group.add_argument("-l", "--layout", choices=["umap", "tsne"], default="umap",
+                                   help="Algorithm to use for graph layout")
+    computation_group.add_argument("-d", "--diffexp", choices=["ttest"], default="ttest",
+                                   help="Algorithm to used to calculate differential expression")
     return parser
 
 

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -65,15 +65,6 @@ class ScanpyEngine(CXGDriver):
                     raise TypeError(f"Annotations of type {curr_axis[ann].dtype} are unsupported by cellxgene.")
                 self.schema["annotations"][ax].append(ann_schema)
 
-    @classmethod
-    def add_to_parser(cls, subparser):
-        computation_group = subparser.add_argument_group('computational arguments')
-        # TODO these choices should be generated from the actual available methods see GH issue #94
-        computation_group.add_argument("-l", "--layout", choices=["umap", "tsne"], default="umap",
-                                       help="Algorithm to use for graph layout")
-        computation_group.add_argument("-d", "--diffexp", choices=["ttest"], default="ttest",
-                                       help="Algorithm to used to calculate differential expression")
-
     @staticmethod
     def _load_data(data):
         # See https://scanpy.readthedocs.io/en/latest/api/scanpy.api.read.html


### PR DESCRIPTION
I moved the computational args back to app.py. While these are scanpy specific we probably shouldn't require importing scanpy and all the packages that come along with it just to figure out which layout options we have. This speeds up time to get help immensely.

@bkmartinjr you can put your obs/var-name options directly in app.py for now