### PR TITLE
first draft of release process

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,4 +1,4 @@
-# cellxgene Release Process
+# cellxgene release process
 
 _This document defines the release process for cellxgene_
 
@@ -27,6 +27,23 @@ Follow these steps to create a release.
     - set the version number in `setup.py`
     - build the JS asserts using `bin/build-client`
 4.  Commit and push the new branch
-5.  Create a PR for the release. _As needed, conduct PR review._
+5.  Create a PR for the release.
+    - [optional] As needed, conduct PR review.
 6.  Create Github release using the version number and release notes ([instructions](https://help.github.com/articles/creating-releases/)).
-7.  Publish to PyPi
+7.  Publish to pypi by performing the following steps
+    (assumes you have `setuptools` and `twine` installed and that you have
+    registered for pypi and have write access to the cellxgene pypi package)
+    - build the distribution by calling
+      `python setup.py sdist bdist_wheel`
+      inside the top-level directory
+    - [optional] upload the package to test pypi
+      `twine upload --repository-url https://test.pypi.org/legacy/ dist/*`
+    - [optional] test the test installation in a fresh virtual environment using
+      `pip install --index-url https://test.pypi.org/simple/ cellxgene`
+    - upload the package to real pypi using `twine upload dist/*`
+    - [optional] test the installation in a fresh virtual environment using
+      `pip install cellxgene`
+
+The optional steps are for testing purposes, and are recommended
+for publishing any major releases, and any releases that significantly
+change the packaging (e.g. new bundled files, new dependencies, etc.)

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -9,7 +9,7 @@ to PyPi, with a matching tagged release on github.
 
 The release process should result in the following side-effects:
 
-- Version number bump
+- Version number bump, using semantic versioning
 - JS assets built & packaged, committed to the repo
 - Tagged github release
 - Publication to PyPi
@@ -19,7 +19,7 @@ The release process should result in the following side-effects:
 Follow these steps to create a release.
 
 1.  Preparation:
-    - Define the release version number
+    - Define the release version number, using [semantic versioning](https://semver.org/)
     - Write the release title and release notes
 2.  Create a release branch, eg, `release-version`
 3.  In the release branch:

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,32 @@
+# cellxgene Release Process
+
+_This document defines the release process for cellxgene_
+
+## Overview
+
+The goal of the release process is to publish an installable package
+to PyPi, with a matching tagged release on github.
+
+The release process should result in the following side-effects:
+
+- Version number bump
+- JS assets built & packaged, committed to the repo
+- Tagged github release
+- Publication to PyPi
+
+## Process
+
+Follow these steps to create a release.
+
+1.  Preparation:
+    - Define the release version number
+    - Write the release title and release notes
+2.  Create a release branch, eg, `release-version`
+3.  In the release branch:
+    - set the version number in `client/package.json`
+    - set the version number in `setup.py`
+    - build the JS asserts using `bin/build-client`
+4.  Commit and push the new branch
+5.  Create a PR for the release. _As needed, conduct PR review._
+6.  Create Github release using the version number and release notes ([instructions](https://help.github.com/articles/creating-releases/)).
+7.  Publish to PyPi


### PR DESCRIPTION
on the assumption that we want a PyPi package, which contains pre-built JS assets, I have started a rough cut at a release process (so we all do it the same way).

Ideally we would use this for the initial release.

@freeman-lab - it is a bit thin on the PyPi publication.  Can you expand?