### PR TITLE
External host option

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -24,14 +24,13 @@ from server.app.util.errors import ScanpyFileError
 @click.option("--port", "-p", help="Port to run server on.", metavar="", default=5005, show_default=True)
 @click.option("--obs-names", default=None, metavar="", help="Name of annotation field to use for observations.")
 @click.option("--var-names", default=None, metavar="", help="Name of annotation to use for variables.")
-@click.option("--listen-all", is_flag=True, default=False, show_default=True,
-              help="Bind to all interfaces (this makes the server accessible beyond this computer).")
+@click.option("--host", default=None, help="Host name or ip (for serving externally accessible instance).")
 @click.option("--max-category-items", default=100, metavar="", show_default=True,
               help="Limits the number of categorical annotation items displayed.")
 @click.option("--diffexp-lfc-cutoff", default=0.01, show_default=True,
               help="Relative expression cutoff used when selecting top N differentially expressed genes")
 def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
-           open_browser, port, listen_all, max_category_items, diffexp_lfc_cutoff):
+           open_browser, port, host, max_category_items, diffexp_lfc_cutoff):
     """Launch the cellxgene data viewer.
     This web app lets you explore single-cell expression data.
     Data must be in a format that cellxgene expects, read the
@@ -65,8 +64,8 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
         file_parts = splitext(basename(data))
         title = file_parts[0]
 
-    if listen_all:
-        host = "0.0.0.0"
+    if host:
+        host = host
     else:
         host = "127.0.0.1"
 

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -66,8 +66,10 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
 
     if host:
         host = host
+        flask_host = "0.0.0.0"
     else:
         host = "127.0.0.1"
+        flask_host = host
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"
@@ -116,4 +118,4 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
         f = open(devnull, 'w')
         sys.stdout = f
 
-    app.run(host=host, debug=debug, port=port, threaded=True)
+    app.run(host=flask_host, debug=debug, port=port, threaded=True)

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -24,7 +24,7 @@ from server.app.util.errors import ScanpyFileError
 @click.option("--port", "-p", help="Port to run server on.", metavar="", default=5005, show_default=True)
 @click.option("--obs-names", default=None, metavar="", help="Name of annotation field to use for observations.")
 @click.option("--var-names", default=None, metavar="", help="Name of annotation to use for variables.")
-@click.option("--host", default=None, help="Host name or ip (for serving externally accessible instance).")
+@click.option("--host", default="127.0.0.1", help="Host IP address")
 @click.option("--max-category-items", default=100, metavar="", show_default=True,
               help="Limits the number of categorical annotation items displayed.")
 @click.option("--diffexp-lfc-cutoff", default=0.01, show_default=True,
@@ -63,13 +63,6 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
     if not title:
         file_parts = splitext(basename(data))
         title = file_parts[0]
-
-    if host:
-        host = host
-        flask_host = "0.0.0.0"
-    else:
-        host = "127.0.0.1"
-        flask_host = host
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"
@@ -118,4 +111,4 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
         f = open(devnull, 'w')
         sys.stdout = f
 
-    app.run(host=flask_host, debug=debug, port=port, threaded=True)
+    app.run(host=host, debug=debug, port=port, threaded=True)


### PR DESCRIPTION
Since we are sending the front-end the api base, simply listening to all ports on the backend (0.0.0.0) wasn't working for hosting cellxgene externally. I've replaced the --listen-all option with a --host option. And then send flask either localhost if --host isn't specified or 0.0.0.0 if it is. The host option works with an IP or with a host url.

Fixes #440 