### PR TITLE
correctly handle float columns which only contain NaN

### DIFF
--- a/client/src/components/continuous/continuous.js
+++ b/client/src/components/continuous/continuous.js
@@ -71,7 +71,10 @@ class Continuous extends React.Component {
 
               const summary = obsAnnotations.col(key).summarize();
               const nonFiniteExtent =
-                summary.min === undefined || summary.max === undefined;
+                summary.min === undefined ||
+                summary.max === undefined ||
+                Number.isNaN(summary.min) ||
+                Number.isNaN(summary.max);
               if (!summary.categorical && !nonFiniteExtent) {
                 zebra += 1;
                 return (


### PR DESCRIPTION
If an obs annotation contains *only* float NaNs, the main histogram will incorrectly attempt to render (generating console errors).   This change augments the brushable histogram rendering logic which skips any continuous metadata having a non-finite extent.