### PR TITLE
Update scanpy version

### DIFF
--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 from pandas.core.dtypes.dtypes import CategoricalDtype
-import scanpy.api as sc
+import scanpy as sc
 
 from server.app.driver.driver import CXGDriver
 from server.app.util.constants import Axis, DEFAULT_TOP_N

--- a/server/cli/prepare.py
+++ b/server/cli/prepare.py
@@ -63,7 +63,7 @@ def prepare(
     import matplotlib
 
     matplotlib.use("Agg")
-    import scanpy.api as sc
+    import scanpy as sc
 
     # scanpy settings
     sc.settings.verbosity = 0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,3 @@
-anndata>=0.6.13
 click>=6.7
 Flask>=1.0.2
 Flask-Caching>=1.4.0
@@ -9,7 +8,7 @@ flatbuffers>=1.10.0
 matplotlib>=2.2
 numpy>=1.15.2
 pandas>=0.23.1
-scanpy>=1.3.2
+scanpy>=1.3.7
 scipy>=1.1.0
 scikit-learn>=0.19.1,!=0.20.0
 tables>=3.5.1


### PR DESCRIPTION
Update scanpy version to 1.3.7.

Latest is 1.4, but all the features we want to integrate were in by 1.3.7 (most specifically the `import scanpy` instead of `import scanpy.api`).
