### PR TITLE
performance improvements in color-by feature

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -26,7 +26,7 @@ import actions from "../../actions";
   obsAnnotations: _.get(state.controls.world, "obsAnnotations", null)
 }))
 class HistogramBrush extends React.Component {
-  calcHistogramCache = memoize((obsAnnotations, field, ranges) => {
+  calcHistogramCache = memoize((obsAnnotations, field, rangeMin, rangeMax) => {
     const { world } = this.props;
     const histogramCache = {};
 
@@ -40,7 +40,7 @@ class HistogramBrush extends React.Component {
 
       histogramCache.x = d3
         .scaleLinear()
-        .domain([ranges.min, ranges.max])
+        .domain([rangeMin, rangeMax])
         .range([0, this.width]);
 
       histogramCache.bins = d3
@@ -130,7 +130,8 @@ class HistogramBrush extends React.Component {
     const histogramCache = this.calcHistogramCache(
       obsAnnotations,
       field,
-      ranges
+      ranges.min,
+      ranges.max
     );
 
     const { x, y, bins, numValues } = histogramCache;

--- a/client/src/reducers/controls.js
+++ b/client/src/reducers/controls.js
@@ -112,7 +112,6 @@ const Controls = (
 
     // all of the data + selection state
     world: null,
-    colorName: null,
     colorRGB: null,
     categoricalSelectionState: null,
     crossfilter: null,
@@ -167,8 +166,9 @@ const Controls = (
       /* first light - create world & other data-driven defaults */
       const { universe } = action;
       const world = World.createWorldFromEntireUniverse(universe);
-      const colorName = new Array(universe.nObs).fill(globals.defaultCellColor);
-      const colorRGB = _.map(colorName, c => parseRGB(c));
+      const colorRGB = new Array(universe.nObs).fill(
+        parseRGB(globals.defaultCellColor)
+      );
       const categoricalSelectionState = createCategoricalSelectionState(
         state,
         world
@@ -223,7 +223,6 @@ const Controls = (
         error: null,
         universe,
         world,
-        colorName,
         colorRGB,
         categoricalSelectionState,
         crossfilter,
@@ -240,8 +239,9 @@ const Controls = (
         action.world,
         action.crossfilter
       );
-      const colorName = new Array(world.nObs).fill(globals.defaultCellColor);
-      const colorRGB = _.map(colorName, c => parseRGB(c));
+      const colorRGB = new Array(world.nObs).fill(
+        parseRGB(globals.defaultCellColor)
+      );
       const categoricalSelectionState = createCategoricalSelectionState(
         state,
         world
@@ -289,7 +289,6 @@ const Controls = (
         loading: false,
         error: null,
         world,
-        colorName,
         colorRGB,
         categoricalSelectionState,
         crossfilter,
@@ -442,11 +441,11 @@ const Controls = (
     }
     case "reset colorscale": {
       const { world } = state;
-      const colorName = new Array(world.nObs).fill(globals.defaultCellColor);
-      const colorRGB = _.map(colorName, c => parseRGB(c));
+      const colorRGB = new Array(world.nObs).fill(
+        parseRGB(globals.defaultCellColor)
+      );
       return {
         ...state,
-        colorName,
         colorRGB,
         colorAccessor: null
       };
@@ -609,7 +608,6 @@ const Controls = (
     case "color by continuous metadata": {
       return {
         ...state,
-        colorName: action.colors.name,
         colorRGB: action.colors.rgb,
         colorAccessor: action.colorAccessor,
         colorScale: action.colorScale
@@ -618,7 +616,6 @@ const Controls = (
     case "color by expression": {
       return {
         ...state,
-        colorName: action.colors.name,
         colorRGB: action.colors.rgb,
         colorAccessor: action.gene,
         colorScale: action.colorScale


### PR DESCRIPTION
Fixes #534 

Color by metadata has become quite slow for large collections (multiple seconds to switch color-by choices with 1MM+ cell count).  This PR contains several changes:
* fixes accidentally memoization defeat in histogram creation for brushableHistogram component (was triggering a full histogram rebuild on each color change).
* the unused "colorName" array has been removed from the `controls` reducer.   It previously held a string representation of each cell color (eg, rgb(0,0,0,1)).
* code in `updateCellColors.js` previously set all cell colors by color name, and then parsed into RGB space (ie, 1M+ string parse operations).  This has been modified to compute a predefined number of discrete color bins, and assign these to each cell.

The last change has the effect of discretizing color assignment.  For categorical metadata this is identical to previous behavior - just much faster.   For continuous metadata (either annotations or expression), the code creates a constant number of color bins.  The number of bins can be tuned until it is a reasonable compromise between speed and aesthetics.   It is currently set to 100 color bins, which looks the same to my eye.

@colinmegill - please advise if you wish a larger or smaller number of color bins for continuous metadata.  The current number is based upon my own casual observation, which is known deficient :-)