### PR TITLE
gui multiprocess - experimental feature

### DIFF
--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -18,7 +18,7 @@ from server.utils.constants import MODES
 # TODO remember this or calculate it?
 WIDTH = 1024
 HEIGHT = 768
-GUI_PORT = 8004
+GUI_PORT = 8000
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -36,7 +36,7 @@ class MainWindow(QMainWindow):
         # Strong focus - accepts focus by tab & click
         self.setFocusPolicy(Qt.StrongFocus)
         self.setupLayout()
-        self.setupMenu()
+        # self.setupMenu()
 
     def setupLayout(self):
         self.resize(WIDTH, HEIGHT)
@@ -73,6 +73,7 @@ class MainWindow(QMainWindow):
             self.stacked_layout.addWidget(self.container, 1, 0)
 
     def setupMenu(self):
+        # TODO add communication to subprocess on reload
         main_menu = self.menuBar()
         file_menu = main_menu.addMenu('File')
         load_action = QAction("Load file...", self)
@@ -171,7 +172,6 @@ class LoadWidget(QFrame):
         self.title = splitext(basename(file_name))[0]
         if file_name:
             self.signals.selectedFile.emit(file_name)
-
 
     def onDataReady(self):
         site_ready_worker = SiteReadyWorker(self.window().url)

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -42,7 +42,7 @@ class MainWindow(QMainWindow):
 
     def restartOnError(self):
         if self.worker:
-            self.terminateWorker()
+            self.worker.terminate()
         self.parent_conn.close()
         # close emitter on error/finished
         self.parent_conn, self.child_conn = Pipe()
@@ -50,18 +50,6 @@ class MainWindow(QMainWindow):
         self.emitter_thread = threading.Thread(target=self.load_emitter.run, daemon=True)
         self.emitter_thread.start()
         # send to load with error message?
-
-    def terminateWorker(self):
-        if not self.worker:
-            return
-        try:
-            self.worker.close()
-        except AttributeError:
-            # python 3.6 does not have close
-            self.worker.terminate()
-        except Exception as e:
-            # TODO log error
-            self.worker.terminate()
 
     def setupLayout(self):
         self.resize(WIDTH, HEIGHT)

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -188,6 +188,8 @@ class LoadWidget(QFrame):
         self.window().load_emitter.signals.ready.connect(self.onDataReady)
         self.window().load_emitter.signals.engine_error.connect(self.onEngineError)
         self.window().load_emitter.signals.server_error.connect(self.onServerError)
+        # Error is generic error from emitter
+        self.window().load_emitter.signals.error.connect(self.onServerError)
         self.window().worker = Process(target=worker.run, daemon=True)
         self.window().worker.start()
         self.window().child_conn.close()
@@ -217,7 +219,6 @@ class LoadWidget(QFrame):
             self.window().stacked_layout.setCurrentIndex(1)
 
     def onServerError(self, err):
-        # TODO, any difference in data load versus server error?
         # Restart worker
         self.serverError = True
         # Report error and switch to load screen
@@ -265,7 +266,6 @@ def main():
 
         if main_window.worker:
             main_window.worker.terminate()
-        # TODO clean up threads when we switch threading model
         del main_window  # Just to be safe, similarly to "del app"
         del app  # Must destroy app object before calling Shutdown
         cef.Shutdown()

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -157,12 +157,13 @@ class LoadWidget(QFrame):
         self.embedding_selection = [MODES[idx]]
 
     def createScanpyEngine(self, file_name):
