### PR TITLE
use Math.abs when calculating lasso area

### DIFF
--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -397,7 +397,10 @@ class Graph extends React.Component {
     const minimumPolygoneArea = 10;
     const { dispatch } = this.props;
 
-    if (polygon.length < 3 || d3.polygonArea(polygon) < minimumPolygoneArea) {
+    if (
+      polygon.length < 3 ||
+      Math.abs(d3.polygonArea(polygon)) < minimumPolygoneArea
+    ) {
       // if less than three points, or super small area, treat as a clear selection.
       dispatch({ type: "lasso deselect" });
     } else {


### PR DESCRIPTION
Fix a bug where using the lasso in a clockwise manner made the area calculation negative. 