### PR TITLE
port retry

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,7 @@
     "jest-puppeteer": "^4.1.0",
     "json-loader": "^0.5.4",
     "mini-css-extract-plugin": "^0.4.1",
-    "puppeteer": "^1.12.1",
+    "puppeteer": "^1.15.0",
     "rimraf": "^2.6.3",
     "serve-favicon": "^2.3.0",
     "start-server-and-test": "^1.7.11",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 from os import devnull
 from os.path import splitext, basename
@@ -190,4 +191,6 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
     try:
         server.app.run(host=host, debug=debug, port=port, threaded=True)
     except OSError as e:
-        raise click.ClickException(f"{e}. Port is in use, please specify another port using the --port flag.")
+        if e.errno == errno.EADDRINUSE:
+            raise click.ClickException(f"{e} Port is in use, please specify an open port using the --port flag.")
+        raise click.ClickException(f"{e}")

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -51,12 +51,10 @@ from server.utils.utils import find_available_port
     show_default=True,
     help="Open the web browser after launch.",
 )
-@click.option("--port", "-p", help="Port to run server on.", metavar="", default=5005, show_default=True)
+@click.option("--port", "-p", help="Port to run server on.", metavar="", show_default=True)
 @click.option("--obs-names", default=None, metavar="", help="Name of annotation field to use for observations.")
 @click.option("--var-names", default=None, metavar="", help="Name of annotation to use for variables.")
 @click.option("--host", default="127.0.0.1", help="Host IP address")
