### PR TITLE
add scripts from cli

### DIFF
--- a/client/index_template.html
+++ b/client/index_template.html
@@ -1,35 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+<head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>cellxgene</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,400i,700" rel="stylesheet">
     <style>
-      html, body, p, h1, h2, h3, h4, h5, h6, span, button, input, label, text, div {
-        font-family: 'Roboto Condensed','Helvetica Neue','Helvetica','Arial',sans-serif;
-        font-size: 14px;
-      }
-      body {
-        margin: 0;
-        padding: 0;
-      }
+        html, body, p, h1, h2, h3, h4, h5, h6, span, button, input, label, text, div {
+            font-family: 'Roboto Condensed', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+            font-size: 14px;
+        }
 
-      * {
-        box-sizing: border-box;
-      }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
     </style>
-  </head>
-  <body>
-<script type="text/javascript">
-window.CELLXGENE = {};
-window.CELLXGENE.API = {
-  prefix: window.location.href + "api/",
-  version: "v0.2/"
-};
-</script>
-    <noscript>If you're seeing this message, that means <strong>JavaScript has been disabled on your browser</strong>, please <strong>enable JS</strong> to make this app work.</noscript>
 
-    <div id="root"></div>
-  </body>
+</head>
+<body>
+<script type="text/javascript">
+  window.CELLXGENE = {};
+  window.CELLXGENE.API = {
+    prefix: window.location.href + "api/",
+    version: "v0.2/"
+  };
+</script>
+<noscript>If you're seeing this message, that means <strong>JavaScript has been disabled on your browser</strong>,
+    please <strong>enable JS</strong> to make this app work.
+</noscript>
+
+<div id="root"></div>
+{% for script in SCRIPTS %}
+<script type="text/javascript" src="{{script | safe}}"></script>
+{% endfor %}
+</body>
 </html>

--- a/server/app/web/webapp.py
+++ b/server/app/web/webapp.py
@@ -8,7 +8,8 @@ bp = Blueprint("webapp", __name__, template_folder="templates")
 @bp.route("/")
 def index():
     dataset_title = current_app.config["DATASET_TITLE"]
-    return render_template("index.html", datasetTitle=dataset_title)
+    scripts = current_app.config["SCRIPTS"]
+    return render_template("index.html", datasetTitle=dataset_title, SCRIPTS=scripts)
 
 
 @bp.route("/favicon.png")

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -123,6 +123,8 @@ def launch(
 The --scripts flag is intended for developers to include google analytics etc. You could be opening yourself to a
 security risk by including the --scripts flag. Make sure you trust the scripts that you are including.
         """)
+        scripts_pretty = ", ".join(scripts)
+        click.confirm(f"Are you sure you want to inject these scripts: {scripts_pretty}?", abort=True)
 
     if not verbose:
         sys.tracebacklimit = 0

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -73,20 +73,20 @@ from server.app.util.utils import custom_format_warning
     show_default=True,
 )
 def launch(
-    data,
-    layout,
-    diffexp,
-    title,
-    verbose,
-    debug,
-    obs_names,
-    var_names,
-    open_browser,
-    port,
-    host,
-    max_category_items,
-    diffexp_lfc_cutoff,
-    scripts,
+        data,
+        layout,
+        diffexp,
+        title,
+        verbose,
+        debug,
+        obs_names,
+        var_names,
+        open_browser,
+        port,
+        host,
+        max_category_items,
+        diffexp_lfc_cutoff,
+        scripts,
 ):
     """Launch the cellxgene data viewer.
     This web app lets you explore single-cell expression data.
@@ -112,6 +112,17 @@ def launch(
         open_browser = False
     else:
         warnings.formatwarning = custom_format_warning
+
+    if scripts:
+        click.echo("""
+/ / /\ \ \__ _ _ __ _ __ (_)_ __   __ _
+\ \/  \/ / _` | '__| '_ \| | '_ \ / _` |
+ \  /\  / (_| | |  | | | | | | | | (_| |
+  \/  \/ \__,_|_|  |_| |_|_|_| |_|\__, |
+                                  |___/
+The --scripts flag is intended for developers to include google analytics etc. You could be opening yourself to a
+security risk by including the --scripts flag. Make sure you trust the scripts that you are including.
+        """)
 
     if not verbose:
         sys.tracebacklimit = 0

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -65,6 +65,13 @@ from server.app.util.utils import custom_format_warning
     show_default=True,
     help="Relative expression cutoff used when selecting top N differentially expressed genes",
 )
+@click.option(
+    "--scripts",
+    default=[],
+    multiple=True,
+    help="Additional script files to include in html page",
+    show_default=True,
+)
 def launch(
     data,
     layout,
@@ -79,6 +86,7 @@ def launch(
     host,
     max_category_items,
     diffexp_lfc_cutoff,
+    scripts,
 ):
     """Launch the cellxgene data viewer.
     This web app lets you explore single-cell expression data.
@@ -119,6 +127,7 @@ def launch(
     from server.app.app import app
 
     app.config.update(DATASET_TITLE=title)
+    app.config.update(SCRIPTS=scripts)
 
     if not verbose:
         log = logging.getLogger("werkzeug")

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -114,7 +114,7 @@ def launch(
         warnings.formatwarning = custom_format_warning
 
     if scripts:
-        click.echo("""
+        click.echo(r"""
 / / /\ \ \__ _ _ __ _ __ (_)_ __   __ _
 \ \/  \/ / _` | '__| '_ \| | '_ \ / _` |
  \  /\  / (_| | |  | | | | | | | | (_| |


### PR DESCRIPTION
Fixes #678 

Able to add scripts to the html from launch CLI with --scripts flag. This means it will be accessible from the CLI and from docker since docker runs the `cellxgene` CLI.

I reformatted the html file in the process. I could make that a separate PR, but I think it looks nicer now 😁 