### PR TITLE
improve performance around category highlighting

### DIFF
--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -52,16 +52,27 @@ class Graph extends React.Component {
     return colors;
   });
 
+  computePointSizesFromCrossfilter = memoize((len, crossfilter) => {
+    const sizes = new Float32Array(len);
+    crossfilter.fillByIsSelected(sizes, 4, 0.2);
+
+    return sizes;
+  });
+
   computePointSizes = memoize(
     (len, crossfilter, metadataField, categoryField) => {
       /*
     compute webgl dot size for each point
     */
 
-      const sizes = new Float32Array(len);
-      crossfilter.fillByIsSelected(sizes, 4, 0.2);
+      const selectionSizes = this.computePointSizesFromCrossfilter(
+        len,
+        crossfilter
+      );
+      let sizes;
 
       if (metadataField && categoryField) {
+        sizes = selectionSizes.slice();
         const valuesArr = crossfilter.data.col(metadataField).asArray();
 
         for (let i = 0; i < len; i += 1) {
@@ -69,6 +80,8 @@ class Graph extends React.Component {
             sizes[i] = 10;
           }
         }
+      } else {
+        sizes = selectionSizes;
       }
       return sizes;
     }

--- a/client/src/reducers/centroidLabel.js
+++ b/client/src/reducers/centroidLabel.js
@@ -19,12 +19,12 @@ const CentroidLabel = (state = initialState, action, sharedNextState) => {
         metadataField,
         categoryIndex,
         categoryField,
-        centroidXY: calcCentroid(
+        centroidXY: null /* calcCentroid(  This function call is computationally heavy and also leading to large GC. Before reimplementation, look into optimization and memoization
           world,
           metadataField,
           categoryField,
           layoutChoice.currentDimNames
-        )
+        ) */
       };
 
     case "category value mouse hover end":


### PR DESCRIPTION
There were a few performance issues with category value highlighting on 1e6 cell databases.
1. The centroid util is unperformant and unused
2. There was unnecessary recalculation of point sizes from crossfilter

Solutions:
1. Comment out centroid util function call
2. Create a separate, memoized function for computing point sizes based off of the crossfilter