### PR TITLE
improve graph scale and centering

### DIFF
--- a/client/__tests__/e2e/data.js
+++ b/client/__tests__/e2e/data.js
@@ -27,7 +27,7 @@ export const datasets = {
       lasso: [
         {
           "coordinates-as-percent": { x1: 0.05, y1: 0.25, x2: 0.15, y2: 0.35 },
-          count: "104"
+          count: "101"
         }
       ],
       categorical: [
@@ -91,8 +91,8 @@ export const datasets = {
         }
       },
       lasso: {
-        "coordinates-as-percent": { x1: 0.45, y1: 0.05, x2: 0.5, y2: 0.1 },
-        count: "76"
+        "coordinates-as-percent": { x1: 0.45, y1: 0.05, x2: 0.65, y2: 0.15 },
+        count: "46"
       }
     },
     scatter: {

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -146,9 +146,10 @@ class Graph extends React.Component {
     const sizeBuffer = regl.buffer();
 
     // preallocate coordinate system transformation between data and gl
+    const fractionToUse = 0.98; // fraction of dimension to use
     const transform = {
-      glScaleX: scaleLinear([0, 1], [-1, 1]),
-      glScaleY: scaleLinear([0, 1], [1, -1])
+      glScaleX: scaleLinear([0, 1], [-1 * fractionToUse, 1 * fractionToUse]),
+      glScaleY: scaleLinear([0, 1], [1 * fractionToUse, -1 * fractionToUse])
     };
 
     /* first time, but this duplicates above function, should be possile to avoid this */

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -443,7 +443,7 @@ class ScanpyEngine(CXGDriver):
         * does not support filtering
         * only returns Matrix in columnar layout
 
-        All embeddings must be individually centered & scaled (isotropically) 
+        All embeddings must be individually centered & scaled (isotropically)
         to a [0, 1] range.
         """
         try:

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -442,13 +442,26 @@ class ScanpyEngine(CXGDriver):
         Caveats:
         * does not support filtering
         * only returns Matrix in columnar layout
+
+        All embeddings must be individually centered & scaled (isotropically) 
+        to a [0, 1] range.
         """
         try:
             layout_data = []
             for layout in self.config["layout"]:
                 full_embedding = self.data.obsm[f"X_{layout}"]
                 embedding = full_embedding[:, :2]
-                normalized_layout = (embedding - embedding.min()) / (embedding.max() - embedding.min())
+
+                # scale isotropically
+                min = embedding.min(axis=0)
+                max = embedding.max(axis=0)
+                scale = np.amax(max - min)
+                normalized_layout = (embedding - min) / scale
+
+                # translate to center on both axis
+                translate = 0.5 - ((max - min) / scale / 2)
+                normalized_layout = normalized_layout + translate
+
                 normalized_layout = normalized_layout.astype(dtype=np.float32)
                 layout_data.append(pandas.DataFrame(normalized_layout, columns=[f"{layout}_0", f"{layout}_1"]))
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,4 +12,4 @@ pandas>=0.23.1
 scanpy>=1.3.7
 scipy>=1.1.0
 scikit-learn>=0.19.1,!=0.20.0
-tables>=3.5.1
+tables==3.5.1


### PR DESCRIPTION
Three changes:
* pin python tables module to 3.5.1 (to avoid breakage from recent 3.5.2 release which lacks a wheel)
* add small gutter on the layout canvas so it does not clip dots on the edge
* correctly center on both axis

Fixes #784