### PR TITLE
Add forced directed graph drawing to allowed layout options

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -14,7 +14,12 @@ from server.app.util.utils import custom_format_warning
 @click.command()
 @click.argument("data", metavar="<data file>", type=click.Path(exists=True, file_okay=True, dir_okay=False))
 @click.option(
-    "--layout", "-l", type=click.Choice(["umap", "tsne", "draw_graph_fa", "draw_graph_fr"]), default="umap", show_default=True, help="Method for layout."
+    "--layout",
+    "-l",
+    type=click.Choice(["umap", "tsne", "draw_graph_fa", "draw_graph_fr"]),
+    default="umap",
+    show_default=True,
+    help="Method for layout."
 )
 @click.option(
     "--diffexp",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -14,7 +14,7 @@ from server.app.util.utils import custom_format_warning
 @click.command()
 @click.argument("data", metavar="<data file>", type=click.Path(exists=True, file_okay=True, dir_okay=False))
 @click.option(
-    "--layout", "-l", type=click.Choice(["umap", "tsne"]), default="umap", show_default=True, help="Method for layout."
+    "--layout", "-l", type=click.Choice(["umap", "tsne", "draw_graph_fa", "draw_graph_fr"]), default="umap", show_default=True, help="Method for layout."
 )
 @click.option(
     "--diffexp",


### PR DESCRIPTION
Hi, thank you for the awesome package! :smile:

Can we add two canonical layouts, which are widely used in the community, to the allowed options? Force-directed graph drawing has many flavors, but the ForceAtlas2 layout and the Fruchtermann Reingold are among the most popular and most established.

The SPRING viewer from the Klein lab, uses FA2 by default. Within Scanpy, people compute these layouts using the `tl.draw_graph` tool.

Let me attach a comparison for the typical features of tSNE, UMAP, FA2 (and an FA2 layout that has been initialized using PAGA, but that's not the point here). This is Supplemental Figure 10 from the PAGA paper (https://doi.org/10.1101/208819, in press at Genome Biology).
![image](https://user-images.githubusercontent.com/16916678/53688569-2f2d1700-3d46-11e9-84a5-a33afbe5a36d.png)

You see that also UMAP has a tendency to produce disconnected manifolds when they are actually connected in high dimensions.

In Figure 1 of the PAGA paper, the first 3 layouts are force-directed layouts. They are faithful to topology and known biology (lineages in hematopoiesis):
![image](https://user-images.githubusercontent.com/16916678/53688595-73201c00-3d46-11e9-8f3c-09df7c2055e1.png)

Thanks for considering!
  Alex