### PR TITLE
Clarify that we do not support python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Or you can create a virtual environment by using
 
 ```
 ENV_NAME=cellxgene
-python3 -m venv ${ENV_NAME}
+python3.6 -m venv ${ENV_NAME}
 source ${ENV_NAME}/bin/activate
 pip install cellxgene
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## getting started
 
-You'll need **python 3.6** and **Google Chrome**. The web UI is tested on OSX and Windows using Chrome, and the python CLI is tested on OSX and Ubuntu (via WSL/Windows). It should work on other platforms, but if you run into trouble let us know (see [help](#help-and-contact) below).
+You'll need **python 3.6** and **Google Chrome**. (*Warning*: Python 3.7 is **not** supported at this time)
+The web UI is tested on OSX and Windows using Chrome, and the python CLI is tested on OSX and Ubuntu (via WSL/Windows). It should work on other platforms, but if you run into trouble let us know (see [help](#help-and-contact) below).
+
 
 To install run
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
 from setuptools import setup, find_packages
+import sys
+
+if sys.version_info[0:2] != (3, 6):
+    raise ImportError(
+        "cellxgene only supports python 3.6. "
+        "See https://github.com/chanzuckerberg/cellxgene#conda-and-virtual-environments "
+        "for more details about installation"
+    )
 
 with open("README.md", "rb") as fh:
     long_description = fh.read().decode()
@@ -16,19 +24,24 @@ setup(
     author_email="cweaver@chanzuckerberg.com",
     description="Web application for exploration of large scale scRNA-seq datasets",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     install_requires=requirements,
     include_package_data=True,
     zip_safe=False,
-    classifiers=(
-        "Programming Language :: Python :: 3",
+    classifiers=[
+        "Framework :: Flask",
+        "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
-    ),
-    entry_points={
-        "console_scripts":
-            ["cellxgene = server.cli.cli:cli"]
-    },
-    extras_require=dict(
-        louvain=['python-igraph', 'louvain>=0.6'],
-    ),
+        "Natural Language :: English",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS :: MacOS X",
+        "Programming Language :: JavaScript",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+    ],
+    entry_points={"console_scripts": ["cellxgene = server.cli.cli:cli"]},
+    extras_require=dict(louvain=["python-igraph", "louvain>=0.6"]),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ import sys
 
 if sys.version_info[0:2] != (3, 6):
     raise ImportError(
-        "cellxgene only supports python 3.6. "
+        "cellxgene currently only supports python 3.6. Python 3.7 is known to fail; we will look at supporting "
+        "versions other than 3.6 in the future."
         "See https://github.com/chanzuckerberg/cellxgene#conda-and-virtual-environments "
-        "for more details about installation"
+        "for more help with installation."
     )
 
 with open("README.md", "rb") as fh:


### PR DESCRIPTION
Added warning that we do not support python 3.7 in readme, and an import error to installation when installing with anything but python 3.6. 

I also added some more classifiers while I was under the hood in setup.py

Fixes #510 