### PR TITLE
create occupancy stacks for all category values, not just top N values

### DIFF
--- a/client/src/components/categorical/occupancy.js
+++ b/client/src/components/categorical/occupancy.js
@@ -6,13 +6,7 @@ import * as d3 from "d3";
 @connect()
 class Occupancy extends React.Component {
   render() {
-    const {
-      occupancy,
-      colorScale,
-      categoricalSelection,
-      colorAccessor,
-      schema
-    } = this.props;
+    const { occupancy, colorScale, colorAccessor, schema, world } = this.props;
     const width = 100;
     const height = 11;
 
@@ -25,8 +19,9 @@ class Occupancy extends React.Component {
       .range([0, width]);
 
     let currentOffset = 0;
-
-    const stacks = categoricalSelection[colorAccessor].categoryValues.map(d => {
+    const dfColumn = world.obsAnnotations.col(colorAccessor);
+    const categoryValues = dfColumn.summarize().categories;
+    const stacks = categoryValues.map(d => {
       const o = occupancy.get(d);
 
       const scaledValue = x(o);


### PR DESCRIPTION
This PR fixes issue 721 -- the categorical metadata chooser would only render occupancy stacks for categorical values in the top 100. 

Fixes #721