### PR TITLE
exclude recent scipy versions

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,6 +11,6 @@ numpy>=1.15.2
 pandas>=0.23.1
 psutil>=5.6.2
 scanpy>=1.3.7
-scipy>=1.1.0
+scipy>=1.1.0,<1.3
 scikit-learn>=0.19.1,!=0.20.0
 tables>=3.5.1


### PR DESCRIPTION
Urgent bugfix.

Fixes `ImportError: cannot import name 'IndexMixin'` error cause by conflict between scipy 1.3.1 and anndata. 

Revisit scipy requirements when anndata release fix. See: https://github.com/theislab/anndata/issues/146