### PR TITLE
reset colorAccessor and colorMode if colored diffexp gene is removed

### DIFF
--- a/client/src/reducers/colors.js
+++ b/client/src/reducers/colors.js
@@ -1,4 +1,4 @@
-import { ColorHelpers as CH } from "../util/stateManager";
+import { ColorHelpers } from "../util/stateManager";
 
 const ColorsReducer = (
   state = {
@@ -17,7 +17,7 @@ const ColorsReducer = (
       const { world } = nextSharedState;
       const colorMode = null;
       const colorAccessor = null;
-      const { rgb, scale } = CH.createColors(world, colorMode);
+      const { rgb, scale } = ColorHelpers.createColors(world, colorMode);
       return {
         ...state,
         colorAccessor,
@@ -30,7 +30,7 @@ const ColorsReducer = (
     case "set clip quantiles":
     case "set World to current selection": {
       const { world: prevWorld, controls: prevControls } = prevSharedState;
-      const resetColorState = CH.checkIfColorByDiffexpAndResetColors(
+      const resetColorState = ColorHelpers.checkIfColorByDiffexpAndResetColors(
         prevControls,
         state,
         prevWorld
@@ -41,7 +41,11 @@ const ColorsReducer = (
 
       const { colorMode, colorAccessor } = state;
       const { world } = nextSharedState;
-      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
+      const { rgb, scale } = ColorHelpers.createColors(
+        world,
+        colorMode,
+        colorAccessor
+      );
       return {
         ...state,
         rgb,
@@ -52,7 +56,7 @@ const ColorsReducer = (
     case "reset colorscale": {
       return {
         ...state,
-        ...CH.resetColors(prevSharedState.world)
+        ...ColorHelpers.resetColors(prevSharedState.world)
       };
     }
 
@@ -67,7 +71,11 @@ const ColorsReducer = (
       const colorMode = !resetCurrent ? action.type : null;
       const colorAccessor = !resetCurrent ? action.colorAccessor : null;
 
-      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
+      const { rgb, scale } = ColorHelpers.createColors(
+        world,
+        colorMode,
+        colorAccessor
+      );
       return {
         ...state,
         colorMode,
@@ -86,7 +94,11 @@ const ColorsReducer = (
       const colorMode = !resetCurrent ? action.type : null;
       const colorAccessor = !resetCurrent ? action.gene : null;
 
-      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
+      const { rgb, scale } = ColorHelpers.createColors(
+        world,
+        colorMode,
+        colorAccessor
+      );
       return {
         ...state,
         colorMode,
@@ -98,7 +110,7 @@ const ColorsReducer = (
 
     case "clear differential expression": {
       const { world: prevWorld, controls: prevControls } = prevSharedState;
-      const resetColorState = CH.checkIfColorByDiffexpAndResetColors(
+      const resetColorState = ColorHelpers.checkIfColorByDiffexpAndResetColors(
         prevControls,
         state,
         prevWorld

--- a/client/src/reducers/colors.js
+++ b/client/src/reducers/colors.js
@@ -1,5 +1,17 @@
 import { createColors } from "../util/stateManager";
 
+const resetColors = (prevSharedState, state) => {
+  const { world } = prevSharedState;
+  const { rgb, scale } = createColors(world);
+  return {
+    ...state,
+    colorMode: null,
+    colorAccessor: null,
+    rgb,
+    scale
+  };
+};
+
 const ColorsReducer = (
   state = {
     colorMode: null,
@@ -40,15 +52,7 @@ const ColorsReducer = (
     }
 
     case "reset colorscale": {
-      const { world } = prevSharedState;
-      const { rgb, scale } = createColors(world);
-      return {
-        ...state,
-        colorMode: null,
-        colorAccessor: null,
-        rgb,
-        scale
-      };
+      return resetColors(prevSharedState, state);
     }
 
     case "color by categorical metadata":
@@ -89,6 +93,13 @@ const ColorsReducer = (
         rgb,
         scale
       };
+    }
+
+    case "clear differential expression": {
+      const { controls } = prevSharedState;
+
+      if (!controls.diffexpGenes.includes(state.colorAccessor)) return state;
+      return resetColors(prevSharedState, state);
     }
 
     default: {

--- a/client/src/reducers/colors.js
+++ b/client/src/reducers/colors.js
@@ -1,4 +1,4 @@
-import { ColorHelpers } from "../util/stateManager";
+import { ColorHelpers as CH } from "../util/stateManager";
 
 const ColorsReducer = (
   state = {
@@ -17,7 +17,7 @@ const ColorsReducer = (
       const { world } = nextSharedState;
       const colorMode = null;
       const colorAccessor = null;
-      const { rgb, scale } = ColorHelpers.createColors(world, colorMode);
+      const { rgb, scale } = CH.createColors(world, colorMode);
       return {
         ...state,
         colorAccessor,
@@ -30,7 +30,7 @@ const ColorsReducer = (
     case "set clip quantiles":
     case "set World to current selection": {
       const { world: prevWorld, controls: prevControls } = prevSharedState;
-      const resetColorState = ColorHelpers.checkIfColorByDiffexpAndResetColors(
+      const resetColorState = CH.checkIfColorByDiffexpAndResetColors(
         prevControls,
         state,
         prevWorld
@@ -41,11 +41,7 @@ const ColorsReducer = (
 
       const { colorMode, colorAccessor } = state;
       const { world } = nextSharedState;
-      const { rgb, scale } = ColorHelpers.createColors(
-        world,
-        colorMode,
-        colorAccessor
-      );
+      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
       return {
         ...state,
         rgb,
@@ -56,7 +52,7 @@ const ColorsReducer = (
     case "reset colorscale": {
       return {
         ...state,
-        ...ColorHelpers.resetColors(prevSharedState.world)
+        ...CH.resetColors(prevSharedState.world)
       };
     }
 
@@ -71,11 +67,7 @@ const ColorsReducer = (
       const colorMode = !resetCurrent ? action.type : null;
       const colorAccessor = !resetCurrent ? action.colorAccessor : null;
 
-      const { rgb, scale } = ColorHelpers.createColors(
-        world,
-        colorMode,
-        colorAccessor
-      );
+      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
       return {
         ...state,
         colorMode,
@@ -94,11 +86,7 @@ const ColorsReducer = (
       const colorMode = !resetCurrent ? action.type : null;
       const colorAccessor = !resetCurrent ? action.gene : null;
 
-      const { rgb, scale } = ColorHelpers.createColors(
-        world,
-        colorMode,
-        colorAccessor
-      );
+      const { rgb, scale } = CH.createColors(world, colorMode, colorAccessor);
       return {
         ...state,
         colorMode,
@@ -110,7 +98,7 @@ const ColorsReducer = (
 
     case "clear differential expression": {
       const { world: prevWorld, controls: prevControls } = prevSharedState;
-      const resetColorState = ColorHelpers.checkIfColorByDiffexpAndResetColors(
+      const resetColorState = CH.checkIfColorByDiffexpAndResetColors(
         prevControls,
         state,
         prevWorld

--- a/client/src/util/stateManager/colorHelpers.js
+++ b/client/src/util/stateManager/colorHelpers.js
@@ -126,3 +126,17 @@ export const resetColors = world => {
     scale
   };
 };
+
+export const checkIfColorByDiffexpAndResetColors = (
+  prevControls,
+  state,
+  prevWorld
+) => {
+  if (prevControls.diffexpGenes.includes(state.colorAccessor)) {
+    return {
+      ...state,
+      ...resetColors(prevWorld)
+    };
+  }
+  return null;
+};

--- a/client/src/util/stateManager/colorHelpers.js
+++ b/client/src/util/stateManager/colorHelpers.js
@@ -15,7 +15,7 @@ create new colors state object.   Paramters:
     "color by continuous metadata", "color by categorical metadata"
   -
 */
-function createColors(world, colorMode = null, colorAccessor = null) {
+export function createColors(world, colorMode = null, colorAccessor = null) {
   switch (colorMode) {
     case "color by categorical metadata": {
       return createColorsByCategoricalMetadata(world, colorAccessor);
@@ -117,4 +117,12 @@ function createColorsByExpression(world, accessor) {
   return { rgb, scale };
 }
 
-export default createColors;
+export const resetColors = world => {
+  const { rgb, scale } = createColors(world);
+  return {
+    colorMode: null,
+    colorAccessor: null,
+    rgb,
+    scale
+  };
+};

--- a/client/src/util/stateManager/index.js
+++ b/client/src/util/stateManager/index.js
@@ -14,7 +14,7 @@ This is all VERY tightly integrated with reducers and actions, and
 exists to support those concepts.
 */
 
-export { default as createColors } from "./colorHelpers";
+export * as ColorHelpers from "./colorHelpers";
 export * as Universe from "./universe";
 export * as World from "./world";
 export * as WorldUtil from "./worldUtil";


### PR DESCRIPTION
this pr adds the functionality of clearing `colorAccessor` and `colorMode` within the sharedState `color`

Behavior before merge:
1) User creates a diffexp 
1) colors by a gene exposed by diffexp
1) mini histograms appear and graph points are colored
1) user clears diffexp or makes selection world
1)  __colorScale still exists and is not reset__

Behavior after merge:
           5.  __colorScale is reset__

This PR implements the following changes:
* In the `colorHelpers` stateManger util:
  * Switched `createColors()` from default to named export
  * Created `resetColors` to reset state values to defaults
  * Created `checkIfColorByDiffexpAndResetColors` to check if colorAccessor is set to a diffexp gene and reset state values conditonaly
* In the stateManager util `index`:
   * Edited import/export to reflect default->named export change
* In the `colors` reducer:
   *  Various changes to reflect util changes
   * Utilize `checkIfColorByDiffexpAndResetColors` inside of `set World to current selection` action to reset colors if needed
   * Utilize `resetColors` in `reset colorscale` action
   * Create `clear differential expression` action to reset colors if needed