### PR TITLE
install from dist/ instead of build/ on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
 install:
   - set -eo pipefail
   - pip install flake8
-  - make build
-  - make install
+  - make pydist
+  - make install-dist
   - pip install -r server/requirements-dev.txt
 
 jobs:

--- a/makefile
+++ b/makefile
@@ -122,6 +122,10 @@ install-release : uninstall
 	pip install --no-cache-dir cellxgene
 	@echo "Installed cellxgene from pypi.org"
 
+# install from dist
+install-dist : uninstall
+	pip install dist/cellxgene*.tar.gz
+
 uninstall :
 	pip uninstall -y cellxgene || :
 


### PR DESCRIPTION
On travis, build a distribution and install from there, instead of installing from `build/`. This will surface missing `__init__.py` files and lessen the burden of testing releases.