-        worker = Worker(self.window().child_conn, file_name, self.title, host="127.0.0.1", port=GUI_PORT,
+        worker = Worker((self.window().parent_conn, self.window().child_conn), file_name, self.title, host="127.0.0.1", port=GUI_PORT,
                         layout=self.embedding_selection)
         self.window().load_emitter.signals.ready.connect(self.onDataReady)
         self.window().load_emitter.signals.error.connect(self.onDataError)
         self.window().worker = Process(target=worker.run, daemon=True)
         self.window().worker.start()
+        self.window().child_conn.close()
 
     def onLoad(self):
         options = QFileDialog.Options()

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -131,7 +131,7 @@ class LoadWidget(QFrame):
         self.embeddings = QComboBox(self)
         self.embeddings.currentIndexChanged.connect(self.updateEmbedding)
         self.embeddings.addItems(MODES)
-        self.embedding_selection = MODES[0]
+        self.embedding_selection = [MODES[0]]
         load_layout.addWidget(self.embeddings, 1, 0)
 
         self.load = QPushButton("Open...")
@@ -155,7 +155,7 @@ class LoadWidget(QFrame):
         self.signals.selectedFile.connect(self.createScanpyEngine)
 
     def updateEmbedding(self, idx):
-        self.embedding_selection = MODES[idx]
+        self.embedding_selection = [MODES[idx]]
 
     def createScanpyEngine(self, file_name):
         worker = DataLoadWorker(file_name, self.embedding_selection)

--- a/server/gui/main.py
+++ b/server/gui/main.py
@@ -12,13 +12,14 @@ from server.gui.browser import CefWidget, CefApplication
 from server.gui.workers import Worker, SiteReadyWorker
 from server.gui.utils import WINDOWS, LINUX, MAC, FileLoadSignals, Emitter, WorkerSignals
 from server.utils.constants import MODES
+from server.utils.utils import find_available_port
 
 
 # Configuration
 # TODO remember this or calculate it?
 WIDTH = 1024
 HEIGHT = 768
-GUI_PORT = 8050
+GUI_PORT = find_available_port("localhost")
 
 class MainWindow(QMainWindow):
     def __init__(self):

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -23,6 +23,18 @@ class WorkerSignals(QObject):
     ready = Signal()
 
 
+class SiteReadySignals(QObject):
+    """
+    Defines the signals available from a running worker thread.
+    Supported signals are:
+        timeout
+        ready
+        error - `str` error message
+    """
+    ready = Signal()
+    timeout = Signal()
+    error = Signal(str)
+
 class FileLoadSignals(QObject):
     selectedFile = Signal(str)
 

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -56,7 +56,7 @@ class Emitter:
         while True:
             try:
                 signature = self.transport.recv()
-            except EOFError:
-                break  
+            except Exception as e:
+                self.signals.error.emit(str(e))
             else:
                 self._emit(*signature)

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -18,7 +18,8 @@ class WorkerSignals(QObject):
         result - `object` data returned from processing, anything
     """
     finished = Signal()
-    error = Signal(str)
+    engine_error = Signal(str)
+    server_error = Signal(str)
     result = Signal(object)
     ready = Signal()
 
@@ -55,7 +56,7 @@ class Emitter:
         while True:
             try:
                 signature = self.transport.recv()
-            except Exception:
-                break
+            except EOFError:
+                break  
             else:
                 self._emit(*signature)

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -35,8 +35,10 @@ class SiteReadySignals(QObject):
     timeout = Signal()
     error = Signal(str)
 
+
 class FileLoadSignals(QObject):
     selectedFile = Signal(str)
+
 
 class Emitter:
     def __init__(self, transport, signals):

--- a/server/gui/utils.py
+++ b/server/gui/utils.py
@@ -13,13 +13,35 @@ class WorkerSignals(QObject):
     Defines the signals available from a running worker thread.
     Supported signals are:
         finished
+        ready
         error - `str` error message
         result - `object` data returned from processing, anything
     """
     finished = Signal()
     error = Signal(str)
     result = Signal(object)
+    ready = Signal()
 
 
 class FileLoadSignals(QObject):
     selectedFile = Signal(str)
+
+class Emitter:
+    def __init__(self, transport, signals):
+        self.transport = transport
+        self.signals = signals()
+
+    def _emit(self, signature, args=None):
+        if args:
+            getattr(self.signals, signature).emit(args)
+        else:
+            getattr(self.signals, signature).emit()
+
+    def run(self):
+        while True:
+            try:
+                signature = self.transport.recv()
+            except Exception:
+                break
+            else:
+                self._emit(*signature)

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -1,7 +1,11 @@
 from multiprocessing import Process
 import traceback
+import time
 
-s
+import requests
+
+from server.gui.utils import SiteReadySignals
+
 class EmittingProcess(Process):
     def __init__(self, transport, *arg, **kwargs):
         super(EmittingProcess, self).__init__()
@@ -14,7 +18,7 @@ class EmittingProcess(Process):
 
 class Worker(EmittingProcess):
     def __init__(self, transport, data_file, title, host, port, layout=["umap"], *args, **kwargs):
-        super(Worker, self).__init__()
+        super(Worker, self).__init__(transport)
         self.data_file = data_file
         self.layout = layout
         self.title = title
@@ -22,31 +26,50 @@ class Worker(EmittingProcess):
         self.port = port
 
     def run(self):
-        from server.app.app import Server
-        from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
-        server = Server()
-        app = server.create_app()
-        args = {
-            "layout": self.layout,
-            "diffexp": "ttest",
-            "max_category_items": 100,
-            "diffexp_lfc_cutoff": 0.01,
-            "obs_names": None,
-            "var_names": None,
-        }
-        data = ScanpyEngine(self.data_file, args)
-        server.attach_data(data, self.title)
-        self.emit("ready")
-        # TODO listen for finished to kill?
-        server.app.run(host=self.host, debug=True, port=self.port, threaded=True)
+        if not self.data_file:
+            self.emit("finished")
+            return
+        try:
+            from server.app.app import Server
+            from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
+            server = Server()
+            app = server.create_app()
+            args = {
+                "layout": self.layout,
+                "diffexp": "ttest",
+                "max_category_items": 100,
+                "diffexp_lfc_cutoff": 0.01,
+                "obs_names": None,
+                "var_names": None,
+            }
+            data = ScanpyEngine(self.data_file, args)
+            server.attach_data(data, self.title)
+            self.emit("ready")
+            # TODO listen for finished to kill?
+            server.app.run(host=self.host, debug=False, port=self.port, threaded=True)
+        except Exception as e:
+            traceback.print_exc()
+            self.emit("error", str(e))
+        finally:
+            self.emit("finished")
 
 
-class ServerRunWorker():
-    def __init__(self, app, host, port, *args, **kwargs):
-        super(ServerRunWorker, self).__init__()
-        self.app = app
-        self.host = host
-        self.port = port
+class SiteReadyWorker:
+    def __init__(self, location):
+        super(SiteReadyWorker, self).__init__()
+        self.signals = SiteReadySignals()
+        self.location = location
 
     def run(self):
-        self.app.run(host=self.host, debug=False, port=self.port, threaded=True)
+        session = requests.Session()
+        for i in range(90):
+            try:
+                session.head(self.location)
+                self.signals.ready.emit()
+                break
+            except requests.exceptions.ConnectionError:
+                time.sleep(1)
+            except Exception as e:
+                traceback.print_exc()
+                self.signals.error.emit(str(e))
+        self.signals.timeout.emit()

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -10,7 +10,9 @@ from server.gui.utils import SiteReadySignals
 class EmittingProcess(Process):
     def __init__(self, transport, *arg, **kwargs):
         super(EmittingProcess, self).__init__()
-        self.transport = transport
+        transport[0].close()
+        self.transport = transport[1]
+
 
     def emit(self, signal_name, *args):
         message = (signal_name, *args)

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -14,12 +14,10 @@ class EmittingProcess(Process):
         self.child_conn = child_conn
 
     def run(self):
-        pass
-        # self.parent_conn.close()
+        self.parent_conn.close()
 
     def emit(self, signal_name, *args):
         message = (signal_name, *args)
-        print(message)
         self.child_conn.send(message)
 
 
@@ -67,7 +65,6 @@ class Worker(EmittingProcess):
             return
         # launch server
         try:
-            # TODO listen for finished to kill?
             server.app.run(host=self.host, debug=False, port=self.port, threaded=True)
         except Exception as e:
             traceback.print_exc()

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -1,22 +1,31 @@
+from multiprocessing import Process
 import traceback
 
-from server.gui.utils import WorkerSignals
+s
+class EmittingProcess(Process):
+    def __init__(self, transport, *arg, **kwargs):
+        super(EmittingProcess, self).__init__()
+        self.transport = transport
+
+    def emit(self, signal_name, *args):
+        message = (signal_name, *args)
+        self.transport.send(message)
 
 
-class DataLoadWorker():
-    def __init__(self, data_file, layout="umap", *args, **kwargs):
-        super(DataLoadWorker, self).__init__()
+class Worker(EmittingProcess):
+    def __init__(self, transport, data_file, title, host, port, layout=["umap"], *args, **kwargs):
+        super(Worker, self).__init__()
         self.data_file = data_file
         self.layout = layout
-        self.signals = WorkerSignals()
+        self.title = title
+        self.host = host
+        self.port = port
 
     def run(self):
-        if not self.data_file:
-            self.signals.finished.emit()
-            return
-
-        # delayed import to speed load
+        from server.app.app import Server
         from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
+        server = Server()
+        app = server.create_app()
         args = {
             "layout": self.layout,
             "diffexp": "ttest",
@@ -25,15 +34,11 @@ class DataLoadWorker():
             "obs_names": None,
             "var_names": None,
         }
-        try:
-            data_results = ScanpyEngine(self.data_file, args)
-        except Exception as e:
-            traceback.print_exc()
-            self.signals.error.emit(str(e))
-        else:
-            self.signals.result.emit(data_results)
-        finally:
-            self.signals.finished.emit()
+        data = ScanpyEngine(self.data_file, args)
+        server.attach_data(data, self.title)
+        self.emit("ready")
+        # TODO listen for finished to kill?
+        server.app.run(host=self.host, debug=True, port=self.port, threaded=True)
 
 
 class ServerRunWorker():

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -6,6 +6,7 @@ import requests
 
 from server.gui.utils import SiteReadySignals
 
+
 class EmittingProcess(Process):
     def __init__(self, transport, *arg, **kwargs):
         super(EmittingProcess, self).__init__()
@@ -33,7 +34,7 @@ class Worker(EmittingProcess):
             from server.app.app import Server
             from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
             server = Server()
-            app = server.create_app()
+            server.create_app()
             args = {
                 "layout": self.layout,
                 "diffexp": "ttest",

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -8,20 +8,24 @@ from server.gui.utils import SiteReadySignals
 
 
 class EmittingProcess(Process):
-    def __init__(self, transport, *arg, **kwargs):
+    def __init__(self, parent_conn, child_conn, *arg, **kwargs):
         super(EmittingProcess, self).__init__()
-        transport[0].close()
-        self.transport = transport[1]
+        self.parent_conn = parent_conn
+        self.child_conn = child_conn
 
+    def run(self):
+        pass
+        # self.parent_conn.close()
 
     def emit(self, signal_name, *args):
         message = (signal_name, *args)
-        self.transport.send(message)
+        print(message)
+        self.child_conn.send(message)
 
 
 class Worker(EmittingProcess):
-    def __init__(self, transport, data_file, title, host, port, layout=["umap"], *args, **kwargs):
-        super(Worker, self).__init__(transport)
+    def __init__(self, parent_conn, child_conn, data_file, title, host, port, layout=["umap"], *args, **kwargs):
+        super(Worker, self).__init__(parent_conn, child_conn)
         self.data_file = data_file
         self.layout = layout
         self.title = title
@@ -29,14 +33,23 @@ class Worker(EmittingProcess):
         self.port = port
 
     def run(self):
+        super(Worker, self).run()
         if not self.data_file:
             self.emit("finished")
             return
+        from server.app.app import Server
+        from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
+        # create server
         try:
-            from server.app.app import Server
-            from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
             server = Server()
             server.create_app()
+        except Exception as e:
+            traceback.print_exc()
+            self.emit("server_error", str(e))
+            self.emit("finished")
+            return
+        # load data
+        try:
             args = {
                 "layout": self.layout,
                 "diffexp": "ttest",
@@ -48,11 +61,17 @@ class Worker(EmittingProcess):
             data = ScanpyEngine(self.data_file, args)
             server.attach_data(data, self.title)
             self.emit("ready")
+        except Exception as e:
+            self.emit("engine_error", str(e))
+            self.emit("finished")
+            return
+        # launch server
+        try:
             # TODO listen for finished to kill?
             server.app.run(host=self.host, debug=False, port=self.port, threaded=True)
         except Exception as e:
             traceback.print_exc()
-            self.emit("error", str(e))
+            self.emit("server_error", str(e))
         finally:
             self.emit("finished")
 

--- a/server/gui/workers.py
+++ b/server/gui/workers.py
@@ -42,7 +42,6 @@ class Worker(EmittingProcess):
             server = Server()
             server.create_app()
         except Exception as e:
-            traceback.print_exc()
             self.emit("server_error", str(e))
             self.emit("finished")
             return
@@ -50,7 +49,6 @@ class Worker(EmittingProcess):
         try:
             args = {
                 "layout": self.layout,
-                "diffexp": "ttest",
                 "max_category_items": 100,
                 "diffexp_lfc_cutoff": 0.01,
                 "obs_names": None,

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
     entry_points={"console_scripts": ["cellxgene = server.cli.cli:cli"]},
-    extras_require=dict(louvain=["python-igraph", "louvain>=0.6"], gui=["PySide2>=5.12.3", "cefpython3>=66"]),
+    extras_require=dict(louvain=["python-igraph", "louvain>=0.6"], gui=["PySide2>=5.12.3", "cefpython3>=66", "requests"]),
 )


### PR DESCRIPTION
Switch data load/server to multiprocessing instead of threads. This fixes the issue where extremely large files would block the UI and exit of the app (~750k cells) even in the multithreaded mode.

On file selection a new process will start to launch the server and load the data.  On exit or error this process will be killed. When the data has loaded, the browser navigates to the cellxgene url and is revealed in the gui window. (FYI we can't separate the server process and the data load process because the anndata data object cannot be pickled - what multiprocessing uses for interprocess serialization for communication).

I turned off reload since I wanted to put this out before I went on PTO for the next two days, but I know how to put it back in.

Also, I have a new thread that waits for the sever to start before navigating to it -- it's the same as how we do it in our unit tests.