### PR TITLE
faster ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
     python: "3.6"
     script: ./travis-build.sh
   - name: "Docker Build"
+    install: skip
     python: "3.6"
     script: docker build .
   - name: "Smoke Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: required
 node_js:
   - 8
 cache:
-  pip: true
+  - pip
+  - npm
 install:
   - set -eo pipefail
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
   - make build
   - make install
   - pip install -r server/requirements-dev.txt
-  - docker build .
 
 jobs:
   include:
@@ -21,6 +20,9 @@ jobs:
   - name: "Branch Tests 3.6"
     python: "3.6"
     script: ./travis-build.sh
+  - name: "Docker Build"
+    python: "3.6"
+    script: docker build .
   - name: "Smoke Tests"
     python: "3.6"
     if: branch = master AND type = cron


### PR DESCRIPTION
CI build goes from 10-12 min -> 3-5 min.

Caching npm and move docker build to it's own job so it can be parallelized.