### PR TITLE
scaling omitted from event handlers

### DIFF
--- a/client/__tests__/e2e/data.js
+++ b/client/__tests__/e2e/data.js
@@ -27,7 +27,7 @@ export const datasets = {
       lasso: [
         {
           "coordinates-as-percent": { x1: 0.05, y1: 0.25, x2: 0.15, y2: 0.35 },
-          count: "43"
+          count: "104"
         }
       ],
       categorical: [
@@ -92,7 +92,7 @@ export const datasets = {
       },
       lasso: {
         "coordinates-as-percent": { x1: 0.45, y1: 0.05, x2: 0.5, y2: 0.1 },
-        count: "65"
+        count: "76"
       }
     },
     scatter: {


### PR DESCRIPTION
resolve remaining issue with graph scaling when aspect ratio is < 1.  This adds scaling to the event handlers (it was previously resolved for rendering).

Fixes #788 