### PR TITLE
Update test ui names

### DIFF
--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -4,23 +4,29 @@ const jest_env = process.env.JEST_ENV || "dev";
 const appPort = process.env.JEST_CXG_PORT || 3000;
 const appUrlBase = `http://localhost:${appPort}`;
 const DEV = jest_env === "dev";
+const DEBUG = jest_env === "debug";
 
 let browser;
 let page;
 const browserViewport = { width: 1280, height: 960 };
 
+if (DEBUG) jest.setTimeout(100000);
+
 beforeAll(async () => {
   const browser_params = DEV
-    ? { headless: false, slowMo: 100, devtools: true }
+    ? { headless: false, slowMo: 50 }
+    : DEBUG
+    ? { headless: false, slowMo: 200, devtools: true }
     : {};
   browser = await puppeteer.launch(browser_params);
   page = await browser.newPage();
   page.setViewport(browserViewport);
-  if (DEV) page.on("console", msg => console.log("PAGE LOG:", msg.text()));
+  if (DEV || DEBUG)
+    page.on("console", msg => console.log("PAGE LOG:", msg.text()));
 });
 
 afterAll(() => {
-  if (!DEV) {
+  if (!DEBUG) {
     browser.close();
   }
 });

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -72,7 +72,7 @@ describe("search for genes", () => {
 describe("select cells and diffexp", () => {
   test("selects cells from layout and adds to cell set 1", async () => {
     await page.goto(appUrlBase);
-    const layout = await page.waitForSelector("[data-testid='layout']");
+    const layout = await page.waitForSelector("[data-testid='layout-graph']");
     const size = await layout.boxModel();
     const cellset1 = {
       start: {
@@ -92,7 +92,7 @@ describe("select cells and diffexp", () => {
 
   test("selects cells from layout and adds to cell set 2", async () => {
     await page.goto(appUrlBase);
-    const layout = await page.waitForSelector("[data-testid='layout']");
+    const layout = await page.waitForSelector("[data-testid='layout-graph']");
     const size = await layout.boxModel();
     const cellset2 = {
       start: {
@@ -112,7 +112,7 @@ describe("select cells and diffexp", () => {
 
   test("selects cells, saves them and performs diffexp", async () => {
     await page.goto(appUrlBase);
-    const layout = await page.waitForSelector("[data-testid='layout']");
+    const layout = await page.waitForSelector("[data-testid='layout-graph']");
     const size = await layout.boxModel();
     const cellset1 = {
       start: {


### PR DESCRIPTION
Updated UI tests name (tests were failing because we renamed layout -> layout-graph)

Also added a debug mode in addition to dev mode for running tests. DEV opens browser but the slowmo is minimal, it is meant for validating that the smoke tests pass after making changes. DEBUG mode opens dev tools, doesn't close the browser, and slows the tests way down. This is meant to debug failing tests.