### PR TITLE
windows fixes

### DIFF
--- a/server/gui/browser.py
+++ b/server/gui/browser.py
@@ -11,10 +11,6 @@ WindowUtils = cef.WindowUtils()
 # OS differences
 # noinspection PyUnresolvedReferences
 CefWidgetParent = QWidget
-if LINUX:
-    # noinspection PyUnresolvedReferences
-    CefWidgetParent = QX11EmbedContainer
-
 
 class CefWidget(CefWidgetParent):
     def __init__(self, parent=None):

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -16,10 +16,10 @@ from server.gui.utils import WINDOWS, LINUX, MAC, FileLoadSignals, Emitter, Work
 from server.utils.constants import MODES
 from server.utils.utils import find_available_port
 
-
-dirname = dirname(PySide2.__file__)
-plugin_path = join(dirname, 'plugins', 'platforms')
-environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_path
+if WINDOWS or LINUX:
+    dirname = dirname(PySide2.__file__)
+    plugin_path = join(dirname, 'plugins', 'platforms')
+    environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_path
 
 # Configuration
 # TODO remember this or calculate it?
@@ -58,8 +58,8 @@ class MainWindow(QMainWindow):
         self.cef_widget = CefWidget(self)
         self.data_widget = LoadWidget(self)
         self.stacked_layout = QStackedLayout()
-        self.stacked_layout.addWidget(self.data_widget)
         self.stacked_layout.addWidget(self.cef_widget)
+        self.stacked_layout.addWidget(self.data_widget)
         main_layout = QVBoxLayout()
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
@@ -85,7 +85,9 @@ class MainWindow(QMainWindow):
             # cef widget in the layout with the container.
             self.container = QWidget.createWindowContainer(
                 self.cef_widget.hidden_window, parent=self)
-            self.stacked_layout.addWidget(self.container, 1, 0)
+            self.stacked_layout.replaceWidget(self.cef_widget, self.container)
+        # CEF browser
+        self.stacked_layout.setCurrentIndex(1)
 
     def setupServer(self):
         self.shutdownServer()

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -1,7 +1,8 @@
 # flake8: noqa F403, F405
 from functools import partialmethod
 from multiprocessing import Pipe, Process
-from os.path import splitext, basename
+from os import environ
+from os.path import splitext, basename, dirname, join
 import sys
 import threading
 
@@ -46,6 +47,8 @@ class MainWindow(QMainWindow):
         self.setupLayout()
         self.setupMenu()
 
+    def showBrowser(self):
+        self.stacked_layout.setCurrentIndex(BROWSER_INDEX)
     def restartOnError(self):
         self.window().shutdownServer()
         # close emitter on error/finished
@@ -226,7 +229,7 @@ class LoadWidget(QFrame):
     def onServerReady(self):
         if not self.serverError:
             self.window().cef_widget.browser.Navigate(self.window().url)
-            self.window().stacked_layout.setCurrentIndex(BROWSER_INDEX)
+            self.window().showBrowser()
 
     def onError(self, err, server_error=False):
         # Restart worker

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -56,6 +56,7 @@ class MainWindow(QMainWindow):
     def setupLayout(self):
         self.resize(WIDTH, HEIGHT)
         self.cef_widget = CefWidget(self)
+        self.cef_widget.setSizePolicy(QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding))
         self.data_widget = LoadWidget(self)
         self.stacked_layout = QStackedLayout()
         self.stacked_layout.addWidget(self.cef_widget)

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -221,7 +221,7 @@ class LoadWidget(QFrame):
     def onDataReady(self):
         self.site_ready_worker = SiteReadyWorker(self.window().url)
         self.site_ready_worker.signals.ready.connect(self.onServerReady)
-        self.site_ready_worker.signals.error.connect(self.onError)
+        self.site_ready_worker.signals.error.connect(self.onServerError)
 
         srw_thread = threading.Thread(target=self.site_ready_worker.run, daemon=True)
         srw_thread.start()

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -6,6 +6,7 @@ import sys
 import threading
 
 from cefpython3 import cefpython as cef
