### PR TITLE
fix incompatibility of flask reload and port searching

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -11,7 +11,7 @@ import click
 from server.app.app import Server
 from server.app.util.errors import ScanpyFileError
 from server.app.util.utils import custom_format_warning
-from server.utils.utils import find_available_port
+from server.utils.utils import find_available_port, is_port_available
 
 
 # anything bigger than this will generate a special message
@@ -143,6 +143,9 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
 
     if not port:
         port = find_available_port(host)
+    else:
+        if not is_port_available(host, int(port)):
+            raise click.ClickException(f"The port selected {port} is in use, please specify an open port using the --port flag.")
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -19,7 +19,7 @@ class EndPoints(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--debug", "--port", "5005"])
+        cls.ps = Popen(["cellxgene", "launch", "example-dataset/pbmc3k.h5ad", "--verbose", "--port", "5005"])
         session = requests.Session()
         for i in range(90):
             try:

--- a/server/test/test_nan_rest.py
+++ b/server/test/test_nan_rest.py
@@ -21,7 +21,7 @@ class WithNaNs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ps = Popen(
-            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--port", "5006"]
+            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--verbose", "--port", "5006"]
         )
         session = requests.Session()
         for i in range(90):

--- a/server/test/test_nan_rest.py
+++ b/server/test/test_nan_rest.py
@@ -8,7 +8,7 @@ import decode_fbs
 
 import requests
 
-LOCAL_URL = "http://127.0.0.1:5005/"
+LOCAL_URL = "http://127.0.0.1:5006/"
 VERSION = "v0.2"
 URL_BASE = f"{LOCAL_URL}api/{VERSION}/"
 
@@ -21,7 +21,7 @@ class WithNaNs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ps = Popen(
-            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--port", "5005"]
+            ["cellxgene", "launch", "server/test/test_datasets/nan.h5ad", "--debug", "--port", "5006"]
         )
         session = requests.Session()
         for i in range(90):

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -10,7 +10,6 @@ def find_available_port(host, port=5005):
     # Takes approx 2 seconds to do a scan of 5000 ports on my laptop
     num_ports_to_try = 5000
     for port_to_try in range(port, port + num_ports_to_try):
-        print(type(port_to_try))
         if is_port_available(host, port_to_try):
             return port_to_try
     raise socket.error(errno.EADDRINUSE, f"No port in range {port} - {port + num_ports_to_try - 1} available.")

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -10,10 +10,18 @@ def find_available_port(host, port=5005):
     # Takes approx 2 seconds to do a scan of 5000 ports on my laptop
     num_ports_to_try = 5000
     for port_to_try in range(port, port + num_ports_to_try):
-        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            try:
-                s.bind((host, port_to_try))
-                return port_to_try
-            except socket.error:
-                pass
+        print(type(port_to_try))
+        if is_port_available(host, port_to_try):
+            return port_to_try
     raise socket.error(errno.EADDRINUSE, f"No port in range {port} - {port + num_ports_to_try - 1} available.")
+
+
+def is_port_available(host, port):
+    is_available = False
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        try:
+            s.bind((host, port))
+            is_available = True
+        except socket.error:
+            pass
+    return is_available


### PR DESCRIPTION
in the 0.10 pre-release, if both --port and --debug were specified, the CLI will error out.  This is caused by flask reload causing the port code to run twice.   

Changes:
* `--debug` now only prints verbose warnings and disables browser launch. 
* a new flag, `--developer` enables hot reload and implies `--debug`
* because `--developer` and `--port` are incompatible, a new human-readable error is triggered by the combination.

So, these are legal:
* `cellxgene launch foo.h5ad --debug --port 9999` - verbose logging, serving on port 9999
* `cellxgene launch foo.h5ad --developer` - scan to find available port, verbose logging, hot reload