### PR TITLE
Support `diffmap` and `phate` layouts. Explicitly handle embeddings with >2 components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You should see your web browser open with the following
 
 There are several options available, such as:
 
-- `--layout` to specify the layout as `tsne`, `umap`, `draw_graph_fa`, or `draw_graph_fr` 
+- `--layout` to specify the layout as `tsne`, `umap`, `diffmap`, `phate`, `draw_graph_fa`, or `draw_graph_fr`
 - `--title` to show a title on the explorer
 - `--open` to automatically open the web browser after launching (OS X only)
 

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -325,14 +325,11 @@ class ScanpyEngine(CXGDriver):
         * only returns Matrix in columnar layout
         """
         try:
-            import click
-            click.echo('click echo worked')
-            print('print worked')
-            raise KeyError('error raising works')
-            df_layout = self.data.obsm[f"X_{self.layout_method}"]
+            df_layout = self.data.obsm[f"X_{self.layout_method}"][:,:2]
         except ValueError as e:
             raise PrepareError(
                 f"Layout has not been calculated using {self.layout_method}, "
                 f"please prepare your datafile and relaunch cellxgene") from e
+
         normalized_layout = (df_layout - df_layout.min()) / (df_layout.max() - df_layout.min())
         return encode_matrix_fbs(normalized_layout.astype(dtype=np.float32), col_idx=None, row_idx=None)

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -325,6 +325,10 @@ class ScanpyEngine(CXGDriver):
         * only returns Matrix in columnar layout
         """
         try:
+            import click
+            click.echo('click echo worked')
+            print('print worked')
+            raise KeyError('error raising works')
             df_layout = self.data.obsm[f"X_{self.layout_method}"]
         except ValueError as e:
             raise PrepareError(

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -325,7 +325,10 @@ class ScanpyEngine(CXGDriver):
         * only returns Matrix in columnar layout
         """
         try:
-            df_layout = self.data.obsm[f"X_{self.layout_method}"][:, :2]
+            full_embedding = self.data.obsm[f"X_{self.layout_method}"]
+            if full_embedding.shape[1] > 2:
+                warnings.warn(f"Warning: found {full_embedding.shape[1]} components of embedding. Using the first two for layout display.")
+            df_layout = full_embedding[:, :2]
         except ValueError as e:
             raise PrepareError(
                 f"Layout has not been calculated using {self.layout_method}, "

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -327,7 +327,8 @@ class ScanpyEngine(CXGDriver):
         try:
             full_embedding = self.data.obsm[f"X_{self.layout_method}"]
             if full_embedding.shape[1] > 2:
-                warnings.warn(f"Warning: found {full_embedding.shape[1]} components of embedding. Using the first two for layout display.")
+                warnings.warn(f"Warning: found {full_embedding.shape[1]} \
+                components of embedding. Using the first two for layout display.")
             df_layout = full_embedding[:, :2]
         except ValueError as e:
             raise PrepareError(

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -325,7 +325,7 @@ class ScanpyEngine(CXGDriver):
         * only returns Matrix in columnar layout
         """
         try:
-            df_layout = self.data.obsm[f"X_{self.layout_method}"][:,:2]
+            df_layout = self.data.obsm[f"X_{self.layout_method}"][:, :2]
         except ValueError as e:
             raise PrepareError(
                 f"Layout has not been calculated using {self.layout_method}, "

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -16,7 +16,7 @@ from server.app.util.utils import custom_format_warning
 @click.option(
     "--layout",
     "-l",
-    type=click.Choice(["umap", "tsne", "draw_graph_fa", "draw_graph_fr"]),
+    type=click.Choice(["umap", "tsne", "draw_graph_fa", "draw_graph_fr", "diffmap", "phate"]),
     default="umap",
     show_default=True,
     help="Method for layout."


### PR DESCRIPTION
This PR fixes a potential bug in how we load layouts (Fixes #661). It also provides basic support for trajectory visualization (Fixes #660).  

The app already supports visualization of cells' positions in pseudotime (via continuous metadata field `dpt_pseudotime`) and trajectory branch assignments (via categorical metadata field `dpt_group`).  

By supporting `diffmap` and `phate` as supported layouts, we can enable users to explore the output of most of the trajectory inference methods implemented in the current version of scanpy:

![image](https://user-images.githubusercontent.com/12618847/54776384-40db3f00-4bcd-11e9-89b0-9219146059b3.png) 

![image](https://user-images.githubusercontent.com/12618847/54776429-594b5980-4bcd-11e9-9499-3c013bcabd6d.png)

In the process of adding support for these, I also discovered that we don't explicitly pull the first two components of a given embedding (this is relevant for the currently-supported layouts, as well, as umap and tsne can also be exported with >2 components). Easy fix to head off any future confusion.