### PR TITLE
Performance work, plus fix #405

### DIFF
--- a/client/__tests__/util/stateManager/world.test.js
+++ b/client/__tests__/util/stateManager/world.test.js
@@ -77,7 +77,8 @@ describe("createWorldFromEntireUniverse", () => {
 
         varDataCache: expect.any(Object),
 
-        worldObsIndex: null // indicating full universe
+        obsIndex: null, // null indicating full universe
+        obsBackIndex: null
       })
     );
   });
@@ -120,16 +121,21 @@ describe("createWorldFromCurrentSelection", () => {
       nObs: universeIndices.length,
       obsAnnotations: _.map(universeIndices, i => universe.obsAnnotations[i]),
       obsLayout: {
-        X: _.map(universeIndices, i => universe.obsLayout.X[i]),
-        Y: _.map(universeIndices, i => universe.obsLayout.Y[i])
+        X: new Float32Array(
+          _.map(universeIndices, i => universe.obsLayout.X[i])
+        ),
+        Y: new Float32Array(
+          _.map(universeIndices, i => universe.obsLayout.Y[i])
+        )
       },
-      worldObsIndex: _.transform(
+      obsBackIndex: _.transform(
         universeIndices,
         (result, univIdx, worldIdx) => {
           result[univIdx] = worldIdx;
         },
-        new Array(universe.nObs).fill(-1)
-      )
+        new Uint32Array(universe.nObs).fill(-1)
+      ),
+      obsIndex: new Uint32Array(universeIndices)
     };
 
     expect(world).toMatchObject(
@@ -141,9 +147,13 @@ describe("createWorldFromCurrentSelection", () => {
         obsAnnotations: expected.obsAnnotations,
         varAnnotations: universe.varAnnotations,
         obsLayout: expected.obsLayout,
-        summary: expect.any(Object) /* we could do better! */,
+        summary: {
+          obs: expect.any(Object) /* we could do better! */,
+          var: expect.any(Object) /* we could do better! */
+        },
         varDataCache: expect.any(Object),
-        worldObsIndex: expected.worldObsIndex
+        obsIndex: expected.obsIndex,
+        obsBackIndex: expected.obsBackIndex
       })
     );
   });
