### PR TITLE
improve type handling for non-string annotation data

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -5,34 +5,13 @@ import { connect } from "react-redux";
 import * as globals from "../../globals";
 import Category from "./category";
 
-/* Cap the max number of displayed categories */
-const truncateCategories = options => {
-  const numOptions = _.size(options);
-  if (numOptions <= globals.maxCategoricalOptionsToDisplay) {
-    return options;
-  }
-  return _(options)
-    .map((v, k) => ({ name: k, val: v }))
-    .sortBy("val")
-    .slice(numOptions - globals.maxCategoricalOptionsToDisplay)
-    .transform((r, v) => {
-      r[v.name] = v.val;
-    }, {})
-    .value();
-};
-
 @connect(state => ({
-  ranges: _.get(state.controls.world, "summary.obs", null),
-  categorySelectionLimit: _.get(
-    state.config,
-    "parameters.max-category-items",
-    globals.configDefaults.parameters["max-category-items"]
-  )
+  categoricalSelectionState: state.controls.categoricalSelectionState
 }))
 class Categories extends React.Component {
   render() {
-    const { ranges, categorySelectionLimit } = this.props;
-    if (!ranges) return null;
+    const { categoricalSelectionState } = this.props;
+    if (!categoricalSelectionState) return null;
 
     return (
       <div
@@ -47,27 +26,9 @@ class Categories extends React.Component {
         >
           Categorical Metadata
         </p>
-        {_.map(ranges, (value, key) => {
-          const isColorField = key.includes("color") || key.includes("Color");
-          const isSelectableCategory =
-            value.options &&
-            !isColorField &&
-            key !== "name" &&
-            value.numOptions < categorySelectionLimit;
-
-          if (isSelectableCategory) {
-            const categoryOptions = truncateCategories(value.options);
-            return (
-              <Category
-                key={key}
-                metadataField={key}
-                values={categoryOptions}
-                isTruncated={categoryOptions !== value.options}
-              />
-            );
-          }
-          return undefined;
-        })}
+        {_.map(categoricalSelectionState, (catState, catName) => (
+          <Category key={catName} metadataField={catName} />
+        ))}
       </div>
     );
   }

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -25,16 +25,24 @@ class Category extends React.Component {
     const { categoricalSelectionState, metadataField } = this.props;
     const cat = categoricalSelectionState[metadataField];
     const categoryCount = {
-      total: cat.numOptions,
-      on: _.reduce(cat.optionSelected, (res, cond) => (cond ? res + 1 : res), 0)
+      // total number of options in this category
+      totalOptionCount: cat.numOptions,
+      // number of selected options in this category
+      selectedOptionCount: _.reduce(
+        cat.optionSelected,
+        (res, cond) => (cond ? res + 1 : res),
+        0
+      )
     };
-    if (categoryCount.on === categoryCount.total) {
+    if (categoryCount.selectedOptionCount === categoryCount.totalOptionCount) {
       /* everything is on, so not indeterminate */
       this.checkbox.indeterminate = false;
-    } else if (categoryCount.on === 0) {
+    } else if (categoryCount.selectedOptionCount === 0) {
       /* nothing is on, so no */
       this.checkbox.indeterminate = false;
-    } else if (categoryCount.on < categoryCount.total) {
+    } else if (
+      categoryCount.selectedOptionCount < categoryCount.totalOptionCount
+    ) {
       /* to be explicit... */
       this.checkbox.indeterminate = true;
     }

--- a/client/src/components/categorical/util.js
+++ b/client/src/components/categorical/util.js
@@ -1,7 +1,11 @@
 // jshint esversion: 6
+
+// values is [ [optVal, optIdx], ...]
+// index is range array
+// return sorted index
 export default values =>
-  Object.keys(values).sort((a, b) => {
-    const textA = a.toUpperCase();
-    const textB = b.toUpperCase();
+  values.sort((a, b) => {
+    const textA = String(a[0]).toUpperCase();
+    const textB = String(b[0]).toUpperCase();
     return textA < textB ? -1 : textA > textB ? 1 : 0;
   });

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -4,45 +4,49 @@ import React from "react";
 import _ from "lodash";
 
 @connect(state => ({
-  categoricalAsBooleansMap: state.controls.categoricalAsBooleansMap,
+  categoricalSelectionState: state.controls.categoricalSelectionState,
   colorScale: state.controls.colorScale,
   colorAccessor: state.controls.colorAccessor,
   schema: _.get(state.controls.world, "schema", null)
 }))
 class CategoryValue extends React.Component {
   toggleOff() {
-    const { dispatch, metadataField, value } = this.props;
+    const { dispatch, metadataField, optionIndex } = this.props;
     dispatch({
       type: "categorical metadata filter deselect",
       metadataField,
-      value
+      optionIndex
     });
   }
 
   toggleOn() {
-    const { dispatch, metadataField, value } = this.props;
+    const { dispatch, metadataField, optionIndex } = this.props;
     dispatch({
       type: "categorical metadata filter select",
       metadataField,
-      value
+      optionIndex
     });
   }
 
   render() {
     const {
-      categoricalAsBooleansMap,
+      categoricalSelectionState,
       metadataField,
-      count,
-      value,
+      optionIndex,
       colorAccessor,
       colorScale,
       i,
       schema
     } = this.props;
 
-    if (!categoricalAsBooleansMap) return null;
+    if (!categoricalSelectionState) return null;
 
-    const selected = categoricalAsBooleansMap[metadataField][value];
+    const category = categoricalSelectionState[metadataField];
+    const selected = category.optionSelected[optionIndex];
+    const count = category.optionCount[optionIndex];
+    const value = category.optionValue[optionIndex];
+    const displayString = String(category.optionValue[optionIndex]).valueOf();
+
     /* this is the color scale, so add swatches below */
     const c = metadataField === colorAccessor;
     let categories = null;
@@ -78,7 +82,7 @@ class CategoryValue extends React.Component {
               type="checkbox"
             />
             <span className="bp3-control-indicator" />
-            {value}
+            {displayString}
           </label>
         </div>
         <span>

--- a/client/src/util/stateManager/summarizeAnnotations.js
+++ b/client/src/util/stateManager/summarizeAnnotations.js
@@ -48,6 +48,12 @@ Example:
 
 NOTE: will not summarize the required 'name' annotation, as that is
 specified as unique per element.
+
+TODO: XXX - this data structure coerces all metadata categories into a string
+(ie, stores values as an Object property in the `options` field).   This looses
+information (eg, type) for category types which are not strings.  Consider an
+alterative data structure that does not use the object property for non-string
+data types (and does not use _.countBy to summarize).
 */
 function summarizeDimension(schema, annotations) {
   return _(schema)
@@ -58,11 +64,13 @@ function summarizeDimension(schema, annotations) {
       const continuous = type === "int32" || type === "float32";
 
       if (!continuous) {
+        const categories = _.uniq(_.flatMap(annotations, name));
         const options = _.countBy(annotations, name);
         const numOptions = _.size(options);
         return {
           numOptions,
-          options
+          options,
+          categories
         };
       }
 


### PR DESCRIPTION
Fixes #457 

Several improvements to annotation/metadata handling:
* revised front-end categorical metadata (components and reducers) to not assume all annotation is composed of string data.   It will now safely handle native types (bool, string, number, etc).
* improved the type inferencing in the ScanPy engine so that it correctly handles bools, and does not mistakenly coerce between incompatible numpy types.

While this fixes #457, there is still residual issues with how we summarize metadata in the front-end (specfically, `world.summary` assumes all annotation/metadata values can be safely converted to Object lables/strings without losing information).   There will be another PR to fix that.