### PR TITLE
Default warning in debug mode

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 from flask import Flask
 from flask_caching import Cache
@@ -8,12 +7,10 @@ from flask_cors import CORS
 from flask_restful_swagger_2 import get_swagger_blueprint
 
 from .rest_api.rest import get_api_resources
-from .util.utils import Float32JSONEncoder, custom_format_warning
+from .util.utils import Float32JSONEncoder
 from .web import webapp
 
 REACTIVE_LIMIT = 1_000_000
-
-warnings.formatwarning = custom_format_warning
 
 app = Flask(__name__, static_folder="web/static")
 app.json_encoder = Float32JSONEncoder

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -1,11 +1,14 @@
-import sys
-import click
 import logging
 from os import devnull
 from os.path import splitext, basename
+import sys
+import warnings
 import webbrowser
 
+import click
+
 from server.app.util.errors import ScanpyFileError
+from server.app.util.utils import custom_format_warning
 
 
 @click.command()
@@ -48,9 +51,6 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
     # Startup message
     click.echo("[cellxgene] Starting the CLI...")
 
-    # Import Flask app
-    from server.app.app import app
-
     # Argument checking
     name, extension = splitext(data)
     if extension != ".h5ad":
@@ -59,6 +59,8 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
     if debug:
         verbose = True
         open_browser = False
+    else:
+        warnings.formatwarning = custom_format_warning
 
     if not verbose:
         sys.tracebacklimit = 0
@@ -70,6 +72,9 @@ def launch(data, layout, diffexp, title, verbose, debug, obs_names, var_names,
     # Setup app
     cellxgene_url = f"http://{host}:{port}"
     api_base = f"{cellxgene_url}/api/"
+
+    # Import Flask app
+    from server.app.app import app
 
     app.config.update(
         DATASET_TITLE=title,


### PR DESCRIPTION
Fixes #496 

This allows warnings to have their default format when a user request debug mode. (Also cleaned up the import statement order while I was under the hood.)