### PR TITLE
Add Docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+bin
+client
+dist
+docs
+server

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - ./bin/build-client
   - pip install -e .
   - pip install -r server/requirements-dev.txt
+  - docker build .
 script:
   - set -eo pipefail
   - flake8 server/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:bionic
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+EXPOSE 5005:5005
+
+RUN apt-get update
+RUN apt-get install -y build-essential libxml2-dev python3-dev python3-pip zlib1g-dev
+RUN pip3 install cellxgene
+
+ENTRYPOINT ["cellxgene"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,8 @@ FROM ubuntu:bionic
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-EXPOSE 5005:5005
-
-RUN apt-get update
-RUN apt-get install -y build-essential libxml2-dev python3-dev python3-pip zlib1g-dev
-RUN pip3 install cellxgene
+RUN apt-get update && \
+    apt-get install -y build-essential libxml2-dev python3-dev python3-pip zlib1g-dev && \
+    pip3 install cellxgene
 
 ENTRYPOINT ["cellxgene"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ source ${ENV_NAME}/bin/activate
 pip install cellxgene
 ```
 
+## docker
+
+We have included a dockerfile to conveniently run cellxgene from docker. 
+
+1. Build the  image `docker build . -t cellxgene`
+2. Run the container and mount data `docker run -v "$PWD/example-dataset/:/data/" -p 5005:5005 cellxgene launch --host 0.0.0.0 data/pbmc3k.h5ad`
+    * You will need to use --host 0.0.0.0 to have the container listen to incoming requests from the browser
+
+
 ## FAQ
 
 > Someone sent me a directory of `10X-Genomics` data with a `mtx` file and I've never used `scanpy`, can I use `cellxgene`?

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,4 +11,4 @@ numpy>=1.14.5
 pandas>=0.23.1
 scanpy>=1.3.2
 scipy>=1.1.0
-scikit-learn==0.19.1
+scikit-learn>=0.19.1,!=0.20.0


### PR DESCRIPTION
Now that cellxgene can be installed via pip, the docker container creation is a little more straightforward. I've updated @flying-sheep's request but was able to start from an ubuntu image instead of having to use the scanpy image. 

Adding the container build to the tests takes approx 1min 15s. I'm not sure if it is worth it.