### PR TITLE
update config params to match REST API spec

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -25,8 +25,8 @@ const truncateCategories = options => {
   ranges: _.get(state.controls.world, "summary.obs", null),
   categorySelectionLimit: _.get(
     state.config,
-    "parameters.category-selection-limit",
-    globals.configDefaults.parameters["category-selection-limit"]
+    "parameters.max-category-items",
+    globals.configDefaults.parameters["max-category-items"]
   )
 }))
 class Categories extends React.Component {

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -39,7 +39,7 @@ export const configDefaults = {
   features: {},
   displayNames: {},
   parameters: {
-    "category-selection-limit": 1000
+    "max-category-items": 1000
   }
 };
 


### PR DESCRIPTION
update the front-end use of config params to match the spec changes.

Fixes #354 #360 