### PR TITLE
[EASY] removed --diffexp cli param

### DIFF
--- a/server/app/driver/driver.py
+++ b/server/app/driver/driver.py
@@ -28,7 +28,6 @@ class CXGDriver(metaclass=ABCMeta):
     def _get_default_config():
         return {
             "layout": None,
-            "diffexp": None,
             "max_category_items": None,
             "diffexp_lfc_cutoff": None
         }
@@ -38,14 +37,12 @@ class CXGDriver(metaclass=ABCMeta):
         features = {
             "cluster": {"available": False},
             "layout": {"obs": {"available": False}, "var": {"available": False}},
-            "diffexp": {"available": False},
+            "diffexp": {"available": True, "interactiveLimit": 50000}
         }
         # TODO - Interactive limit should be generated from the actual available methods see GH issue #94
         if self.config["layout"]:
             # TODO handle "var" when gene layout becomes available
             features["layout"]["obs"] = {"available": True, "interactiveLimit": 50000}
-        if self.config["diffexp"]:
-            features["diffexp"] = {"available": True, "interactiveLimit": 50000}
         return features
 
     @abstractmethod

--- a/server/app/scanpy_engine/scanpy_engine.py
+++ b/server/app/scanpy_engine/scanpy_engine.py
@@ -43,7 +43,6 @@ class ScanpyEngine(CXGDriver):
     def _get_default_config():
         return {
             "layout": [],
-            "diffexp": "ttest",
             "max_category_items": 100,
             "obs_names": None,
             "var_names": None,

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -28,14 +28,6 @@ BIG_FILE_SIZE_THRESHOLD = 100 * 2**20  # 100MB
     show_default=True,
     help="Layout name, eg, 'umap'."
 )
-@click.option(
-    "--diffexp",
-    "-d",
-    type=click.Choice(["ttest"]),
-    default="ttest",
-    show_default=True,
-    help="Method for differential expression.",
-)
 @click.option("--title", "-t", help="Title to display (if omitted will use file name).", metavar="")
 @click.option(
     "--verbose",
@@ -83,7 +75,6 @@ BIG_FILE_SIZE_THRESHOLD = 100 * 2**20  # 100MB
 def launch(
         data,
         layout,
-        diffexp,
         title,
         verbose,
         debug,
@@ -181,7 +172,6 @@ security risk by including the --scripts flag. Make sure you trust the scripts t
 
     args = {
         "layout": layout,
-        "diffexp": diffexp,
         "max_category_items": max_category_items,
         "diffexp_lfc_cutoff": diffexp_lfc_cutoff,
         "obs_names": obs_names,

--- a/server/test/test_nan_scanpy_engine.py
+++ b/server/test/test_nan_scanpy_engine.py
@@ -13,7 +13,6 @@ class NaNTest(unittest.TestCase):
     def setUp(self):
         self.args = {
             "layout": ["umap"],
-            "diffexp": "ttest",
             "max_category_items": 100,
             "obs_names": None,
             "var_names": None,

--- a/server/test/test_scanpy_engine.py
+++ b/server/test/test_scanpy_engine.py
@@ -16,7 +16,6 @@ class EngineTest(unittest.TestCase):
     def setUp(self):
         args = {
             "layout": ["umap"],
-            "diffexp": "ttest",
             "max_category_items": 100,
             "obs_names": None,
             "var_names": None,

--- a/server/test/test_scanpy_engine_data_load.py
+++ b/server/test/test_scanpy_engine_data_load.py
@@ -16,7 +16,6 @@ class DataLoadEngineTest(unittest.TestCase):
     def test_delayed_load_args(self):
         args = {
             "layout": ["tsne"],
-            "diffexp": "ttest",
             "max_category_items": 1000,
             "obs_names": "foo",
             "var_names": "bar",


### PR DESCRIPTION
Fixes #823. Removes --diffexp from cli and config since it is not used.

This will help me when refactoring click params to support the gui app.