### PR TITLE
Add alternative to install [louvain] extra requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cellxgene prepare --help
 pip install cellxgene[louvain]
 ```
 
-On some environments installing the extra requires for lovain as above does not work. Alternatively, you can install these dependencies by hand in addition to the cellxgene package.
+If the aforementioned optional package installation fails, you can also install these packages directly:
 
 ```
 pip install python-igraph louvain>=0.6

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ cellxgene prepare --help
 pip install cellxgene[louvain]
 ```
 
+On some environments installing the extra requires for lovain as above does not work. Alternatively, you can install these dependencies by hand in addition to the cellxgene package.
+
+```
+pip install python-igraph louvain>=0.6
+```
+
 ## conda and virtual environments
 
 If you use conda and want to create a conda environment for `cellxgene` you can use the following commands


### PR DESCRIPTION
Updated the install instructions to describe how to install the requirements to perform louvain clustering individually. Using setup.py's extra requires method `pip install scanpy[louvain]` does not work on all environments.

@davidrecordon please ensure that this passes license requirements
@bkmartinjr / @freeman-lab please check that the instructions are clear and in the right place

Fixes #451 