### PR TITLE
Csweaver/add errors to smoke test

### DIFF
--- a/client/__tests__/e2e/data.js
+++ b/client/__tests__/e2e/data.js
@@ -73,7 +73,8 @@ export const datasets = {
 
     genes: {
       bulkadd: ["S100A8", "FCGR3A", "LGALS2", "GSTP1"],
-      search: "ACD"
+      search: "ACD",
+      "bad search": "not a gene"
     },
     subset: {
       cellset1: [

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -144,6 +144,22 @@ describe("gene entry", async () => {
     );
     expect(userGeneHist).toEqual(expect.arrayContaining(testGenes));
   });
+
+  test("bad gene causes error", async () => {
+    await utils.clickOn("section-bulk-add");
+    await utils.typeInto("input-bulk-add", data.genes["bad search"]);
+    await page.keyboard.press("Enter");
+    await cxgActions.errorAppears();
+  });
+
+  test("bulk add bad formatting causes error", async () => {
+    await cxgActions.reset();
+    const testGenes = data.genes.bulkadd;
+    await utils.clickOn("section-bulk-add");
+    await utils.typeInto("input-bulk-add", testGenes.join(";"));
+    await page.keyboard.press("Enter");
+    await cxgActions.errorAppears();
+  });
 });
 
 describe("diffexp", async () => {

--- a/client/__tests__/e2e/puppeteerUtils.js
+++ b/client/__tests__/e2e/puppeteerUtils.js
@@ -1,11 +1,15 @@
 export const puppeteerUtils = puppeteerPage => ({
-  async waitByID(testid) {
-    return await puppeteerPage.waitForSelector(`[data-testid='${testid}']`);
+  async waitByID(testid, props = {}) {
+    return await puppeteerPage.waitForSelector(
+      `[data-testid='${testid}']`,
+      props
+    );
   },
 
-  async waitByClass(testclass) {
+  async waitByClass(testclass, props = {}) {
     return await puppeteerPage.waitForSelector(
-      `[data-testclass='${testclass}']`
+      `[data-testclass='${testclass}']`,
+      props
     );
   },
 
@@ -157,5 +161,11 @@ export const cellxgeneActions = puppeteerPage => ({
     await puppeteerUtils(puppeteerPage).clickOn("reset");
     // loading state never actually happens, reset is too fast
     await page.waitFor(200);
+  },
+
+  async errorAppears() {
+    await puppeteerUtils(puppeteerPage).waitByClass("toast", {
+      timeout: 200
+    });
   }
 });

--- a/client/src/components/framework/toasters.js
+++ b/client/src/components/framework/toasters.js
@@ -1,31 +1,37 @@
+import React from "react";
 import { Position, Toaster, Intent } from "@blueprintjs/core";
 
 /** Singleton toaster instance. Create separate instances for different options. */
 
-const ErrorToastTopCenter = Toaster.create({
-  className: "recipe-toaster",
-  position: Position.TOP
-});
+class ErrorToast {
+  toast = Toaster.create({
+    className: "recipe-toaster",
+    "data-testclass": "toast",
+    position: Position.TOP
+  });
+
+  show(message, props) {
+    message = <span data-testclass="toast">{message}</span>;
+    return this.toast.show({ message, ...props });
+  }
+}
+const ErrorToastTopCenter = new ErrorToast();
 
 /*
 A "user" error - eg, bad input
 */
 export const postUserErrorToast = message =>
-  ErrorToastTopCenter.show({ message, intent: Intent.WARNING });
+  ErrorToastTopCenter.show(message, { intent: Intent.WARNING });
 
 /*
 A toast the user must dismiss manually, because they need to act on its information,
 ie., 8 bulk add genes out of 40 were bad. Manually see which ones and fix.
 */
 export const keepAroundErrorToast = message =>
-  ErrorToastTopCenter.show({ message, timeout: 0, intent: Intent.WARNING });
+  ErrorToastTopCenter.show(message, { timeout: 0, intent: Intent.WARNING });
 
 /*
 a hard network error
 */
 export const postNetworkErrorToast = message =>
-  ErrorToastTopCenter.show({
-    message,
-    timeout: 30000,
-    intent: Intent.DANGER
-  });
+  ErrorToastTopCenter.show(message, { timeout: 30000, intent: Intent.DANGER });


### PR DESCRIPTION
This addresses @bkmartinjr's request to check errors for adding a gene from PR #669 

Blueprint.js's toasts don't have any way to pass props to them, so I modified the toasts.js file to wrap the message with a span containing a `data-testclass` prop. 