### PR TITLE
improve selection interaction with clip changes

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -158,7 +158,7 @@ class HistogramBrush extends React.Component {
 
       // ignore programmatically generated events
       if (!d3.event.sourceEvent) return;
-      // ignore cascading events
+      // ignore cascading events, which are programmatically generated
       if (d3.event.sourceEvent.sourceEvent) return;
 
       if (d3.event.selection) {
@@ -195,7 +195,7 @@ class HistogramBrush extends React.Component {
 
       // ignore programmatically generated events
       if (!d3.event.sourceEvent) return;
-      // ignore cascading events
+      // ignore cascading events, which are programmatically generated
       if (d3.event.sourceEvent.sourceEvent) return;
 
       if (d3.event.selection) {

--- a/client/src/reducers/categoricalSelection.js
+++ b/client/src/reducers/categoricalSelection.js
@@ -20,7 +20,8 @@ const CategoricalSelection = (
   switch (action.type) {
     case "initial data load complete (universe exists)":
     case "set World to current selection":
-    case "reset World to eq Universe": {
+    case "reset World to eq Universe":
+    case "set clip quantiles": {
       const { world } = nextSharedState;
       return ControlsHelpers.createCategoricalSelection(
         maxCategoryItems(prevSharedState),

--- a/client/src/reducers/continuousSelection.js
+++ b/client/src/reducers/continuousSelection.js
@@ -2,7 +2,8 @@ import { makeContinuousDimensionName } from "../util/nameCreators";
 
 const ContinuousSelection = (state = {}, action) => {
   switch (action.type) {
-    case "reset World to eq Universe": {
+    case "reset World to eq Universe":
+    case "set clip quantiles": {
       return {};
     }
     case "continuous metadata histogram start":

--- a/client/src/reducers/graphSelection.js
+++ b/client/src/reducers/graphSelection.js
@@ -6,6 +6,7 @@ const GraphSelection = (
   action
 ) => {
   switch (action.type) {
+    case "set clip quantiles":
     case "reset World to eq Universe": {
       return {
         ...state,


### PR DESCRIPTION
Several improvements/bug fixes:
* When clip is changed, selection state is cleared (this is undoable).
* Brushable histogram component updates now correctly handle changes to their underlying dataframe.  Previously they were failing to correctly update their brush selection when the underlying dataframe updated (eg, was clipped).  As a side effect, improved memoization of histogram bins.
* Brushable histograms no longer confuse programmatic brush updates with user inputs (this was manifesting as a console error about undo FSM state).

Fixes #741 as well as several other related errors triggered by changes to the underlying dataframe while a widget has an active selection.

#741 is primarily fixed by clearing selection (changes to reducers).  The other changes to brushable histogram make them more resilient to state changes, should we wish, in the future, to do something more complex to the current selection.