### PR TITLE
increase readability of centroid labels

### DIFF
--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -95,7 +95,8 @@ class CategoryValue extends React.Component {
         style={{
           display: "flex",
           alignItems: "baseline",
-          justifyContent: "space-between"
+          justifyContent: "space-between",
+          padding: "4px 7px"
         }}
         data-testclass="categorical-row"
         onMouseEnter={this.handleMouseEnter}

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -1,6 +1,7 @@
 // jshint esversion: 6
 import { connect } from "react-redux";
 import React from "react";
+import { Classes } from "@blueprintjs/core";
 import Occupancy from "./occupancy";
 import { countCategoryValues2D } from "../../util/stateManager/worldUtil";
 import * as globals from "../../globals";
@@ -99,6 +100,7 @@ class CategoryValue extends React.Component {
         data-testclass="categorical-row"
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseExit}
+        className={Classes.MENU_ITEM}
       >
         <div
           style={{
@@ -110,7 +112,12 @@ class CategoryValue extends React.Component {
             justifyContent: "space-between"
           }}
         >
-          <label className="bp3-control bp3-checkbox">
+          <label
+            className="bp3-control bp3-checkbox"
+            style={{
+              margin: 0
+            }}
+          >
             <input
               onChange={selected ? this.toggleOff : this.toggleOn}
               data-testclass="categorical-value-select"

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -13,10 +13,9 @@ export default (responsive, graphPaddingRight, xy, text, colorBy) => {
     .attr("width", containerWidth)
     .attr("height", responsive.height)
     .attr("class", `${styles.graphSVG}`)
+    /* For now I'm going to put centroid z-index at 998 and lasso on 999 */
     .style("z-index", 998)
     .style("pointer-events", "none");
-  //  TODO: Create own styles, ask Colin for an explanation on the css
-  // For now I'm going to put centroid z-index at 998 and lasso on 999
 
   const label = svg
     .append("g")
@@ -28,7 +27,8 @@ export default (responsive, graphPaddingRight, xy, text, colorBy) => {
     .attr("d", IconSvgPaths20.locate[0])
     .attr("width", 90)
     .attr("height", 90)
-    .attr("fill", colorBy ? "black" : "rgb(32, 178, 212)");
+    .attr("fill", colorBy ? "black" : "rgb(32, 178, 212)")
+    .attr("transform", "scale(3)");
 
   return svg;
 };

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,5 +1,6 @@
 import * as d3 from "d3";
 import styles from "./graph.css";
+import { IconSvgPaths20 } from "@blueprintjs/icons";
 
 export default (responsive, graphPaddingRight, xy, text, colorBy) => {
   const containerWidth = responsive.width - graphPaddingRight;
@@ -22,13 +23,12 @@ export default (responsive, graphPaddingRight, xy, text, colorBy) => {
     .attr("transform", `translate(${xy[0]}, ${xy[1]})`);
 
   label
-    .append("text")
+    .append("path")
     .attr("text-anchor", "middle")
-    .text(text)
-    .style("font-family", "Roboto Condensed")
-    .style("font-size", "18px")
-    .style("font-weight", "700")
-    .style("fill", colorBy ? "black" : "rgb(32, 178, 212)");
+    .attr("d", IconSvgPaths20.locate[0])
+    .attr("width", 90)
+    .attr("height", 90)
+    .attr("fill", colorBy ? "black" : "rgb(32, 178, 212)");
 
   return svg;
 };

--- a/client/src/components/graph/setupCentroidSVG.js
+++ b/client/src/components/graph/setupCentroidSVG.js
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
-import styles from "./graph.css";
 import { IconSvgPaths20 } from "@blueprintjs/icons";
+import styles from "./graph.css";
 
 export default (responsive, graphPaddingRight, xy, text, colorBy) => {
   const containerWidth = responsive.width - graphPaddingRight;


### PR DESCRIPTION
Increases the readability of the labels by removing the text label of the graph and replacing it with a target icon.  Also signifies the displayed label by a hover effect on the left sidebar.

This PR implements the following changes:

* Styling changes to the `value` component
* Removal of the text label in `setupCentroidSVG` in favor of an SVG icon

_Note: This addresses, but does not fully close. #811_