### PR TITLE
update to latest anndata and remove restriction on scipy

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-anndata>=0.6.15
+anndata>=0.6.20
 click>=6.7
 Flask>=1.0.2
 Flask-Caching>=1.4.0
@@ -10,6 +10,6 @@ matplotlib>=2.2
 numpy>=1.15.2
 pandas>=0.23.1
 scanpy>=1.3.7
-scipy>=1.1.0,<1.3
+scipy>=1.1.0
 scikit-learn>=0.19.1,!=0.20.0
 tables>=3.5.1


### PR DESCRIPTION
AnnData has resolved their incompatibility with the latest SciPy version.  This PR:
* removes the scipy version restriction of <1.3.0
* adds a minimum requirement for anndata of >=0.6.20 (which is believed compatible with any ~=1. version of scipy)

