### PR TITLE
draw labels marking the centroids of category value clusters

### DIFF
--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -59,7 +59,8 @@ class CategoryValue extends React.Component {
       colorScale,
       i,
       schema,
-      world
+      world,
+      centroidLabel
     } = this.props;
 
     if (!categoricalSelection) return null;
@@ -95,7 +96,11 @@ class CategoryValue extends React.Component {
         style={{
           display: "flex",
           alignItems: "baseline",
-          justifyContent: "space-between"
+          justifyContent: "space-between",
+          borderRadius: "3px",
+          background: centroidLabel.categoryIndex === categoryIndex &&
+                           centroidLabel.metadataField === metadataField
+                           ? "rgba(115, 134, 148, 0.3)":"inherit"
         }}
         data-testclass="categorical-row"
         onMouseEnter={this.handleMouseEnter.bind(this)}

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -35,7 +35,7 @@ class CategoryValue extends React.Component {
   handleMouseEnter() {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
-      type: "mouse enter",
+      type: "category value mouse hover start",
       metadataField,
       categoryIndex
     })
@@ -44,7 +44,7 @@ class CategoryValue extends React.Component {
   handleMouseExit() {
     const { dispatch, metadataField, categoryIndex } = this.props;
         dispatch({
-      type: "mouse exit",
+      type: "category value mouse hover start",
       metadataField,
       categoryIndex
     })

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -44,7 +44,7 @@ class CategoryValue extends React.Component {
   handleMouseExit() {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
-      type: "category value mouse hover start",
+      type: "category value mouse hover end",
       metadataField,
       categoryIndex
     })

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -9,7 +9,7 @@ import * as globals from "../../globals";
   categoricalSelection: state.categoricalSelection,
   colorScale: state.colors.scale,
   colorAccessor: state.colors.colorAccessor,
-  schema: state.world?.schema,
+  schema: state.world ?.schema,
   world: state.world,
   centroidLabel: state.centroidLabel,
 }))
@@ -43,7 +43,7 @@ class CategoryValue extends React.Component {
 
   handleMouseExit() {
     const { dispatch, metadataField, categoryIndex } = this.props;
-        dispatch({
+    dispatch({
       type: "category value mouse hover start",
       metadataField,
       categoryIndex
@@ -79,7 +79,7 @@ class CategoryValue extends React.Component {
     let occupancy = null;
 
     if (isColorBy && schema) {
-      categories = schema.annotations.obsByName[colorAccessor]?.categories;
+      categories = schema.annotations.obsByName[colorAccessor] ?.categories;
     }
 
     if (colorAccessor && !isColorBy && categoricalSelection[colorAccessor]) {
@@ -99,8 +99,8 @@ class CategoryValue extends React.Component {
           justifyContent: "space-between",
           borderRadius: "3px",
           background: centroidLabel.categoryIndex === categoryIndex &&
-                           centroidLabel.metadataField === metadataField
-                           ? "rgba(115, 134, 148, 0.3)":"inherit"
+            centroidLabel.metadataField === metadataField
+            ? "rgba(115, 134, 148, 0.3)" : "inherit"
         }}
         data-testclass="categorical-row"
         onMouseEnter={this.handleMouseEnter.bind(this)}
@@ -136,15 +136,15 @@ class CategoryValue extends React.Component {
           </label>
           <span style={{ flexShrink: 0 }}>
             {colorAccessor &&
-            !isColorBy &&
-            categoricalSelection[colorAccessor] ? (
-              <Occupancy
-                occupancy={occupancy.get(
-                  category.categoryValues[categoryIndex]
-                )}
-                {...this.props}
-              />
-            ) : null}
+              !isColorBy &&
+              categoricalSelection[colorAccessor] ? (
+                <Occupancy
+                  occupancy={occupancy.get(
+                    category.categoryValues[categoryIndex]
+                  )}
+                  {...this.props}
+                />
+              ) : null}
           </span>
         </div>
         <span>

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -10,7 +10,8 @@ import * as globals from "../../globals";
   colorScale: state.colors.scale,
   colorAccessor: state.colors.colorAccessor,
   schema: state.world?.schema,
-  world: state.world
+  world: state.world,
+  centroidLabel: state.centroidLabel,
 }))
 class CategoryValue extends React.Component {
   toggleOff() {
@@ -29,6 +30,24 @@ class CategoryValue extends React.Component {
       metadataField,
       categoryIndex
     });
+  }
+
+  handleMouseEnter() {
+    const { dispatch, metadataField, categoryIndex } = this.props;
+    dispatch({
+      type: "mouse enter",
+      metadataField,
+      categoryIndex
+    })
+  }
+
+  handleMouseExit() {
+    const { dispatch, metadataField, categoryIndex } = this.props;
+        dispatch({
+      type: "mouse exit",
+      metadataField,
+      categoryIndex
+    })
   }
 
   render() {
@@ -79,6 +98,8 @@ class CategoryValue extends React.Component {
           justifyContent: "space-between"
         }}
         data-testclass="categorical-row"
+        onMouseEnter={this.handleMouseEnter.bind(this)}
+        onMouseLeave={this.handleMouseExit.bind(this)}
       >
         <div
           style={{

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -13,41 +13,41 @@ import * as globals from "../../globals";
   world: state.world
 }))
 class CategoryValue extends React.Component {
-  toggleOff() {
+  toggleOff = () => {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter deselect",
       metadataField,
       categoryIndex
     });
-  }
+  };
 
-  toggleOn() {
+  toggleOn = () => {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter select",
       metadataField,
       categoryIndex
     });
-  }
+  };
 
-  handleMouseEnter() {
+  handleMouseEnter = () => {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "category value mouse hover start",
       metadataField,
       categoryIndex
     });
-  }
+  };
 
-  handleMouseExit() {
+  handleMouseExit = () => {
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "category value mouse hover end",
       metadataField,
       categoryIndex
     });
