### PR TITLE
Moved to python threads

### DIFF
--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -19,3 +19,7 @@ class WorkerSignals(QObject):
     finished = Signal()
     error = Signal(str)
     result = Signal(object)
+
+
+class FileLoadSignals(QObject):
+    selectedFile = Signal(str)

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -1,18 +1,15 @@
 import traceback
 
-from PySide2.QtCore import QRunnable, Slot
-
 from server.gui.utils import WorkerSignals
 
 
-class DataLoadWorker(QRunnable):
+class DataLoadWorker():
     def __init__(self, data_file, layout="umap", *args, **kwargs):
         super(DataLoadWorker, self).__init__()
         self.data_file = data_file
         self.layout = layout
         self.signals = WorkerSignals()
 
-    @Slot()
     def run(self):
         if not self.data_file:
             self.signals.finished.emit()
@@ -39,13 +36,12 @@ class DataLoadWorker(QRunnable):
             self.signals.finished.emit()
 
 
-class ServerRunWorker(QRunnable):
+class ServerRunWorker():
     def __init__(self, app, host, port, *args, **kwargs):
         super(ServerRunWorker, self).__init__()
         self.app = app
         self.host = host
         self.port = port
 
-    @Slot()
     def run(self):
         self.app.run(host=self.host, debug=False, port=self.port, threaded=True)


### PR DESCRIPTION
Switched threading modules from using Qt's QThreadPool and QRunnable to python's threading library.

Motivation: This allows threads to be set as daemons so that they can be killed on exit, it doesn't seem like Qt's thread allow that (in my limited research).

There is still a separate bu where the app freezes during the file load -- this happens at the anndata layer. I've done due diligence and checked that the hang does not occur if you replace the file load with a timer instead. But I think that this change should still go through while I debug the hanging issue as this allows the app to exit more quickly. 


 

  