### PR TITLE
PyQt5 -> PySide2

### DIFF
--- a/server/gui/browser.py
+++ b/server/gui/browser.py
@@ -1,8 +1,8 @@
 # flake8: noqa F403, F405
 from cefpython3 import cefpython as cef
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
 
 from server.gui.utils import WINDOWS, LINUX
 

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -3,8 +3,8 @@ import sys
 from os.path import splitext, basename
 
 from cefpython3 import cefpython as cef
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
+from PySide2.QtCore import *
+from PySide2.QtWidgets import *
 
 from server.app.app import Server
 from server.gui.browser import CefWidget, CefApplication

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -1,6 +1,6 @@
 import platform
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from PySide2.QtCore import QObject, Signal
 
 # Detect OS
 WINDOWS = (platform.system() == "Windows")
@@ -16,6 +16,6 @@ class WorkerSignals(QObject):
         error - `str` error message
         result - `object` data returned from processing, anything
     """
-    finished = pyqtSignal()
-    error = pyqtSignal(str)
-    result = pyqtSignal(object)
+    finished = Signal()
+    error = Signal(str)
+    result = Signal(object)

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -1,6 +1,6 @@
 import traceback
 
-from PyQt5.QtCore import QRunnable, pyqtSlot
+from PySide2.QtCore import QRunnable, Slot
 
 from server.gui.utils import WorkerSignals
 
@@ -12,7 +12,7 @@ class DataLoadWorker(QRunnable):
         self.layout = layout
         self.signals = WorkerSignals()
 
-    @pyqtSlot()
+    @Slot()
     def run(self):
         if not self.data_file:
             self.signals.finished.emit()
@@ -46,6 +46,6 @@ class ServerRunWorker(QRunnable):
         self.host = host
         self.port = port
 
-    @pyqtSlot()
+    @Slot()
     def run(self):
         self.app.run(host=self.host, debug=False, port=self.port, threaded=True)

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
     entry_points={"console_scripts": ["cellxgene = server.cli.cli:cli"]},
-    extras_require=dict(louvain=["python-igraph", "louvain>=0.6"], gui=["PyQt5>=5.12.1", "cefpython3>=66"]),
+    extras_require=dict(louvain=["python-igraph", "louvain>=0.6"], gui=["PySide2>=5.12.3", "cefpython3>=66"]),
 )


### PR DESCRIPTION
Switched qt wrapper libraries. PySide2 uses LGPL as opposed to PyQt5 which uses GPL. LGPL is more compatible with our MIT license and the API's were similar enough that the change was minimal.   