### PR TITLE
Allow float64 to down-cast to float32

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -34,7 +34,7 @@ class HistogramBrush extends React.Component {
       .scaleLinear()
       .range([this.height - this.marginBottom, 0]);
 
-    if (obsAnnotations[0][field]) {
+    if (obsAnnotations[0][field] !== undefined) {
       // recalculate expensive stuff
       const allValuesForContinuousFieldAsArray = _.map(obsAnnotations, field);
 

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -67,7 +67,9 @@ class ScanpyEngine(CXGDriver):
 
     @staticmethod
     def _can_cast_to_float32(ann):
-        if ann.dtype.kind == "f" and np.can_cast(ann.dtype, np.float32):
+        if ann.dtype.kind == "f":
+            if not np.can_cast(ann.dtype, np.float32):
+                warnings.warn(f"Annotation {ann.name} will be converted to 32 bit float and may loose precision.")
             return True
         return False
 


### PR DESCRIPTION
Fixes #471 

Changes:
* CLI (launch):  float64 data in annotations will down-cast to float32.  A warning issued when `launch` starts for each annotation where this will occur.
* front-end: correctly handle falsey data values when creating histograms