-  }
+  };
 
   render() {
     const {
@@ -97,8 +97,8 @@ class CategoryValue extends React.Component {
           justifyContent: "space-between"
         }}
         data-testclass="categorical-row"
-        onMouseEnter={this.handleMouseEnter.bind(this)}
-        onMouseLeave={this.handleMouseExit.bind(this)}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseExit}
       >
         <div
           style={{
@@ -112,9 +112,7 @@ class CategoryValue extends React.Component {
         >
           <label className="bp3-control bp3-checkbox">
             <input
-              onChange={
-                selected ? this.toggleOff.bind(this) : this.toggleOn.bind(this)
-              }
+              onChange={selected ? this.toggleOff : this.toggleOn}
               data-testclass="categorical-value-select"
               data-testid={`categorical-value-select-${metadataField}-${displayString}`}
               checked={selected}

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -9,9 +9,8 @@ import * as globals from "../../globals";
   categoricalSelection: state.categoricalSelection,
   colorScale: state.colors.scale,
   colorAccessor: state.colors.colorAccessor,
-  schema: state.world ?.schema,
-  world: state.world,
-  centroidLabel: state.centroidLabel,
+  schema: state.world?.schema,
+  world: state.world
 }))
 class CategoryValue extends React.Component {
   toggleOff() {
@@ -38,7 +37,7 @@ class CategoryValue extends React.Component {
       type: "category value mouse hover start",
       metadataField,
       categoryIndex
-    })
+    });
   }
 
   handleMouseExit() {
@@ -47,7 +46,7 @@ class CategoryValue extends React.Component {
       type: "category value mouse hover end",
       metadataField,
       categoryIndex
-    })
+    });
   }
 
   render() {
@@ -59,8 +58,7 @@ class CategoryValue extends React.Component {
       colorScale,
       i,
       schema,
-      world,
-      centroidLabel
+      world
     } = this.props;
 
     if (!categoricalSelection) return null;
@@ -79,7 +77,7 @@ class CategoryValue extends React.Component {
     let occupancy = null;
 
     if (isColorBy && schema) {
-      categories = schema.annotations.obsByName[colorAccessor] ?.categories;
+      categories = schema.annotations.obsByName[colorAccessor]?.categories;
     }
 
     if (colorAccessor && !isColorBy && categoricalSelection[colorAccessor]) {
@@ -96,11 +94,7 @@ class CategoryValue extends React.Component {
         style={{
           display: "flex",
           alignItems: "baseline",
-          justifyContent: "space-between",
-          borderRadius: "3px",
-          background: centroidLabel.categoryIndex === categoryIndex &&
-            centroidLabel.metadataField === metadataField
-            ? "rgba(115, 134, 148, 0.3)" : "inherit"
+          justifyContent: "space-between"
         }}
         data-testclass="categorical-row"
         onMouseEnter={this.handleMouseEnter.bind(this)}
@@ -136,15 +130,15 @@ class CategoryValue extends React.Component {
           </label>
           <span style={{ flexShrink: 0 }}>
             {colorAccessor &&
-              !isColorBy &&
-              categoricalSelection[colorAccessor] ? (
-                <Occupancy
-                  occupancy={occupancy.get(
-                    category.categoryValues[categoryIndex]
-                  )}
-                  {...this.props}
-                />
-              ) : null}
+            !isColorBy &&
+            categoricalSelection[colorAccessor] ? (
+              <Occupancy
+                occupancy={occupancy.get(
+                  category.categoryValues[categoryIndex]
+                )}
+                {...this.props}
+              />
+            ) : null}
           </span>
         </div>
         <span>

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -70,7 +70,7 @@ class Graph extends React.Component {
       sizes: null
     };
     this.state = {
-      svg: null,
+      toolSVG: null,
       tool: null,
       container: null
     };
@@ -141,7 +141,7 @@ class Graph extends React.Component {
       layoutChoice,
       graphInteractionMode
     } = this.props;
-    const { reglRender, regl, svg } = this.state;
+    const { reglRender, mode, regl, toolSVG } = this.state;
     let stateChanges = {};
 
     if (reglRender) {
@@ -220,12 +220,12 @@ class Graph extends React.Component {
       prevProps.responsive.height !== responsive.height ||
       prevProps.responsive.width !== responsive.width ||
       /* first time */
-      (responsive.height && responsive.width && !svg) ||
+      (responsive.height && responsive.width && !toolSVG) ||
       selectionTool !== prevProps.selectionTool
     ) {
       /* clear out whatever was on the div, even if nothing, but usually the brushes etc */
       d3.select("#graphAttachPoint")
-        .selectAll("svg")
+        .selectAll("#tool")
         .remove();
 
       let handleStart;
@@ -241,7 +241,7 @@ class Graph extends React.Component {
         handleEnd = this.handleLassoEnd.bind(this);
         handleCancel = this.handleLassoCancel.bind(this);
       }
-      const { svg: newSvg, tool, container } = setupSVGandBrushElements(
+      const { svg: newToolSVG, tool, container } = setupSVGandBrushElements(
         selectionTool,
         handleStart,
         handleDrag,
@@ -250,7 +250,8 @@ class Graph extends React.Component {
         responsive,
         this.graphPaddingRight
       );
-      stateChanges = { ...stateChanges, svg: newSvg, tool, container };
+      
+      stateChanges = { ...stateChanges, toolSVG: newToolSVG, tool, container };
     }
 
     /*
@@ -260,7 +261,7 @@ class Graph extends React.Component {
     if (
       currentSelection !== prevProps.currentSelection ||
       graphInteractionMode !== prevProps.graphInteractionMode ||
-      stateChanges.svg
+      stateChanges.toolSVG
     ) {
       const { tool, container } = this.state;
       this.selectionToolUpdate(

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -264,8 +264,6 @@ class Graph extends React.Component {
 
       const centroidScreen = this.mapPointToScreen(centroidLabel.centroidXY);
 
-      centroidScreen.push(centroidLabel.centroidXY[2]);
-
       const newCentroidSVG = setupCentroidSVG(
         responsive,
         this.graphPaddingRight,

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -25,7 +25,8 @@ import scaleLinear from "../../util/scaleLinear";
   currentSelection: state.graphSelection.selection,
   layoutChoice: state.layoutChoice,
   centroidLabel: state.centroidLabel,
-  graphInteractionMode: state.controls.graphInteractionMode
+  graphInteractionMode: state.controls.graphInteractionMode,
+  colorAccessor: state.colors.colorAccessor
 }))
 class Graph extends React.Component {
   computePointPositions = memoize((X, Y, scaleX, scaleY) => {
@@ -144,6 +145,7 @@ class Graph extends React.Component {
       currentSelection,
       layoutChoice,
       graphInteractionMode,
+      colorAccessor,
       centroidLabel
     } = this.props;
     const { reglRender, mode, regl, toolSVG, centroidSVG } = this.state;
@@ -258,6 +260,8 @@ class Graph extends React.Component {
         .select("#centroid-container")
         .remove();
 
+      console.log(colorAccessor);
+
       if (centroidLabel.metadataField === "" || !centroidLabel.centroidXY) {
         return;
       }
@@ -268,7 +272,8 @@ class Graph extends React.Component {
         responsive,
         this.graphPaddingRight,
         centroidScreen,
-        centroidLabel.categoryField
+        centroidLabel.categoryField,
+        colorAccessor
       );
 
       stateChanges = { ...stateChanges, centroidSVG: newCentroidSVG };

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -242,6 +242,7 @@ class Graph extends React.Component {
         handleEnd = this.handleLassoEnd.bind(this);
         handleCancel = this.handleLassoCancel.bind(this);
       }
+
       const { svg: newToolSVG, tool, container } = setupSVGandBrushElements(
         selectionTool,
         handleStart,
@@ -249,7 +250,8 @@ class Graph extends React.Component {
         handleEnd,
         handleCancel,
         responsive,
-        this.graphPaddingRight
+        this.graphPaddingRight,
+        graphInteractionMode
       );
 
       stateChanges = { ...stateChanges, toolSVG: newToolSVG, tool, container };
@@ -286,7 +288,8 @@ class Graph extends React.Component {
       createCentroidSVG();
     } else if (
       (responsive.height && responsive.width && !toolSVG) ||
-      selectionTool !== prevProps.selectionTool
+      selectionTool !== prevProps.selectionTool ||
+      prevProps.graphInteractionMode !== graphInteractionMode
     ) {
       // first time or change of selection tool6
       createToolSVG();
@@ -633,12 +636,7 @@ class Graph extends React.Component {
             right: 0
           }}
         >
-          <div
-            style={{
-              display: graphInteractionMode === "select" ? "inherit" : "none"
-            }}
-            id="graphAttachPoint"
-          />
+          <div id="graphAttachPoint" />
           <div style={{ padding: 0, margin: 0 }}>
             <canvas
               width={responsive.width - this.graphPaddingRight}

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -260,8 +260,6 @@ class Graph extends React.Component {
         .select("#centroid-container")
         .remove();
 
-      console.log(colorAccessor);
-
       if (centroidLabel.metadataField === "" || !centroidLabel.centroidXY) {
         return;
       }

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -258,7 +258,7 @@ class Graph extends React.Component {
         .select("#centroid-container")
         .remove();
 
-      if (centroidLabel.metadataField === "") {
+      if (centroidLabel.metadataField === "" || !centroidLabel.centroidXY) {
         return;
       }
 
@@ -285,7 +285,7 @@ class Graph extends React.Component {
       (responsive.height && responsive.width && !toolSVG) ||
       selectionTool !== prevProps.selectionTool
     ) {
-      // first time or change of selection tool
+      // first time or change of selection tool6
       createToolSVG();
     } else if (
       centroidLabel !== prevProps.centroidLabel ||

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -224,7 +224,7 @@ class Graph extends React.Component {
     const createToolSVG = () => {
       /* clear out whatever was on the div, even if nothing, but usually the brushes etc */
       d3.select("#graphAttachPoint")
-        .selectAll("#tool")
+        .select("#tool")
         .remove();
 
       let handleStart;
@@ -255,7 +255,7 @@ class Graph extends React.Component {
 
     const createCentroidSVG = () => {
       d3.select("#graphAttachPoint")
-        .selectAll("#centroid ")
+        .select("#centroid")
         .remove();
 
       if (centroidLabel.metadataField === "") {

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -258,12 +258,19 @@ class Graph extends React.Component {
         .selectAll("#centroid ")
         .remove();
 
+      if (centroidLabel.metadataField === "") {
+        return;
+      }
+
       const centroidScreen = this.mapPointToScreen(centroidLabel.centroidXY);
+
+      centroidScreen.push(centroidLabel.centroidXY[2]);
 
       const newCentroidSVG = setupCentroidSVG(
         responsive,
         this.graphPaddingRight,
-        centroidScreen
+        centroidScreen,
+        centroidLabel.categoryField
       );
 
       stateChanges = { ...stateChanges, centroidSVG: newCentroidSVG };

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -255,7 +255,7 @@ class Graph extends React.Component {
 
     const createCentroidSVG = () => {
       d3.select("#graphAttachPoint")
-        .select("#centroid")
+        .select("#centroid-container")
         .remove();
 
       if (centroidLabel.metadataField === "") {

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -12,7 +12,8 @@ export default (responsive, graphPaddingRight, xy, text, colorBy) => {
     .attr("width", containerWidth)
     .attr("height", responsive.height)
     .attr("class", `${styles.graphSVG}`)
-    .style("z-index", 998);
+    .style("z-index", 998)
+    .style("pointer-events", "none");
   //  TODO: Create own styles, ask Colin for an explanation on the css
   // For now I'm going to put centroid z-index at 998 and lasso on 999
 

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 import styles from "./graph.css";
 
-export default (responsive, graphPaddingRight, xy, text) => {
+export default (responsive, graphPaddingRight, xy, text, colorBy) => {
   const containerWidth = responsive.width - graphPaddingRight;
 
   const svg = d3
@@ -25,10 +25,9 @@ export default (responsive, graphPaddingRight, xy, text) => {
     .attr("text-anchor", "middle")
     .text(text)
     .style("font-family", "Roboto Condensed")
-    .style("font-size", "16px")
+    .style("font-size", "18px")
     .style("font-weight", "700")
-    .style("fill", "white")
-    .style("stroke", "black");
+    .style("fill", colorBy ? "black" : "rgb(32, 178, 212)");
 
   return svg;
 };

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -16,17 +16,9 @@ export default (responsive, graphPaddingRight, xy, text) => {
   //  TODO: Create own styles, ask Colin for an explanation on the css
   // For now I'm going to put centroid z-index at 998 and lasso on 999
 
-  const radius = xy[2] * containerWidth * 1.5;
-
   const label = svg
     .append("g")
     .attr("transform", `translate(${xy[0]}, ${xy[1]})`);
-
-  label
-    .append("circle")
-    .attr("r", radius)
-    .style("fill", "rgba(244, 66, 66, .55)")
-    .style("stroke", "rgba(0, 0, 0, .4)");
 
   label
     .append("text")

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,18 +1,28 @@
 import * as d3 from "d3";
 import styles from "./graph.css";
 
-export default (
-  responsive,
-  graphPaddingRight
-) => {
+export default (responsive, graphPaddingRight, xy) => {
   const svg = d3
-  .select("#graphAttachPoint")
-  .append("svg")
-  .attr("id", "centroid")
-  .attr("data-testid", "centroid-overlay")
-  .attr("width", responsive.width - graphPaddingRight)
-  .attr("height", responsive.height)
-  .attr("class", `${styles.graphSVG}`);
-//  TODO: Create own styles, ask Colin for an explanation on the css
+    .select("#graphAttachPoint")
+    .append("svg")
+    .attr("id", "centroid")
+    .attr("data-testid", "centroid-overlay")
+    .attr("width", responsive.width - graphPaddingRight)
+    .attr("height", responsive.height)
+    .attr("class", `${styles.graphSVG}`)
+    .style("z-index", 998);
+  //  TODO: Create own styles, ask Colin for an explanation on the css
+  // For now I'm going to put centroid z-index at 998 and lasso on 999
+
+  const offset = 5;
+
+  svg
+    .append("circle")
+    .attr("cx", xy[0] + offset)
+    .attr("cy", xy[1] + offset)
+    .attr("r", 10)
+    .style("fill", "rgba(244, 66, 66, .55)")
+    .style("stroke", "rgba(0, 0, 0, .4");
+
   return svg;
-}
+};

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,4 +1,5 @@
 import * as d3 from "d3";
+import styles from "./graph.css";
 
 export default (
   responsive,
@@ -7,9 +8,11 @@ export default (
   const svg = d3
   .select("#graphAttachPoint")
   .append("svg")
+  .attr("id", "centroid")
   .attr("data-testid", "centroid-overlay")
   .attr("width", responsive.width - graphPaddingRight)
-  .attr("height", responsive.height);
-
+  .attr("height", responsive.height)
+  .attr("class", `${styles.graphSVG}`);
+//  TODO: Create own styles, ask Colin for an explanation on the css
   return svg;
 }

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,0 +1,15 @@
+import * as d3 from "d3";
+
+export default (
+  responsive,
+  graphPaddingRight
+) => {
+  const svg = d3
+  .select("#graphAttachPoint")
+  .append("svg")
+  .attr("data-testid", "centroid-overlay")
+  .attr("width", responsive.width - graphPaddingRight)
+  .attr("height", responsive.height);
+
+  return svg;
+}

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -24,8 +24,9 @@ export default (responsive, graphPaddingRight, xy, text) => {
     .append("text")
     .attr("text-anchor", "middle")
     .text(text)
-    .style("font-size", "25px")
     .style("font-family", "Roboto Condensed")
+    .style("font-size", "16px")
+    .style("font-weight", "700")
     .style("fill", "white")
     .style("stroke", "black");
 

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -7,7 +7,7 @@ export default (responsive, graphPaddingRight, xy, text) => {
   const svg = d3
     .select("#graphAttachPoint")
     .append("svg")
-    .attr("id", "centroid")
+    .attr("id", "centroid-container")
     .attr("data-testid", "centroid-overlay")
     .attr("width", containerWidth)
     .attr("height", responsive.height)

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,28 +1,40 @@
 import * as d3 from "d3";
 import styles from "./graph.css";
 
-export default (responsive, graphPaddingRight, xy) => {
+export default (responsive, graphPaddingRight, xy, text) => {
+  const containerWidth = responsive.width - graphPaddingRight;
+
   const svg = d3
     .select("#graphAttachPoint")
     .append("svg")
     .attr("id", "centroid")
     .attr("data-testid", "centroid-overlay")
-    .attr("width", responsive.width - graphPaddingRight)
+    .attr("width", containerWidth)
     .attr("height", responsive.height)
     .attr("class", `${styles.graphSVG}`)
     .style("z-index", 998);
   //  TODO: Create own styles, ask Colin for an explanation on the css
   // For now I'm going to put centroid z-index at 998 and lasso on 999
 
-  const offset = 5;
+  const radius = xy[2] * containerWidth * 1.5;
 
-  svg
+  const label = svg
+    .append("g")
+    .attr("transform", `translate(${xy[0]}, ${xy[1]})`);
+
+  label
     .append("circle")
-    .attr("cx", xy[0] + offset)
-    .attr("cy", xy[1] + offset)
-    .attr("r", 10)
+    .attr("r", radius)
     .style("fill", "rgba(244, 66, 66, .55)")
-    .style("stroke", "rgba(0, 0, 0, .4");
+    .style("stroke", "rgba(0, 0, 0, .4)");
+
+  label
+    .append("text")
+    .attr("text-anchor", "middle")
+    .text(text)
+    .style("font-size", "25px")
+    .style("fill", "white")
+    .style("stroke", "black");
 
   return svg;
 };

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -33,6 +33,7 @@ export default (responsive, graphPaddingRight, xy, text) => {
     .attr("text-anchor", "middle")
     .text(text)
     .style("font-size", "25px")
+    .style("font-family", "Roboto Condensed")
     .style("fill", "white")
     .style("stroke", "black");
 

--- a/client/src/components/graph/setupSVGandBrush.js
+++ b/client/src/components/graph/setupSVGandBrush.js
@@ -16,7 +16,8 @@ export default (
   handleEndAction,
   handleCancelAction,
   responsive,
-  graphPaddingRight
+  graphPaddingRight,
+  graphInteractionMode
 ) => {
   const svg = d3
     .select("#graphAttachPoint")
@@ -26,7 +27,8 @@ export default (
     .attr("width", responsive.width - graphPaddingRight)
     .attr("height", responsive.height)
     .attr("class", `${styles.graphSVG}`)
-    .style("z-index", 999);
+    .style("z-index", 999)
+    .style("display", graphInteractionMode === "select" ? "inherit" : "none");
 
   if (selectionToolType === "brush") {
     const brush = d3

--- a/client/src/components/graph/setupSVGandBrush.js
+++ b/client/src/components/graph/setupSVGandBrush.js
@@ -25,7 +25,8 @@ export default (
     .attr("data-testid", "layout-overlay")
     .attr("width", responsive.width - graphPaddingRight)
     .attr("height", responsive.height)
-    .attr("class", `${styles.graphSVG}`);
+    .attr("class", `${styles.graphSVG}`)
+    .style("z-index", 999);
 
   if (selectionToolType === "brush") {
     const brush = d3

--- a/client/src/components/graph/setupSVGandBrush.js
+++ b/client/src/components/graph/setupSVGandBrush.js
@@ -21,6 +21,7 @@ export default (
   const svg = d3
     .select("#graphAttachPoint")
     .append("svg")
+    .attr("id", "tool")
     .attr("data-testid", "layout-overlay")
     .attr("width", responsive.width - graphPaddingRight)
     .attr("height", responsive.height)

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -6,12 +6,11 @@ const initialState = {
 const CentroidLabel = (
   state = initialState,
   action,
-  nextSharedState,
-  prevSharedState
-) => {
+  sharedNextState
+  ) => {
   const { metadataField, categoryIndex } = action;
   switch (action.type) {
-    case "mouse enter":
+    case "category value mouse hover start":
       console.log(action);
       
       return {
@@ -20,14 +19,15 @@ const CentroidLabel = (
         categoryIndex
       }
 
-    case "mouse exit":
+    case "category value mouse hover end":
       console.log(action);
       
         if (metadataField === state.metadataField &&
-          categoryIndex === state. categoryIndex) {
+          categoryIndex === state.categoryIndex) {
           return initialState
         }
         return state;
+        
       default:
       return state
   }

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -1,0 +1,36 @@
+const initialState = {
+  metadataField: "",
+  categoryIndex: -1
+};
+
+const CentroidLabel = (
+  state = initialState,
+  action,
+  nextSharedState,
+  prevSharedState
+) => {
+  const { metadataField, categoryIndex } = action;
+  switch (action.type) {
+    case "mouse enter":
+      console.log(action);
+      
+      return {
+        ...state,
+        metadataField,
+        categoryIndex
+      }
+
+    case "mouse exit":
+      console.log(action);
+      
+        if (metadataField === state.metadataField &&
+          categoryIndex === state. categoryIndex) {
+          return initialState
+        }
+        return state;
+      default:
+      return state
+  }
+};
+
+export default CentroidLabel;

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -1,18 +1,27 @@
+import calcCentroid from "../util/centroid";
+
 const initialState = {
-  metadataField: "",
-  categoryIndex: -1
+  metadataField: 0,
+  categoryField: 0
 };
 
 const CentroidLabel = (
   state = initialState,
   action,
   sharedNextState
-  ) => {
+) => {
+  const { categoricalSelection, world, layoutChoice } = sharedNextState;
   const { metadataField, categoryIndex } = action;
+  // TODO: Use the es7 syntatic sugar 
+  const categoryField = categoricalSelection &&
+    categoricalSelection[metadataField]
+    ? categoricalSelection[metadataField].categoryValues[categoryIndex] : "";
   switch (action.type) {
     case "category value mouse hover start":
       console.log(action);
       
+      console.log(calcCentroid(world, metadataField, categoryField, layoutChoice.currentDimNames))
+
       return {
         ...state,
         metadataField,
@@ -21,14 +30,14 @@ const CentroidLabel = (
 
     case "category value mouse hover end":
       console.log(action);
-      
-        if (metadataField === state.metadataField &&
-          categoryIndex === state.categoryIndex) {
-          return initialState
-        }
-        return state;
-        
-      default:
+
+      if (metadataField === state.metadataField &&
+        categoryIndex === state.categoryIndex) {
+        return initialState
+      }
+      return state;
+
+    default:
       return state
   }
 };

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -4,7 +4,7 @@ const initialState = {
   metadataField: "",
   categoryIndex: -1,
   categoryField: "",
-  centroidXY: [-1, -1, -1]
+  centroidXY: [-1, -1]
 };
 
 const CentroidLabel = (state = initialState, action, sharedNextState) => {

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -14,8 +14,6 @@ const CentroidLabel = (state = initialState, action, sharedNextState) => {
     categoricalSelection?.[metadataField]?.categoryValues[categoryIndex];
   switch (action.type) {
     case "category value mouse hover start":
-      console.log(action);
-
       return {
         ...state,
         metadataField,
@@ -30,8 +28,6 @@ const CentroidLabel = (state = initialState, action, sharedNextState) => {
       };
 
     case "category value mouse hover end":
-      console.log(action);
-
       if (
         metadataField === state.metadataField &&
         categoryIndex === state.categoryIndex

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -1,9 +1,10 @@
 import calcCentroid from "../util/centroid";
 
 const initialState = {
-  metadataField: 0,
-  categoryField: 0,
-  centroidXY: [-1, -1]
+  metadataField: "",
+  categoryIndex: -1,
+  categoryField: "",
+  centroidXY: [-1, -1, -1]
 };
 
 const CentroidLabel = (state = initialState, action, sharedNextState) => {
@@ -22,6 +23,7 @@ const CentroidLabel = (state = initialState, action, sharedNextState) => {
         ...state,
         metadataField,
         categoryIndex,
+        categoryField,
         centroidXY: calcCentroid(
           world,
           metadataField,

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -2,7 +2,8 @@ import calcCentroid from "../util/centroid";
 
 const initialState = {
   metadataField: 0,
-  categoryField: 0
+  categoryField: 0,
+  centroidXY: [-1, -1]
 };
 
 const CentroidLabel = (
@@ -19,13 +20,12 @@ const CentroidLabel = (
   switch (action.type) {
     case "category value mouse hover start":
       console.log(action);
-      
-      console.log(calcCentroid(world, metadataField, categoryField, layoutChoice.currentDimNames))
 
       return {
         ...state,
         metadataField,
-        categoryIndex
+        categoryIndex,
+        centroidXY: calcCentroid(world, metadataField, categoryField, layoutChoice.currentDimNames)
       }
 
     case "category value mouse hover end":

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -6,17 +6,14 @@ const initialState = {
   centroidXY: [-1, -1]
 };
 
-const CentroidLabel = (
-  state = initialState,
-  action,
-  sharedNextState
-) => {
+const CentroidLabel = (state = initialState, action, sharedNextState) => {
   const { categoricalSelection, world, layoutChoice } = sharedNextState;
   const { metadataField, categoryIndex } = action;
-  // TODO: Use the es7 syntatic sugar 
-  const categoryField = categoricalSelection &&
-    categoricalSelection[metadataField]
-    ? categoricalSelection[metadataField].categoryValues[categoryIndex] : "";
+  // TODO: Use the es7 syntatic sugar
+  const categoryField =
+    categoricalSelection && categoricalSelection[metadataField]
+      ? categoricalSelection[metadataField].categoryValues[categoryIndex]
+      : "";
   switch (action.type) {
     case "category value mouse hover start":
       console.log(action);
@@ -25,20 +22,27 @@ const CentroidLabel = (
         ...state,
         metadataField,
         categoryIndex,
-        centroidXY: calcCentroid(world, metadataField, categoryField, layoutChoice.currentDimNames)
-      }
+        centroidXY: calcCentroid(
+          world,
+          metadataField,
+          categoryField,
+          layoutChoice.currentDimNames
+        )
+      };
 
     case "category value mouse hover end":
       console.log(action);
 
-      if (metadataField === state.metadataField &&
-        categoryIndex === state.categoryIndex) {
-        return initialState
+      if (
+        metadataField === state.metadataField &&
+        categoryIndex === state.categoryIndex
+      ) {
+        return initialState;
       }
       return state;
 
     default:
-      return state
+      return state;
   }
 };
 

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -10,11 +10,8 @@ const initialState = {
 const CentroidLabel = (state = initialState, action, sharedNextState) => {
   const { categoricalSelection, world, layoutChoice } = sharedNextState;
   const { metadataField, categoryIndex } = action;
-  // TODO: Use the es7 syntatic sugar
   const categoryField =
-    categoricalSelection && categoricalSelection[metadataField]
-      ? categoricalSelection[metadataField].categoryValues[categoryIndex]
-      : "";
+    categoricalSelection?.[metadataField]?.categoryValues[categoryIndex];
   switch (action.type) {
     case "category value mouse hover start":
       console.log(action);

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -21,34 +21,34 @@ import centroidLabel from "./centroidLabel";
 import undoableConfig from "./undoableConfig";
 
 const Reducer = undoable(
-    cascadeReducers([
-        ["config", config],
-        ["universe", universe],
-        ["world", world],
-        ["layoutChoice", layoutChoice],
-        ["categoricalSelection", categoricalSelection],
-        ["continuousSelection", continuousSelection],
-        ["graphSelection", graphSelection],
-        ["crossfilter", crossfilter],
-        ["colors", colors],
-        ["controls", controls],
-        ["differential", differential],
-        ["responsive", responsive],
-        ["centroidLabel", centroidLabel],
-        ["resetCache", resetCache],
-    ]),
-    [
-        "world",
-        "categoricalSelection",
-        "continuousSelection",
-        "graphSelection",
-        "crossfilter",
-        "colors",
-        "controls",
-        "differential",
-        "layoutChoice"
-    ],
-    undoableConfig
+  cascadeReducers([
+    ["config", config],
+    ["universe", universe],
+    ["world", world],
+    ["layoutChoice", layoutChoice],
+    ["categoricalSelection", categoricalSelection],
+    ["continuousSelection", continuousSelection],
+    ["graphSelection", graphSelection],
+    ["crossfilter", crossfilter],
+    ["colors", colors],
+    ["controls", controls],
+    ["differential", differential],
+    ["responsive", responsive],
+    ["centroidLabel", centroidLabel],
+    ["resetCache", resetCache]
+  ]),
+  [
+    "world",
+    "categoricalSelection",
+    "continuousSelection",
+    "graphSelection",
+    "crossfilter",
+    "colors",
+    "controls",
+    "differential",
+    "layoutChoice"
+  ],
+  undoableConfig
 );
 
 const store = createStore(Reducer, applyMiddleware(thunk));

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -34,8 +34,8 @@ const Reducer = undoable(
         ["controls", controls],
         ["differential", differential],
         ["responsive", responsive],
-        ["resetCache", resetCache],
         ["centroidLabel", centroidLabel],
+        ["resetCache", resetCache],
     ]),
     [
         "world",

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -16,6 +16,7 @@ import layoutChoice from "./layoutChoice";
 import responsive from "./responsive";
 import controls from "./controls";
 import resetCache from "./resetCache";
+import centroidLabel from "./centroidLabel";
 
 import undoableConfig from "./undoableConfig";
 
@@ -33,7 +34,8 @@ const Reducer = undoable(
         ["controls", controls],
         ["differential", differential],
         ["responsive", responsive],
-        ["resetCache", resetCache]
+        ["resetCache", resetCache],
+        ["centroidLabel", centroidLabel],
     ]),
     [
         "world",

--- a/client/src/reducers/undoableConfig.js
+++ b/client/src/reducers/undoableConfig.js
@@ -29,7 +29,10 @@ const skipOnActions = new Set([
   "clear all user defined genes",
 
   "get single gene expression for coloring started",
-  "get single gene expression for coloring error"
+  "get single gene expression for coloring error",
+
+  "category value mouse hover start",
+  "category value mouse hover end"
 ]);
 
 /*

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -48,7 +48,7 @@ const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
     return [medianX, medianY];
   }
 
-  return [0.5, 0.5];
+  return null;
 };
 
 export default calcMedianCentroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -2,11 +2,7 @@ import quantile from "./quantile";
 
 /*
   Centroid coordinate calculation
-
-
 */
-
-
 const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
   const centroid = [0, 0, 0];
   const annoArray = world.obsAnnotations.col(annoName).asArray();
@@ -39,17 +35,15 @@ const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
 
   for (let i = 0, len = annoArray.length; i < len; i += 1) {
     if (annoArray[i] === annoValue) {
-      centroidX.push(layoutXArray[i])
-      centroidY.push(layoutYArray[i])
+      centroidX.push(layoutXArray[i]);
+      centroidY.push(layoutYArray[i]);
     }
   }
 
-  const medianX = quantile([.5], Float64Array.from(centroidX));
-  const medianY = quantile([.5], Float64Array.from(centroidY));
+  const medianX = quantile([0.5], Float64Array.from(centroidX));
+  const medianY = quantile([0.5], Float64Array.from(centroidY));
 
-  return[medianX, medianY]
-}
-
-
+  return [medianX, medianY];
+};
 
 export default calcMedianCentroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -17,6 +17,7 @@ export default function calcCentroid(world, annoName, annoValue, layoutDimNames)
     }
     return data;
   }, { x: 0, y: 0, count: 0 });
+  
 
   const centroid = { x: 0, y: 0 };
 
@@ -24,4 +25,23 @@ export default function calcCentroid(world, annoName, annoValue, layoutDimNames)
   centroid.y = centroidData.y / centroidData.count;
 
   return centroid;
+
+
+  // Optimization from bruce, cut down on object creation/deletion
+  // const {x,y,count } = centroidData;
+  // x = x/count;
+  // y = y/count;
+  // return { x, y, count };
+
+  // let x = 0;
+  // let y = 0;
+  // let count = 0;
+  // for (let i =0, l = annoArray.length ; i < l; i += 1) {
+  //   if (...) {
+  //     x += layoutXarray[i];
+  //   }
+
+
+
+  // }
 }

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -36,11 +36,15 @@ const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
 
   for (let i = 0, len = annoArray.length; i < len; i += 1) {
     if (annoArray[i] === annoValue) {
-      hasFinite = Number.isFinite(annoArray[i]) ? true : hasFinite;
+      hasFinite =
+        Number.isFinite(layoutXArray[i]) || Number.isFinite(layoutYArray[i])
+          ? true
+          : hasFinite;
       centroidX.push(layoutXArray[i]);
       centroidY.push(layoutYArray[i]);
     }
   }
+
   if (hasFinite) {
     const medianX = quantile([0.5], Float64Array.from(centroidX));
     const medianY = quantile([0.5], Float64Array.from(centroidY));

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -1,3 +1,5 @@
+import quantile from "./quantile";
+
 /*
   Centroid coordinate calculation
 
@@ -28,4 +30,27 @@ const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
   return centroid;
 };
 
-export default calcMeanCentroid;
+const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
+  const centroidX = [];
+  const centroidY = [];
+  const annoArray = world.obsAnnotations.col(annoName).asArray();
+  const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
+  const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
+
+  for (let i = 0, len = annoArray.length; i < len; i += 1) {
+    if (annoArray[i] === annoValue) {
+      centroidX.push(layoutXArray[i])
+      centroidY.push(layoutYArray[i])
+    }
+  }
+
+  const medianX = quantile([.5], Float64Array.from(centroidX));
+  const medianY = quantile([.5], Float64Array.from(centroidY));
+  const mass = centroidX.length / world.nObs;
+
+  return[medianX, medianY, mass]
+}
+
+
+
+export default calcMedianCentroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -4,50 +4,28 @@
 
 */
 
-export default function calcCentroid(
-  world,
-  annoName,
-  annoValue,
-  layoutDimNames
-) {
+
+const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
+  const centroid = [0, 0, 0];
   const annoArray = world.obsAnnotations.col(annoName).asArray();
   const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
   const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
 
-  const centroidData = annoArray.reduce(
-    (data, val, i) => {
-      if (val === annoValue) {
-        data.x += layoutXArray[i];
-        data.y += layoutYArray[i];
-        data.count += 1;
-      }
-      return data;
-    },
-    { x: 0, y: 0, count: 0 }
-  );
+  for (let i = 0, len = annoArray.length; i < len; i += 1) {
+    if (annoArray[i] === annoValue) {
+      centroid[0] += layoutXArray[i];
+      centroid[1] += layoutYArray[i];
+      centroid[2] += 1;
+    }
+  }
 
-  const centroid = [];
-
-  centroid[0] = centroidData.x / centroidData.count;
-  centroid[1] = centroidData.y / centroidData.count;
-  centroid[2] = centroidData.count / world.nObs;
-  
+  if (centroid[2] !== 0) {
+    centroid[0] /= centroid[2];
+    centroid[1] /= centroid[2];
+    centroid[2] /= world.nObs;
+  }
 
   return centroid;
+};
 
-  // Optimization from bruce, cut down on object creation/deletion
-  // const {x,y,count } = centroidData;
-  // x = x/count;
-  // y = y/count;
-  // return { x, y, count };
-
-  // let x = 0;
-  // let y = 0;
-  // let count = 0;
-  // for (let i =0, l = annoArray.length ; i < l; i += 1) {
-  //   if (...) {
-  //     x += layoutXarray[i];
-  //   }
-
-  // }
-}
+export default calcMeanCentroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -46,9 +46,8 @@ const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
 
   const medianX = quantile([.5], Float64Array.from(centroidX));
   const medianY = quantile([.5], Float64Array.from(centroidY));
-  const mass = centroidX.length / world.nObs;
 
-  return[medianX, medianY, mass]
+  return[medianX, medianY]
 }
 
 

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -4,7 +4,8 @@ import quantile from "./quantile";
   Centroid coordinate calculation
 */
 const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
-  const centroid = [0, 0, 0];
+  const centroid = [0, 0];
+  let counter = 0;
   const annoArray = world.obsAnnotations.col(annoName).asArray();
   const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
   const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
@@ -13,14 +14,13 @@ const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
     if (annoArray[i] === annoValue) {
       centroid[0] += layoutXArray[i];
       centroid[1] += layoutYArray[i];
-      centroid[2] += 1;
+      counter += 1;
     }
   }
 
   if (centroid[2] !== 0) {
-    centroid[0] /= centroid[2];
-    centroid[1] /= centroid[2];
-    centroid[2] /= world.nObs;
+    centroid[0] /= counter;
+    centroid[1] /= counter;
   }
 
   return centroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -26,12 +26,12 @@ export default function calcCentroid(
     { x: 0, y: 0, count: 0 }
   );
 
-  console.log(centroidData.count);
-
-  const centroid = [0, 0, centroidData.count];
+  const centroid = [];
 
   centroid[0] = centroidData.x / centroidData.count;
   centroid[1] = centroidData.y / centroidData.count;
+  centroid[2] = centroidData.count / world.nObs;
+  
 
   return centroid;
 

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -28,21 +28,27 @@ const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
 const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {
   const centroidX = [];
   const centroidY = [];
+  let hasFinite = false;
+
   const annoArray = world.obsAnnotations.col(annoName).asArray();
   const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
   const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
 
   for (let i = 0, len = annoArray.length; i < len; i += 1) {
     if (annoArray[i] === annoValue) {
+      hasFinite = Number.isFinite(annoArray[i]) ? true : hasFinite;
       centroidX.push(layoutXArray[i]);
       centroidY.push(layoutYArray[i]);
     }
   }
+  if (hasFinite) {
+    const medianX = quantile([0.5], Float64Array.from(centroidX));
+    const medianY = quantile([0.5], Float64Array.from(centroidY));
 
-  const medianX = quantile([0.5], Float64Array.from(centroidX));
-  const medianY = quantile([0.5], Float64Array.from(centroidY));
+    return [medianX, medianY];
+  }
 
-  return [medianX, medianY];
+  return [0.5, 0.5];
 };
 
 export default calcMedianCentroid;

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -19,10 +19,10 @@ export default function calcCentroid(world, annoName, annoValue, layoutDimNames)
   }, { x: 0, y: 0, count: 0 });
   
 
-  const centroid = { x: 0, y: 0 };
+  const centroid = [0, 0];
 
-  centroid.x = centroidData.x / centroidData.count;
-  centroid.y = centroidData.y / centroidData.count;
+  centroid[0] = centroidData.x / centroidData.count;
+  centroid[1] = centroidData.y / centroidData.count;
 
   return centroid;
 

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -1,0 +1,27 @@
+/*
+  Centroid coordinate calculation
+
+
+*/
+
+export default function calcCentroid(world, annoName, annoValue, layoutDimNames) {
+  const annoArray = world.obsAnnotations.col(annoName).asArray();
+  const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
+  const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
+
+  const centroidData = annoArray.reduce((data, val, i) => {
+    if(val === annoValue) {
+      data.x += layoutXArray[i];
+      data.y += layoutYArray[i];
+      data.count += 1;
+    }
+    return data;
+  }, { x: 0, y: 0, count: 0 });
+
+  const centroid = { x: 0, y: 0 };
+
+  centroid.x = centroidData.x / centroidData.count;
+  centroid.y = centroidData.y / centroidData.count;
+
+  return centroid;
+}

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -4,28 +4,36 @@
 
 */
 
-export default function calcCentroid(world, annoName, annoValue, layoutDimNames) {
+export default function calcCentroid(
+  world,
+  annoName,
+  annoValue,
+  layoutDimNames
+) {
   const annoArray = world.obsAnnotations.col(annoName).asArray();
   const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
   const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
 
-  const centroidData = annoArray.reduce((data, val, i) => {
-    if(val === annoValue) {
-      data.x += layoutXArray[i];
-      data.y += layoutYArray[i];
-      data.count += 1;
-    }
-    return data;
-  }, { x: 0, y: 0, count: 0 });
-  
+  const centroidData = annoArray.reduce(
+    (data, val, i) => {
+      if (val === annoValue) {
+        data.x += layoutXArray[i];
+        data.y += layoutYArray[i];
+        data.count += 1;
+      }
+      return data;
+    },
+    { x: 0, y: 0, count: 0 }
+  );
 
-  const centroid = [0, 0];
+  console.log(centroidData.count);
+
+  const centroid = [0, 0, centroidData.count];
 
   centroid[0] = centroidData.x / centroidData.count;
   centroid[1] = centroidData.y / centroidData.count;
 
   return centroid;
-
 
   // Optimization from bruce, cut down on object creation/deletion
   // const {x,y,count } = centroidData;
@@ -40,8 +48,6 @@ export default function calcCentroid(world, annoName, annoValue, layoutDimNames)
   //   if (...) {
   //     x += layoutXarray[i];
   //   }
-
-
 
   // }
 }

--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -4,26 +4,25 @@ import quantile from "./quantile";
   Centroid coordinate calculation
 */
 const calcMeanCentroid = (world, annoName, annoValue, layoutDimNames) => {
-  const centroid = [0, 0];
-  let counter = 0;
+  const centroid = { x: 0, y: 0, size: 0 };
   const annoArray = world.obsAnnotations.col(annoName).asArray();
   const layoutXArray = world.obsLayout.col(layoutDimNames[0]).asArray();
   const layoutYArray = world.obsLayout.col(layoutDimNames[1]).asArray();
 
   for (let i = 0, len = annoArray.length; i < len; i += 1) {
     if (annoArray[i] === annoValue) {
-      centroid[0] += layoutXArray[i];
-      centroid[1] += layoutYArray[i];
-      counter += 1;
+      centroid.x += layoutXArray[i];
+      centroid.y += layoutYArray[i];
+      centroid.size += 1;
     }
   }
 
   if (centroid[2] !== 0) {
-    centroid[0] /= counter;
-    centroid[1] /= counter;
+    centroid.x /= centroid.size;
+    centroid.y /= centroid.size;
   }
 
-  return centroid;
+  return [centroid.x, centroid.y];
 };
 
 const calcMedianCentroid = (world, annoName, annoValue, layoutDimNames) => {


### PR DESCRIPTION
_EDIT: Some additional features were removed from this PR to prevent feature creep. See #811_

Categorical data is currently hard to parse when there is a wide variety of labels.  By implementing centroid labels for each category label, clusters will be more easily distinguished. The label location is calculated using the median x and y values of all relevant cells. 

This PR implements the following changes:
- A new reducer which holds:
  - The selected metadata and category values
  - The XY position of the centroid
- A util which calculates the centroid given a category value
- An additional SVG layer on top of the existing lasso layer and necessary refactors to distinguish one another
- A file for setting up and drawing the centroid label

Fixes #595 