+import PySide2
 from PySide2.QtCore import *
 from PySide2.QtWidgets import *
 
@@ -15,6 +16,10 @@ from server.gui.utils import WINDOWS, LINUX, MAC, FileLoadSignals, Emitter, Work
 from server.utils.constants import MODES
 from server.utils.utils import find_available_port
 
+
+dirname = dirname(PySide2.__file__)
+plugin_path = join(dirname, 'plugins', 'platforms')
+environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_path
 
 # Configuration
 # TODO remember this or calculate it?

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -26,6 +26,8 @@ if WINDOWS or LINUX:
 WIDTH = 1024
 HEIGHT = 768
 GUI_PORT = find_available_port("localhost")
+BROWSER_INDEX = 0
+LOAD_INDEX = 1
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -87,8 +89,7 @@ class MainWindow(QMainWindow):
             self.container = QWidget.createWindowContainer(
                 self.cef_widget.hidden_window, parent=self)
             self.stacked_layout.replaceWidget(self.cef_widget, self.container)
-        # CEF browser
-        self.stacked_layout.setCurrentIndex(1)
+        self.stacked_layout.setCurrentIndex(LOAD_INDEX)
 
     def setupServer(self):
         self.shutdownServer()
@@ -116,7 +117,7 @@ class MainWindow(QMainWindow):
         file_menu.addAction(load_action)
 
     def showLoad(self):
-        self.stacked_layout.setCurrentIndex(0)
+        self.stacked_layout.setCurrentIndex(LOAD_INDEX)
 
     def closeEvent(self, event):
         # Close browser (force=True) and free CEF reference
@@ -225,7 +226,7 @@ class LoadWidget(QFrame):
     def onServerReady(self):
         if not self.serverError:
             self.window().cef_widget.browser.Navigate(self.window().url)
-            self.window().stacked_layout.setCurrentIndex(1)
+            self.window().stacked_layout.setCurrentIndex(BROWSER_INDEX)
 
     def onError(self, err, server_error=False):
         # Restart worker
@@ -233,7 +234,7 @@ class LoadWidget(QFrame):
             self.serverError = True
             # Report error and switch to load screen
             self.window().shutdownServer()
-        self.window().stacked_layout.setCurrentIndex(0)
+        self.window().stacked_layout.setCurrentIndex(LOAD_INDEX)
         self.error_label.setText(f"Error: {err}")
         self.error_label.resize(self.MAX_CONTENT_WIDTH, self.error_label.height())
 

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -1,3 +1,4 @@
+import errno
 import platform
 
 from PySide2.QtCore import QObject, Signal
@@ -60,6 +61,12 @@ class Emitter:
             except EOFError:
                 # Server done
                 break
+            except OSError as e:
+                if e.errno == errno.EBADF:
+                    break
+                else:
+                    self.signals.error.emit(str(e))
+                    break
             except Exception as e:
                 self.signals.error.emit(str(e))
                 break

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -1,5 +1,4 @@
 from multiprocessing import Process
-import traceback
 import time
 
 import requests

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -65,7 +65,6 @@ class Worker(EmittingProcess):
         try:
             server.app.run(host=self.host, debug=False, port=self.port, threaded=True)
         except Exception as e:
-            traceback.print_exc()
             self.emit("server_error", str(e))
         finally:
             self.emit("finished")

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -86,6 +86,5 @@ class SiteReadyWorker:
             except requests.exceptions.ConnectionError:
                 time.sleep(1)
             except Exception as e:
-                traceback.print_exc()
                 self.signals.error.emit(str(e))
         self.signals.timeout.emit()


### PR DESCRIPTION
Fix cellxgene gui (Experimental feature) on windows. 

2 issues fixed:
1. Qt plugin not automatically found on windows. Added code to search for the plugin based on the pyside install location
2. The browser embedding sizing is wrong when it's in a stacked layout but not the active layout. I set it as the active layout during setup and then bring the data load layout to the front before the app is shown to the user. 

Linux is still broken (the hidden window isn't playing nice with the stacked layout) but I removed code that was pyqt5 specific and was breaking it more (QX11EmbedContainer)