### PR TITLE
do not reset color scale when dismissing scatterplot

### DIFF
--- a/client/src/components/scatterplot/scatterplot.js
+++ b/client/src/components/scatterplot/scatterplot.js
@@ -345,14 +345,11 @@ class Scatterplot extends React.Component {
           <Button
             type="button"
             minimal
-            onClick={() => {
+            onClick={() =>
               dispatch({
                 type: "clear scatterplot"
-              });
-              dispatch({
-                type: "reset colorscale"
-              });
-            }}
+              })
+            }
           >
             remove
           </Button>


### PR DESCRIPTION
Fixes #609 

Change: removed the (previously) explicit reset of color-by when dismissing scatterplot.