### PR TITLE
remove selection interaction from categorical value label

### DIFF
--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -131,19 +131,21 @@ class CategoryValue extends React.Component {
             justifyContent: "space-between"
           }}
         >
-          <label className="bp3-control bp3-checkbox" style={{ margin: 0 }}>
-            <input
-              onChange={selected ? this.toggleOff : this.toggleOn}
-              data-testclass="categorical-value-select"
-              data-testid={`categorical-value-select-${metadataField}-${displayString}`}
-              checked={selected}
-              type="checkbox"
-            />
-            <span
-              className="bp3-control-indicator"
-              onMouseEnter={this.handleMouseExit}
-              onMouseLeave={this.handleMouseEnter}
-            />
+          <div style={{ display: "flex" }}>
+            <label className="bp3-control bp3-checkbox" style={{ margin: 0 }}>
+              <input
+                onChange={selected ? this.toggleOff : this.toggleOn}
+                data-testclass="categorical-value-select"
+                data-testid={`categorical-value-select-${metadataField}-${displayString}`}
+                checked={selected}
+                type="checkbox"
+              />
+              <span
+                className="bp3-control-indicator"
+                onMouseEnter={this.handleMouseExit}
+                onMouseLeave={this.handleMouseEnter}
+              />
+            </label>
             <span
               data-testid={`categorical-value-${metadataField}-${displayString}`}
               data-testclass="categorical-value"
@@ -151,7 +153,7 @@ class CategoryValue extends React.Component {
             >
               {displayString}
             </span>
-          </label>
+          </div>
           <span style={{ flexShrink: 0 }}>
             {colorAccessor && !isColorBy ? (
               <Occupancy category={category} {...this.props} />


### PR DESCRIPTION
This PR make a quick change to remove the ability to select/un-select a categorical value by clicking on the value's name. This is done to preserve the hover action while also maintaining a visual response to selecting/unselecting on the graph.