### PR TITLE
fix accept type bug

### DIFF
--- a/client/src/util/actionHelpers.js
+++ b/client/src/util/actionHelpers.js
@@ -35,7 +35,7 @@ const doFetch = async (url, acceptType) => {
       Accept: acceptType
     })
   });
-  if (res.ok && res.headers.get("Content-Type") === acceptType) {
+  if (res.ok && res.headers.get("Content-Type").includes(acceptType)) {
     return res;
   }
   // else an error


### PR DESCRIPTION
Check's if the accept type is in the content type header. Previously it would break if the header included the charset in addition to the accept type.