### PR TITLE
[EASY] remove build-dev from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ coverage
 
 # production
 build/
-build-dev/
 dist/
 *.egg-info
 


### PR DESCRIPTION
Tony caught this, but I had merged already.