### PR TITLE
Use url_root from Flask rather than hardcoding hostname.

### DIFF
--- a/server/app/web/webapp.py
+++ b/server/app/web/webapp.py
@@ -1,5 +1,5 @@
 import os
-from flask import Blueprint, render_template, send_from_directory, current_app
+from flask import Blueprint, render_template, send_from_directory, current_app, request
 
 
 bp = Blueprint("webapp", __name__, template_folder="templates")
@@ -7,7 +7,7 @@ bp = Blueprint("webapp", __name__, template_folder="templates")
 
 @bp.route("/")
 def index():
-    url_base = current_app.config["CXG_API_BASE"]
+    url_base = request.url_root + "api/"
     dataset_title = current_app.config["DATASET_TITLE"]
     return render_template("index.html", prefix=url_base, datasetTitle=dataset_title)
 

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -117,12 +117,11 @@ def launch(
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"
-    api_base = f"{cellxgene_url}/api/"
 
     # Import Flask app
     from server.app.app import app
 
-    app.config.update(DATASET_TITLE=title, CXG_API_BASE=api_base)
+    app.config.update(DATASET_TITLE=title)
 
     if not verbose:
         log = logging.getLogger("werkzeug")


### PR DESCRIPTION
Currently the base URL for pull requests hardcodes the hostname.

This was preventing me from running in a remote host's Docker container
or behind a proxy without some hostname hacks.

This changes the url_base for API requests to be determined dynamically
from the request, so it will work behind proxies, etc.