### PR TITLE
change npm test scripts to support windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,13 +9,13 @@
     "build": "npm run clean && webpack --config configuration/webpack/webpack.config.prod.js",
     "clean": "rimraf build",
     "dev": "npm run clean && webpack --config configuration/webpack/webpack.config.dev.js",
-    "e2e": "jest --verbose false --config __tests__/e2e/e2eJestConfig.json e2e/e2e.test.js",
+    "e2e": "node node_modules/jest/bin/jest.js --verbose false --config __tests__/e2e/e2eJestConfig.json e2e/e2e.test.js",
     "lint": "eslint src",
     "smoke-test": "start-server-and-test start-server-for-test :5000 e2e",
     "start": "node server/development.js",
     "start-server-for-test": "cellxgene launch -p 5000 ../example-dataset/pbmc3k.h5ad",
-    "test": "jest",
-    "unit-test": "jest --testPathIgnorePatterns e2e"
+    "test": "node node_modules/jest/bin/jest.js",
+    "unit-test": "node node_modules/jest/bin/jest.js --testPathIgnorePatterns e2e"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
Modified the NPM scripts commands for testing so they are portable (ie, work on windows, not just Linux/OSX).   You can't assume that bash is the default shell, so where the script just launches a script wrapper around a JS file, invoke node directly.

There are other commands (eg, clean) that are not updated, but we don't normally build or release on Windows, so this shouldn't be a problem.  With this fix, `npm run unit-tests` will work on Windows/cmd.exe