@@ -205,6 +215,7 @@ describe("subsetVarData", () => {
       world,
       crossfilter
     );
+    expect(newWorld.obsIndex).toMatchObject(new Uint32Array([0, 2]));
 
     /* expect a subset */
     const result = World.subsetVarData(newWorld, universe, sourceVarData);

--- a/client/__tests__/util/stateManager/world.test.js
+++ b/client/__tests__/util/stateManager/world.test.js
@@ -173,11 +173,15 @@ describe("createObsDimensionMap", () => {
     expect(dimensionMap).toBeDefined();
     REST.annotationsObs.names.forEach(name => {
       const dim = dimensionMap[obsAnnoDimensionName(name)];
-      const { type } = schemaByObsName[name];
-      if (type === "string" || type === "boolean" || type === "categorical") {
-        expect(dim).toBeInstanceOf(Crossfilter.EnumDimension);
+      if (name === "name") {
+        expect(dim).toBeUndefined();
       } else {
-        expect(dim).toBeInstanceOf(Crossfilter.ScalarDimension);
+        const { type } = schemaByObsName[name];
+        if (type === "string" || type === "boolean" || type === "categorical") {
+          expect(dim).toBeInstanceOf(Crossfilter.EnumDimension);
+        } else {
+          expect(dim).toBeInstanceOf(Crossfilter.ScalarDimension);
+        }
       }
     });
     expect(dimensionMap[layoutDimensionName("X")]).toBeInstanceOf(

--- a/client/__tests__/util/typedCrossfilter/util.test.js
+++ b/client/__tests__/util/typedCrossfilter/util.test.js
@@ -1,0 +1,115 @@
+import {
+  fillRange,
+  sliceByIndex,
+  makeSortIndex,
+  lowerBound,
+  lowerBoundIndirect,
+  upperBoundIndirect
+} from "../../../src/util/typedCrossfilter/util";
+
+describe("fillRange", () => {
+  test("Array", () => {
+    expect(fillRange(new Array(6))).toMatchObject([0, 1, 2, 3, 4, 5]);
+    expect(fillRange(new Array(4), 1)).toMatchObject([1, 2, 3, 4]);
+    expect(fillRange([])).toMatchObject([]);
+  });
+
+  test("Uint32Array", () => {
+    expect(fillRange(new Uint32Array(6))).toMatchObject(
+      new Uint32Array([0, 1, 2, 3, 4, 5])
+    );
+    expect(fillRange(new Array(4), 1)).toMatchObject(
+      new Uint32Array([1, 2, 3, 4])
+    );
+    expect(fillRange([])).toMatchObject(new Uint32Array([]));
+  });
+});
+
+describe("sliceByIndex", () => {
+  test("Array", () => {
+    expect(sliceByIndex([0, 1, 2, 3, 4], [0, 1, 2])).toMatchObject([0, 1, 2]);
+    expect(sliceByIndex([0, 1, 2, 3, 4], [2, 1, 0])).toMatchObject([2, 1, 0]);
+    expect(sliceByIndex([0, 1, 2, 3, 4], [])).toMatchObject([]);
+    expect(sliceByIndex([], [])).toMatchObject([]);
+  });
+
+  test("Uint32Array", () => {
+    expect(
+      sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([0, 1, 2]))
+    ).toMatchObject([0, 1, 2]);
+    expect(
+      sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([2, 1, 0]))
+    ).toMatchObject([2, 1, 0]);
+    expect(sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([]))).toMatchObject(
+      []
+    );
+    expect(sliceByIndex([], new Uint32Array([]))).toMatchObject([]);
+
+    expect(
+      sliceByIndex(new Uint32Array([0, 1, 2, 3, 4]), new Uint32Array([0, 1, 2]))
+    ).toMatchObject(new Uint32Array([0, 1, 2]));
+    expect(
+      sliceByIndex(new Uint32Array([0, 1, 2, 3, 4]), new Uint32Array([2, 1, 0]))
+    ).toMatchObject(new Uint32Array([2, 1, 0]));
+    expect(
+      sliceByIndex(
+        new Uint32Array([0, 1, 2, 3, 4]),
+        new Uint32Array(new Uint32Array([]))
+      )
+    ).toMatchObject(new Uint32Array([]));
+    expect(
+      sliceByIndex(new Uint32Array([]), new Uint32Array([]))
+    ).toMatchObject(new Uint32Array([]));
+  });
+
+  test("Float32Array", () => {
+    expect(
+      sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [0, 1, 2])
+    ).toMatchObject(new Float32Array([0, 1, 2]));
+    expect(
+      sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [2, 1, 0])
+    ).toMatchObject(new Float32Array([2, 1, 0]));
+    expect(sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [])).toMatchObject(
+      new Float32Array([])
+    );
+    expect(sliceByIndex(new Float32Array([]), [])).toMatchObject(
+      new Float32Array([])
+    );
+  });
+});
+
+describe("makeSortIndex", () => {
+  test("Array", () => {
+    expect(makeSortIndex([3, 2, 1, 0])).toMatchObject(
+      new Uint32Array([3, 2, 1, 0])
+    );
+    expect(makeSortIndex([3, 2, 1, 0, 4])).toMatchObject(
+      new Uint32Array([3, 2, 1, 0, 4])
+    );
+    expect(makeSortIndex([])).toMatchObject(new Uint32Array([]));
+  });
+
+  test("Float32Array", () => {
+    expect(makeSortIndex(new Float32Array([3, 2, 1, 0]))).toMatchObject(
+      new Uint32Array([3, 2, 1, 0])
+    );
+    expect(makeSortIndex(new Float32Array([3, 2, 1, 0, 4]))).toMatchObject(
+      new Uint32Array([3, 2, 1, 0, 4])
+    );
+    expect(makeSortIndex(new Float32Array([]))).toMatchObject(
+      new Uint32Array([])
+    );
+  });
+
+  test("Int32Array", () => {
+    expect(makeSortIndex(new Int32Array([3, 2, 1, 0]))).toMatchObject(
+      new Uint32Array([3, 2, 1, 0])
+    );
+    expect(makeSortIndex(new Int32Array([3, 2, 1, 0, 4]))).toMatchObject(
+      new Uint32Array([3, 2, 1, 0, 4])
+    );
+    expect(makeSortIndex(new Int32Array([]))).toMatchObject(
+      new Uint32Array([])
+    );
+  });
+});

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -149,16 +149,13 @@ function requestSingleGeneExpressionCountsForColoringPOST(gene) {
   return async (dispatch, getState) => {
     dispatch({ type: "get single gene expression for coloring started" });
     try {
-      const expressionData = await _doRequestExpressionData(
-        dispatch,
-        getState,
-        [gene]
-      );
+      await _doRequestExpressionData(dispatch, getState, [gene]);
+      const { world } = getState().controls;
       dispatch({
         type: "color by expression",
         gene,
         data: {
-          [gene]: expressionData[gene]
+          [gene]: kvCache.get(world.varDataCache, gene)
         }
       });
     } catch (error) {
@@ -173,16 +170,15 @@ function requestSingleGeneExpressionCountsForColoringPOST(gene) {
 const requestUserDefinedGene = gene => async (dispatch, getState) => {
   dispatch({ type: "request user defined gene started" });
   try {
-    const data = await await _doRequestExpressionData(dispatch, getState, [
-      gene
-    ]);
+    await await _doRequestExpressionData(dispatch, getState, [gene]);
+    const { world } = getState().controls;
 
     /* then send the success case action through */
     return dispatch({
       type: "request user defined gene success",
       data: {
         genes: [gene],
-        expression: data[gene]
+        expression: kvCache.get(world.varDataCache, gene)
       }
     });
   } catch (error) {

--- a/client/src/reducers/differential.js
+++ b/client/src/reducers/differential.js
@@ -51,6 +51,7 @@ const Differential = (
     case "set World to current selection":
       return {
         ...state,
+        diffExp: null,
         celllist1: null,
         celllist2: null
       };

--- a/client/src/util/stateManager/world.js
+++ b/client/src/util/stateManager/world.js
@@ -241,9 +241,10 @@ export function createObsDimensionMap(crossfilter, world) {
   */
   const { schema, obsLayout } = world;
 
-  const dimensionMap = _.transform(
-    schema.annotations.obs,
-    (result, anno) => {
+  // Create a crossfilter dimension for all obs annotations *except* 'name'
+  const dimensionMap = _(schema.annotations.obs)
+    .filter(anno => anno.name !== "name")
+    .transform((result, anno) => {
       const dimType = deduceDimensionType(anno, anno.name);
       // XXX if dimtype is a scalar, we may be able to do better?
       if (dimType) {
@@ -252,9 +253,8 @@ export function createObsDimensionMap(crossfilter, world) {
           dimType
         );
       } // else ignore the annotation
-    },
-    {}
-  );
+    }, {})
+    .value();
 
   /*
   Add crossfilter dimensions allowing filtering on layout

--- a/client/src/util/typedCrossfilter/index.js
+++ b/client/src/util/typedCrossfilter/index.js
@@ -31,7 +31,7 @@ more complex API.  In a few cases, elements of that API were incorporated.
 import PositiveIntervals from "./positiveIntervals";
 import BitArray from "./bitArray";
 import {
-  fillRange,
+  makeSortIndex,
   lowerBound,
   lowerBoundIndirect,
   upperBoundIndirect
@@ -126,16 +126,31 @@ class ScalarDimension {
     // current selection filter, expressed as PostiveIntervals.
     this.currentFilter = [];
 
-    // Create value array
-    const array = this._createValueArray(
-      value,
-      new ValueArrayType(this.crossfilter.data.length)
-    );
+    // Two modes - caller can provide a pre-created value array,
+    // or a map function which will create it.
+    let array;
+    if (value instanceof ValueArrayType) {
+      if (value.length !== this.crossfilter.data.length) {
+        throw new RangeError(
+          "ScalarDimension values length must equal crossfilter data record count"
+        );
+      }
+      array = value;
+    } else if (value instanceof Function) {
+      // Create value array
+      array = this._createValueArray(
+        value,
+        new ValueArrayType(this.crossfilter.data.length)
+      );
+    } else {
+      throw new NotImplementedError(
+        "dimension value must be function or value array type"
+      );
+    }
     this.value = array;
 
     // create sort index
-    this.index = fillRange(new Uint32Array(this.crossfilter.data.length));
-    this.index.sort((a, b) => array[a] - array[b]);
+    this.index = makeSortIndex(array);
 
     // groups, if any
     this.groups = [];

--- a/client/src/util/typedCrossfilter/util.js
+++ b/client/src/util/typedCrossfilter/util.js
@@ -16,6 +16,25 @@ export function fillRange(arr, start = 0) {
   return larr;
 }
 
+// slice out of one array into another, using an index array
+//
+export function sliceByIndex(src, index) {
+  if (index === undefined || index === null) {
+    return src;
+  }
+  const dst = new src.constructor(index.length);
+  for (let i = 0; i < index.length; i += 1) {
+    dst[i] = src[index[i]];
+  }
+  return dst;
+}
+
+export function makeSortIndex(src) {
+  const index = fillRange(new Uint32Array(src.length));
+  index.sort((a, b) => src[a] - src[b]);
+  return index;
+}
+
 // Search for `value` in the sorted array `arr`, in the range [first, last).
 // Return the first (left most) index where arr[index] >= value.
 //

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -148,7 +148,7 @@ def run_scanpy(args):
     if args.open_browser:
         webbrowser.open(cellxgene_url)
     print(f"Please go to {cellxgene_url}")
-    app.run(host=host, debug=args.debug, port=args.port)
+    app.run(host=host, debug=args.debug, port=args.port, threaded=True)
 
 
 def main():

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -5,7 +5,6 @@ from pandas import DataFrame
 import scanpy.api as sc
 from scipy import stats, sparse
 
-from server.app.app import cache
 from server.app.driver.driver import CXGDriver
 from server.app.util.constants import Axis, DEFAULT_TOP_N, DiffExpMode
 from server.app.util.utils import FilterError, InteractiveError, PrepareError
@@ -96,11 +95,10 @@ class ScanpyEngine(CXGDriver):
 
     @staticmethod
     def _load_data(data):
-        # See https://scanpy.readthedocs.io/en/latest/api/scanpy.api.read.html
-        # Based upon this advice, setting cache=True parameter
+        # Based on benchmarking, cache=True has no impact on perf.
         # Note: as of current scanpy/anndata release, setting backed='r' will
         # result in an error.
-        return sc.read(data, cache=True)
+        return sc.read(data, cache=False)
 
     @staticmethod
     def _top_sort(values, sort_order, top_n=None):
@@ -251,7 +249,6 @@ class ScanpyEngine(CXGDriver):
 
         return data
 
-    @cache.memoize()
     def annotation(self, filter, axis, fields=None):
         """
          Gets annotation value for each observation
@@ -274,7 +271,6 @@ class ScanpyEngine(CXGDriver):
         }
         return result
 
-    @cache.memoize()
     def data_frame(self, filter, axis):
         """
         Retrieves data for each variable for observations in data frame
@@ -366,7 +362,6 @@ class ScanpyEngine(CXGDriver):
         # Results need to be returned in var index order
         return sorted(result, key=lambda gene: gene[0])
 
-    @cache.memoize()
     def layout(self, filter, interactive_limit=None):
         """
         Computes a n-d layout for cells through dimensionality reduction.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 anndata>=0.6.12
 click==6.7
-Flask==1.0.2
+Flask>=1.0.2
 Flask-Caching==1.4.0
 Flask-Compress==1.4.0
 Flask-Cors==3.0.6

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 anndata>=0.6.12
 click==6.7
-Flask==0.12.4
+Flask==1.0.2
 Flask-Caching==1.4.0
 Flask-Compress==1.4.0
 Flask-Cors==3.0.6


### PR DESCRIPTION
Apologies in advance to my PR reviewers.  This is actually two PRs that were inappropriately comingled.   CLI and front-end changes are independent.

Changes:
- CLI: 
    - Remove redundant layer of caching/memoization
    - turn on HTTP server multi-threading
    - upgrade to production Flask release (>= 1.0.2)
- Front-end:
    - Fixes #405 - action helpers were using "universe" instead of "world" expression data
    - Fixes #288 - improved memory efficiency in crossfilter dimension handling: don't create useless dimensions, don't create duplicate copies of data where using identity projection for the dimension
    - upgrade stateManager world data slicing to prevent future slicing errors (factored code out into util functions, improved tests)

Fixes #405 
Fixes #288 
