### PR TITLE
Set API path based on access address

### DIFF
--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -10,7 +10,7 @@ const nodeModules = path.resolve("node_modules");
 
 const babelOptions = require("../babel/babel.prod");
 
-const publicPath = "/";
+const publicPath = "";
 
 module.exports = {
   mode: "production",

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -24,7 +24,7 @@
 <script type="text/javascript">
 window.CELLXGENE = {};
 window.CELLXGENE.API = {
-  prefix: "{{ prefix | safe }}",
+  prefix: window.location.href + "api/",
   version: "v0.2/"
 };
 </script>

--- a/server/app/web/templates/swagger.html
+++ b/server/app/web/templates/swagger.html
@@ -73,7 +73,7 @@
 <script>
 	window.onload = function () {
 		const ui = SwaggerUIBundle({
-			url: window.location.origin + "/api/swagger.json",
+			url: window.location.href.replace(/\/swagger$/, "") + "/api/swagger.json",
 			dom_id: '#swagger-ui',
 			deepLinking: true,
 			presets: [

--- a/server/app/web/webapp.py
+++ b/server/app/web/webapp.py
@@ -7,9 +7,8 @@ bp = Blueprint("webapp", __name__, template_folder="templates")
 
 @bp.route("/")
 def index():
-    url_base = request.url_root + "api/"
     dataset_title = current_app.config["DATASET_TITLE"]
-    return render_template("index.html", prefix=url_base, datasetTitle=dataset_title)
+    return render_template("index.html", datasetTitle=dataset_title)
 
 
 # renders swagger documentation

--- a/server/app/web/webapp.py
+++ b/server/app/web/webapp.py
@@ -1,5 +1,5 @@
 import os
-from flask import Blueprint, render_template, send_from_directory, current_app, request
+from flask import Blueprint, render_template, send_from_directory, current_app
 
 
 bp = Blueprint("webapp", __name__, template_folder="templates")


### PR DESCRIPTION
Building on #520, this should make using cellxgene through a proxy easier. Instead of using `request.url_root` this will use the whole address, making it easier to host cellxgene instances at multiple routes, or via https. Here's a simple example:

```apacheconf
# /etc/apache2/sites-enabled/reverseprox.conf
<VirtualHost *:80>
    # Setup
    ServerName {server_url}
    LoadModule proxy_module modules/mod_proxy.so
    ProxyPreserveHost On
    ProxyRequests Off
    # Setting routes for cellxgene
    ProxyPass "/dataset1/" "http://0.0.0.0:5005/"
    ProxyPassReverse "/dataset1/" "http://0.0.0.0:5005/"
    ProxyPass "/dataset2/" "http://0.0.0.0:5006/"
    ProxyPassReverse "/dataset2/" "http://0.0.0.0:5006/"
</VirtualHost>
```

The only remaining issue are the `/static` resources, whose url's seem to be set during the build process. I'd appreciate any suggestions on this bit.