### PR TITLE
More informative out-of-memory error

### DIFF
--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -143,6 +143,9 @@ class ScanpyEngine(CXGDriver):
                 "using `cellxgene prepare`, please run `cellxgene prepare --help` for more "
                 "information."
             )
+        except MemoryError as e:
+            raise ScanpyFileError("Error while loading file: out of memory, file is too large"
+                                  " for memory available")
         except Exception as e:
             raise ScanpyFileError(
                 f"Error while loading file: {e}, File must be in the .h5ad format, please check "

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -143,7 +143,7 @@ class ScanpyEngine(CXGDriver):
                 "using `cellxgene prepare`, please run `cellxgene prepare --help` for more "
                 "information."
             )
-        except MemoryError as e:
+        except MemoryError:
             raise ScanpyFileError("Error while loading file: out of memory, file is too large"
                                   " for memory available")
         except Exception as e:


### PR DESCRIPTION
Fixes #642 

Catch memory error when loading scanpy file. 