### PR TITLE
latent bug in color toggle UI change

### DIFF
--- a/client/src/reducers/colors.js
+++ b/client/src/reducers/colors.js
@@ -57,7 +57,7 @@ const ColorsReducer = (
       /* toggle between this mode and reset */
       const colorMode = action.type !== state.colorMode ? action.type : null;
       const colorAccessor =
-        action.colorAccessor !== state.colorAccessor
+        action.colorAccessor !== state.colorAccessor && colorMode !== null
           ? action.colorAccessor
           : null;
 
@@ -77,7 +77,9 @@ const ColorsReducer = (
       /* toggle between this mode and reset */
       const colorMode = action.type !== state.colorMode ? action.type : null;
       const colorAccessor =
-        action.gene !== state.colorAccessor ? action.gene : null;
+        action.gene !== state.colorAccessor && coorMode !== null
+          ? action.gene
+          : null;
 
       const { rgb, scale } = createColors(world, colorMode, colorAccessor);
       return {


### PR DESCRIPTION
The change to the change for #693.  It contained a regression where the colorMode and colorAccessor would get out of sync, confusing the reducer logic.   This change ensures that when color is reset, both variables are in sync (set to null or not set to null).