### PR TITLE
[EASY] fix max-category-items

### DIFF
--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -63,7 +63,7 @@ class ConfigAPI(Resource):
                     "dataset": current_app.config["DATASET_TITLE"],
                 },
                 "parameters": {
-                    "max_category_items": current_app.data.config["max_category_items"]
+                    "max-category-items": current_app.data.config["max_category_items"]
                 },
                 "library_versions": {
                     "scanpy": pkg_resources.get_distribution("scanpy").version,

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -65,7 +65,7 @@ BIG_FILE_SIZE_THRESHOLD = 100 * 2**20  # 100MB
     default=100,
     metavar="",
     show_default=True,
-    help="Limits the number of categorical annotation items displayed.",
+    help="Categories with more distinct values than this will not be displayed.",
 )
 @click.option(
     "--diffexp-lfc-cutoff",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -62,7 +62,7 @@ BIG_FILE_SIZE_THRESHOLD = 100 * 2**20  # 100MB
 @click.option("--host", default="127.0.0.1", help="Host IP address")
 @click.option(
     "--max-category-items",
-    default=100,
+    default=1000,
     metavar="",
     show_default=True,
     help="Categories with more distinct values than this will not be displayed.",

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -78,8 +78,6 @@ class EngineTest(unittest.TestCase):
     def test_schema(self):
         with open(path.join(path.dirname(__file__), "schema.json")) as fh:
             schema = json.load(fh)
-            print(schema)
-            print(self.data.schema)
             self.assertEqual(self.data.schema, schema)
 
     def test_schema_produces_error(self):


### PR DESCRIPTION
Fixes #812 

The `--max-category-items` flag has never actually worked. On the back-end it was called "max_category_items" and on the front end it was "max-category-items" and since it was set using the spread operator, the user specified value, never overrode the client default. I renamed it on the backend for minimum code changes.