-@click.option("--no-port-scan", is_flag=True, default=False, show_default=True,
-              help="Disable automatic scan for unused port.")
 @click.option(
     "--max-category-items",
     default=100,
@@ -89,7 +87,6 @@ def launch(
         open_browser,
         port,
         host,
-        no_port_scan,
         max_category_items,
         diffexp_lfc_cutoff,
         scripts,
@@ -139,16 +136,8 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
         file_parts = splitext(basename(data))
         title = file_parts[0]
 
-    print(no_port_scan)
-    if not no_port_scan:
-        new_port = find_available_port(host, port)
-        # warn if the user specified port is being overridden
-        if new_port != port and port != 5005:
-            click.echo(
-                f"[cellxgene] Warning: the port you specified was in use, using port {new_port} instead. "
-                f"If you want to require cellxgene to only use the port specified and exit if that port is not "
-                f"available run launch with the --fixed-port flag")
-        port = new_port
+    if not port:
+        port = find_available_port(host)
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -139,6 +139,7 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
         file_parts = splitext(basename(data))
         title = file_parts[0]
 
+    print(no_port_scan)
     if not no_port_scan:
         new_port = find_available_port(host, port)
         # warn if the user specified port is being overridden

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -194,4 +194,4 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
             raise click.ClickException("Port is in use, please specify an open port using the --port flag.") from e
-        raise e
+        raise

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -11,6 +11,7 @@ from server.app.app import Server
 from server.app.util.errors import ScanpyFileError
 from server.app.util.utils import custom_format_warning
 from server.utils.constants import MODES
+from server.utils.utils import find_available_port
 
 
 @click.command()
@@ -199,36 +200,3 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
         server.app.run(host=host, debug=debug, port=port, threaded=True)
     except OSError as e:
         raise click.ClickException(f"{e}. Port is in use, please specify another port using the --port flag.")
-
-
-def find_available_port(host, port):
-    """
-    Helper method to find open port on host. Tries 50 ports incremented from the specified port
-    """
-    import errno
-    import socket
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    new_port = port
-    found_port = False
-    num_ports_to_try = 50
-    for i in range(num_ports_to_try):
-        new_port = port + i
-        while True:
-            try:
-                s.bind((host, new_port))
-                found_port = True
-                break
-            except socket.error as e:
-                # Reraise if error is not "address in use"
-                if e.errno != errno.EADDRINUSE:
-                    raise e
-                break
-        if found_port:
-            break
-    if not found_port:
-        click.echo(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
-                   f" available to run cellxgene server on.")
-        click.echo(f"[cellxgene] Exiting")
-        raise OSError("No available ports")
-    s.close()
-    return new_port

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -203,32 +203,32 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
 
 def find_available_port(host, port):
     """
-    Helper method to find open port on host. Tries 50 ports incremented from specified port
+    Helper method to find open port on host. Tries 50 ports incremented from the specified port
     """
     import errno
     import socket
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     new_port = port
-    for i in range(3):
+    found_port = False
+    num_ports_to_try = 50
+    for i in range(num_ports_to_try):
         new_port = port + i
-        print(new_port)
         while True:
             try:
                 s.bind((host, new_port))
-                print("worked")
+                found_port = True
                 break
             except socket.error as e:
-                if e.errno == errno.EADDRINUSE:
-                    continue
-                else:
-                    raise
-            finally:
-                s.close()
+                # Reraise if error is not "address in use"
+                if e.errno != errno.EADDRINUSE:
+                    raise e
                 break
-    # else:
-    #     click.echo(f"[cellxgene] No port in range {new_port} - {new_port + 50} was
-    #     available to run cellxgene server on.")
-    #     click.echo(f"[cellxgene] Exiting")
-    #     raise OSError("No available ports")
+        if found_port:
+            break
+    if not found_port:
+        click.echo(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
+                   f" available to run cellxgene server on.")
+        click.echo(f"[cellxgene] Exiting")
+        raise OSError("No available ports")
     s.close()
     return new_port

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -52,7 +52,8 @@ from server.utils.utils import find_available_port
     show_default=True,
     help="Open the web browser after launch.",
 )
-@click.option("--port", "-p", help="Port to run server on.", metavar="", show_default=True)
+@click.option("--port", "-p", help="Port to run server on, if not specified cellxgene will find an available port.",
+              metavar="", show_default=True)
 @click.option("--obs-names", default=None, metavar="", help="Name of annotation field to use for observations.")
 @click.option("--var-names", default=None, metavar="", help="Name of annotation to use for variables.")
 @click.option("--host", default="127.0.0.1", help="Host IP address")
@@ -192,5 +193,5 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
         server.app.run(host=host, debug=debug, port=port, threaded=True)
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
-            raise click.ClickException(f"{e} Port is in use, please specify an open port using the --port flag.")
-        raise click.ClickException(f"{e}")
+            raise click.ClickException("Port is in use, please specify an open port using the --port flag.") from e
+        raise e

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -55,8 +55,8 @@ from server.utils.utils import find_available_port
 @click.option("--obs-names", default=None, metavar="", help="Name of annotation field to use for observations.")
 @click.option("--var-names", default=None, metavar="", help="Name of annotation to use for variables.")
 @click.option("--host", default="127.0.0.1", help="Host IP address")
-@click.option("--fixed-port", is_flag=True, default=False, show_default=True,
-              help="Error if request port is not available instead of searching for another available port.")
+@click.option("--no-port-scan", is_flag=True, default=False, show_default=True,
+              help="Disable automatic scan for unused port.")
 @click.option(
     "--max-category-items",
     default=100,
@@ -89,7 +89,7 @@ def launch(
         open_browser,
         port,
         host,
-        fixed_port,
+        no_port_scan,
         max_category_items,
         diffexp_lfc_cutoff,
         scripts,
@@ -139,14 +139,15 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
         file_parts = splitext(basename(data))
         title = file_parts[0]
 
-    if not fixed_port:
+    if not no_port_scan:
         new_port = find_available_port(host, port)
-        if new_port != port:
+        # warn if the user specified port is being overridden
+        if new_port != port and port != 5005:
             click.echo(
                 f"[cellxgene] Warning: the port you specified was in use, using port {new_port} instead. "
                 f"If you want to require cellxgene to only use the port specified and exit if that port is not "
                 f"available run launch with the --fixed-port flag")
-            port = new_port
+        port = new_port
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -19,7 +19,7 @@ class EndPoints(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--fixed-port"])
+        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--no-port-scan"])
         session = requests.Session()
         for i in range(90):
             try:

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -19,7 +19,7 @@ class EndPoints(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--no-port-scan"])
+        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--port", "5005"])
         session = requests.Session()
         for i in range(90):
             try:

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -19,7 +19,7 @@ class EndPoints(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug"])
+        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--fixed-port"])
         session = requests.Session()
         for i in range(90):
             try:

--- a/server/test/test_nan_rest.py
+++ b/server/test/test_nan_rest.py
@@ -21,7 +21,7 @@ class WithNaNs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ps = Popen(
-            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--fixed-port"]
+            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--no-port-scan"]
         )
         session = requests.Session()
         for i in range(90):

--- a/server/test/test_nan_rest.py
+++ b/server/test/test_nan_rest.py
@@ -21,7 +21,7 @@ class WithNaNs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ps = Popen(
-            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug"]
+            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--fixed-port"]
         )
         session = requests.Session()
         for i in range(90):

--- a/server/test/test_nan_rest.py
+++ b/server/test/test_nan_rest.py
@@ -21,7 +21,7 @@ class WithNaNs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ps = Popen(
-            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--no-port-scan"]
+            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--port", "5005"]
         )
         session = requests.Session()
         for i in range(90):

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -2,21 +2,20 @@ import contextlib
 import errno
 import socket
 
+
 def find_available_port(host, port):
     """
     Helper method to find open port on host. Tries 50 ports incremented from the specified port
     """
-    new_port = port
     found_port = False
     num_ports_to_try = 50
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        for port_to_try in range(port, port + num_ports_to_try):
+    for port_to_try in range(port, port + num_ports_to_try):
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             while True:
                 try:
                     s.bind((host, port_to_try))
                     found_port = True
-                    new_port = port_to_try
-                    break
+                    return port_to_try
                 except socket.error as e:
                     # Reraise if error is not "address in use"
                     if e.errno != errno.EADDRINUSE:
@@ -25,8 +24,7 @@ def find_available_port(host, port):
             if found_port:
                 break
     if not found_port:
-        print(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
-                   f" available to run cellxgene server on.")
+        print(f"[cellxgene] No port in range {port} - {port + num_ports_to_try - 1} was"
+              f" available to run cellxgene server on.")
         print(f"[cellxgene] Exiting")
         raise OSError("No available ports")
-    return new_port

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -16,4 +16,4 @@ def find_available_port(host, port=5005):
                 return port_to_try
             except socket.error:
                 pass
-    raise OSError(errno.EADDRINUSE, f"No port in range {port} - {port + num_ports_to_try - 1} available.")
+    raise socket.error(errno.EADDRINUSE, f"No port in range {port} - {port + num_ports_to_try - 1} available.")

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import socket
 
 
@@ -15,4 +16,4 @@ def find_available_port(host, port=5005):
                 return port_to_try
             except socket.error:
                 pass
-    raise OSError(f"No port in range {port} - {port + num_ports_to_try - 1} available.")
+    raise OSError(errno.EADDRINUSE, f"No port in range {port} - {port + num_ports_to_try - 1} available.")

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -11,7 +11,7 @@ def find_available_port(host, port):
     new_port = port
     found_port = False
     num_ports_to_try = 50
-    for i in range(num_ports_to_try):
+    for port_to_try in range(port, port + num_ports_to_try):
         new_port = port + i
         while True:
             try:

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -7,24 +7,19 @@ def find_available_port(host, port):
     """
     Helper method to find open port on host. Tries 50 ports incremented from the specified port
     """
-    found_port = False
     num_ports_to_try = 50
     for port_to_try in range(port, port + num_ports_to_try):
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             while True:
                 try:
                     s.bind((host, port_to_try))
-                    found_port = True
                     return port_to_try
                 except socket.error as e:
                     # Reraise if error is not "address in use"
                     if e.errno != errno.EADDRINUSE:
                         raise e
                     break
-            if found_port:
-                break
-    if not found_port:
-        print(f"[cellxgene] No port in range {port} - {port + num_ports_to_try - 1} was"
-              f" available to run cellxgene server on.")
-        print(f"[cellxgene] Exiting")
-        raise OSError("No available ports")
+    print(f"[cellxgene] No port in range {port} - {port + num_ports_to_try - 1} was"
+          f" available to run cellxgene server on.")
+    print(f"[cellxgene] Exiting")
+    raise OSError("No available ports")

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -1,34 +1,32 @@
-import click
-
+import contextlib
+import errno
+import socket
 
 def find_available_port(host, port):
     """
     Helper method to find open port on host. Tries 50 ports incremented from the specified port
     """
-    import errno
-    import socket
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     new_port = port
     found_port = False
     num_ports_to_try = 50
-    for port_to_try in range(port, port + num_ports_to_try):
-        new_port = port + i
-        while True:
-            try:
-                s.bind((host, new_port))
-                found_port = True
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        for port_to_try in range(port, port + num_ports_to_try):
+            while True:
+                try:
+                    s.bind((host, port_to_try))
+                    found_port = True
+                    new_port = port_to_try
+                    break
+                except socket.error as e:
+                    # Reraise if error is not "address in use"
+                    if e.errno != errno.EADDRINUSE:
+                        raise e
+                    break
+            if found_port:
                 break
-            except socket.error as e:
-                # Reraise if error is not "address in use"
-                if e.errno != errno.EADDRINUSE:
-                    raise e
-                break
-        if found_port:
-            break
     if not found_port:
-        click.echo(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
+        print(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
                    f" available to run cellxgene server on.")
-        click.echo(f"[cellxgene] Exiting")
+        print(f"[cellxgene] Exiting")
         raise OSError("No available ports")
-    s.close()
     return new_port

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -1,0 +1,34 @@
+import click
+
+
+def find_available_port(host, port):
+    """
+    Helper method to find open port on host. Tries 50 ports incremented from the specified port
+    """
+    import errno
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    new_port = port
+    found_port = False
+    num_ports_to_try = 50
+    for i in range(num_ports_to_try):
+        new_port = port + i
+        while True:
+            try:
+                s.bind((host, new_port))
+                found_port = True
+                break
+            except socket.error as e:
+                # Reraise if error is not "address in use"
+                if e.errno != errno.EADDRINUSE:
+                    raise e
+                break
+        if found_port:
+            break
+    if not found_port:
+        click.echo(f"[cellxgene] No port in range {new_port} - {new_port + num_ports_to_try - 1} was"
+                   f" available to run cellxgene server on.")
+        click.echo(f"[cellxgene] Exiting")
+        raise OSError("No available ports")
+    s.close()
+    return new_port

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -4,7 +4,7 @@ import socket
 
 def find_available_port(host, port=5005):
     """
-    Helper method to find open port on host. Tries 50 ports incremented from the specified port
+    Helper method to find open port on host. Tries 5000 ports incremented from the specified port
     """
     # Takes approx 2 seconds to do a scan of 5000 ports on my laptop
     num_ports_to_try = 5000

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -1,25 +1,18 @@
 import contextlib
-import errno
 import socket
 
 
-def find_available_port(host, port):
+def find_available_port(host, port=5005):
     """
     Helper method to find open port on host. Tries 50 ports incremented from the specified port
     """
-    num_ports_to_try = 50
+    # Takes approx 2 seconds to do a scan of 5000 ports on my laptop
+    num_ports_to_try = 5000
     for port_to_try in range(port, port + num_ports_to_try):
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            while True:
-                try:
-                    s.bind((host, port_to_try))
-                    return port_to_try
-                except socket.error as e:
-                    # Reraise if error is not "address in use"
-                    if e.errno != errno.EADDRINUSE:
-                        raise e
-                    break
-    print(f"[cellxgene] No port in range {port} - {port + num_ports_to_try - 1} was"
-          f" available to run cellxgene server on.")
-    print(f"[cellxgene] Exiting")
-    raise OSError("No available ports")
+            try:
+                s.bind((host, port_to_try))
+                return port_to_try
+            except socket.error as e:
+                pass
+    raise OSError(f"No port in range {port} - {port + num_ports_to_try - 1} available.")

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -13,6 +13,6 @@ def find_available_port(host, port=5005):
             try:
                 s.bind((host, port_to_try))
                 return port_to_try
-            except socket.error as e:
+            except socket.error:
                 pass
     raise OSError(f"No port in range {port} - {port + num_ports_to_try - 1} available.")


### PR DESCRIPTION
Fixes #698 

If port is in use tries incrementing the specified port up to 50 times to find an available one. Adds `--fixed-port` option to enforce using only the specified port. Also gives a more informative error message if the port launched is in use. 

Reviewers:
@bkmartinjr  (required)
@ttung  (optional, but would appreciate your advice)
@neuromusic (optional) - you submitted the feature request, does this meet your use case?