### PR TITLE
add point dilatation on hover

### DIFF
--- a/client/src/components/categorical/categorical.css
+++ b/client/src/components/categorical/categorical.css
@@ -1,0 +1,3 @@
+:local(.value):hover {
+  background: rgba(167, 182, 194, 0.3);
+}

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -97,8 +97,8 @@ class CategoryValue extends React.Component {
           justifyContent: "space-between"
         }}
         data-testclass="categorical-row"
-        onMouseEnter={null /* this.handleMouseEnter */}
-        onMouseLeave={null /* this.handleMouseLeave */}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
       >
         <div
           style={{

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -101,6 +101,8 @@ class CategoryValue extends React.Component {
           justifyContent: "space-between",
           marginBottom: "2px"
         }}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseExit}
       >
         <div
           style={{
@@ -120,12 +122,14 @@ class CategoryValue extends React.Component {
               checked={selected}
               type="checkbox"
             />
-            <span className="bp3-control-indicator" />
+            <span
+              className="bp3-control-indicator"
+              onMouseEnter={this.handleMouseExit}
+              onMouseLeave={this.handleMouseEnter}
+            />
             <span
               data-testid={`categorical-value-${metadataField}-${displayString}`}
               data-testclass="categorical-value"
-              onMouseEnter={this.handleMouseEnter}
-              onMouseLeave={this.handleMouseExit}
             >
               {displayString}
             </span>

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -100,7 +100,8 @@ class CategoryValue extends React.Component {
           padding: "4px 7px",
           display: "flex",
           alignItems: "baseline",
-          justifyContent: "space-between"
+          justifyContent: "space-between",
+          marginBottom: "2px"
         }}
       >
         <div

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -15,7 +15,6 @@ import styles from "./categorical.css";
 }))
 class CategoryValue extends React.Component {
   toggleOff = () => {
-    this.handleMouseExit();
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter deselect",
@@ -25,7 +24,6 @@ class CategoryValue extends React.Component {
   };
 
   toggleOn = () => {
-    this.handleMouseExit();
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter select",
@@ -96,8 +94,6 @@ class CategoryValue extends React.Component {
         key={i}
         className={styles.value}
         data-testclass="categorical-row"
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseExit}
         style={{
           padding: "4px 7px",
           display: "flex",
@@ -128,6 +124,8 @@ class CategoryValue extends React.Component {
             <span
               data-testid={`categorical-value-${metadataField}-${displayString}`}
               data-testclass="categorical-value"
+              onMouseEnter={this.handleMouseEnter}
+              onMouseLeave={this.handleMouseExit}
             >
               {displayString}
             </span>

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -99,7 +99,8 @@ class CategoryValue extends React.Component {
           display: "flex",
           alignItems: "baseline",
           justifyContent: "space-between",
-          marginBottom: "2px"
+          marginBottom: "2px",
+          borderRadius: "2px"
         }}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseExit}

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -15,6 +15,7 @@ import styles from "./categorical.css";
 }))
 class CategoryValue extends React.Component {
   toggleOff = () => {
+    this.handleMouseExit();
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter deselect",
@@ -24,6 +25,7 @@ class CategoryValue extends React.Component {
   };
 
   toggleOn = () => {
+    this.handleMouseExit();
     const { dispatch, metadataField, categoryIndex } = this.props;
     dispatch({
       type: "categorical metadata filter select",

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -4,6 +4,7 @@ import React from "react";
 import Occupancy from "./occupancy";
 import { countCategoryValues2D } from "../../util/stateManager/worldUtil";
 import * as globals from "../../globals";
+import styles from "./categorical.css";
 
 @connect(state => ({
   categoricalSelection: state.categoricalSelection,
@@ -91,14 +92,16 @@ class CategoryValue extends React.Component {
     return (
       <div
         key={i}
+        className={styles.value}
+        data-testclass="categorical-row"
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseExit}
         style={{
+          padding: "4px 7px",
           display: "flex",
           alignItems: "baseline",
           justifyContent: "space-between"
         }}
-        data-testclass="categorical-row"
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
       >
         <div
           style={{
@@ -110,7 +113,7 @@ class CategoryValue extends React.Component {
             justifyContent: "space-between"
           }}
         >
-          <label className="bp3-control bp3-checkbox">
+          <label className="bp3-control bp3-checkbox" style={{ margin: 0 }}>
             <input
               onChange={selected ? this.toggleOff : this.toggleOn}
               data-testclass="categorical-value-select"

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -298,15 +298,13 @@ class Graph extends React.Component {
       stateChanges = { ...stateChanges, centroidSVG: newCentroidSVG };
     };
 
-    // SVG creation is disabled for now
-
+    // Centroid SVG creation is disabled for now but should go into the first and third cases if enabled
     if (
       prevProps.responsive.height !== responsive.height ||
       prevProps.responsive.width !== responsive.width
     ) {
       // If the window size has changed we want to recreate all SVGs
       createToolSVG();
-      // createCentroidSVG();
     } else if (
       (responsive.height && responsive.width && !toolSVG) ||
       selectionTool !== prevProps.selectionTool ||
@@ -319,7 +317,6 @@ class Graph extends React.Component {
       (responsive.height && responsive.width && !centroidSVG)
     ) {
       // First time for centroid or label change
-      // createCentroidSVG();
     }
 
     /*

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -52,30 +52,27 @@ class Graph extends React.Component {
     return colors;
   });
 
-  computePointSizes = memoize((len, crossfilter) => {
-    /*
+  computePointSizes = memoize(
+    (len, crossfilter, metadataField, categoryField) => {
+      /*
     compute webgl dot size for each point
     */
-    console.log("call");
 
-    const centroidLabel = null;
-    const sizes = new Float32Array(len);
-    crossfilter.fillByIsSelected(sizes, 4, 0.2);
-    if (centroidLabel?.metadataField && centroidLabel?.categoryIndex) {
-      console.log("Dilate");
+      const sizes = new Float32Array(len);
+      crossfilter.fillByIsSelected(sizes, 4, 0.2);
 
-      const valuesArr = crossfilter.data
-        .col(centroidLabel.metadataField)
-        .asArray();
+      if (metadataField && categoryField) {
+        const valuesArr = crossfilter.data.col(metadataField).asArray();
 
-      for (let i = 0; i < len; i += 1) {
-        if (valuesArr[i] === centroidLabel.categoryField) {
-          sizes[i] = 10;
+        for (let i = 0; i < len; i += 1) {
+          if (valuesArr[i] === categoryField) {
+            sizes[i] = 10;
+          }
         }
       }
+      return sizes;
     }
-    return sizes;
-  });
+  );
 
   constructor(props) {
     super(props);
@@ -219,7 +216,13 @@ class Graph extends React.Component {
       }
 
       /* sizes for each point */
-      const newSizes = this.computePointSizes(nObs, crossfilter, centroidLabel);
+      const { metadataField, categoryField } = centroidLabel;
+      const newSizes = this.computePointSizes(
+        nObs,
+        crossfilter,
+        metadataField,
+        categoryField
+      );
       if (renderCache.sizes !== newSizes) {
         /* update our cache & GL if the buffer changes */
         renderCache.size = newSizes;

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -56,8 +56,24 @@ class Graph extends React.Component {
     /*
     compute webgl dot size for each point
     */
+    console.log("call");
+
+    const centroidLabel = null;
     const sizes = new Float32Array(len);
     crossfilter.fillByIsSelected(sizes, 4, 0.2);
+    if (centroidLabel?.metadataField && centroidLabel?.categoryIndex) {
+      console.log("Dilate");
+
+      const valuesArr = crossfilter.data
+        .col(centroidLabel.metadataField)
+        .asArray();
+
+      for (let i = 0; i < len; i += 1) {
+        if (valuesArr[i] === centroidLabel.categoryField) {
+          sizes[i] = 10;
+        }
+      }
+    }
     return sizes;
   });
 
@@ -203,7 +219,7 @@ class Graph extends React.Component {
       }
 
       /* sizes for each point */
-      const newSizes = this.computePointSizes(nObs, crossfilter);
+      const newSizes = this.computePointSizes(nObs, crossfilter, centroidLabel);
       if (renderCache.sizes !== newSizes) {
         /* update our cache & GL if the buffer changes */
         renderCache.size = newSizes;

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -298,13 +298,15 @@ class Graph extends React.Component {
       stateChanges = { ...stateChanges, centroidSVG: newCentroidSVG };
     };
 
+    // SVG creation is disabled for now
+
     if (
       prevProps.responsive.height !== responsive.height ||
       prevProps.responsive.width !== responsive.width
     ) {
       // If the window size has changed we want to recreate all SVGs
       createToolSVG();
-      createCentroidSVG();
+      // createCentroidSVG();
     } else if (
       (responsive.height && responsive.width && !toolSVG) ||
       selectionTool !== prevProps.selectionTool ||
@@ -317,7 +319,7 @@ class Graph extends React.Component {
       (responsive.height && responsive.width && !centroidSVG)
     ) {
       // First time for centroid or label change
-      createCentroidSVG();
+      // createCentroidSVG();
     }
 
     /*


### PR DESCRIPTION
This PR slightly re-enables centroid labels, effectively undoing #833 for #809.  It also features graph point dilation on hover of category fields.  The state of centroid labels is that they are being computed but not shown.  This is because the centroid logic feeds into the point dilation.

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/8716829/60930661-5606d700-a26b-11e9-9d3e-2a39b99fc13d.gif)
----
This PR implements the following changes:
- In the `value` component
  - Removed the comments added in #809 to enable #833
  -  Add styling to aid hover effect
  - Inverse hover actions on checkbox (hover on resets centroid state, hover off adds it)
- In `categorical.css`
  - Add hover psuedoelement styling
- In the `graph` component
  - Add functionality to `computePointSizes()` to size by hovered category field in addition to selection
 - Remove centroid labels
---
This PR will close #811 