### PR TITLE
[EASY] add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > an interactive explorer for single-cell transcriptomics data
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3338548.svg)](https://doi.org/10.5281/zenodo.3338548)
+[![DOI](https://zenodo.org/badge/105615409.svg)](https://zenodo.org/badge/latestdoi/105615409)
 
 [![PyPI](https://img.shields.io/pypi/v/cellxgene)](https://pypi.org/project/cellxgene/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)](https://pypistats.org/packages/cellxgene)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > an interactive explorer for single-cell transcriptomics data
 
-[![DOI](https://zenodo.org/badge/105615409.svg)](https://zenodo.org/badge/latestdoi/105615409)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3338548.svg)](https://doi.org/10.5281/zenodo.3338548)
+![PyPI](https://img.shields.io/pypi/v/cellxgene) ![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)
+![GitHub last commit](https://img.shields.io/github/last-commit/chanzuckerberg/cellxgene)
 
 _cellxgene_ (pronounced "sell-by-jean") is an interactive data explorer for single-cell transcriptomics datasets, such as those coming from the [Human Cell Atlas](https://humancellatlas.org). Leveraging modern web development techniques to enable fast visualizations of at least 1 million cells, we hope to enable biologists and computational researchers to explore their data, and to demonstrate general, scalable, and reusable patterns for scientific data visualization.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 > an interactive explorer for single-cell transcriptomics data
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3338548.svg)](https://doi.org/10.5281/zenodo.3338548)
-![PyPI](https://img.shields.io/pypi/v/cellxgene) ![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)
-![GitHub last commit](https://img.shields.io/github/last-commit/chanzuckerberg/cellxgene)
+
+[![PyPI](https://img.shields.io/pypi/v/cellxgene)](https://pypi.org/project/cellxgene/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)](https://pypistats.org/packages/cellxgene)
+
+[![GitHub last commit](https://img.shields.io/github/last-commit/chanzuckerberg/cellxgene)](https://github.com/chanzuckerberg/cellxgene/pulse)
 
 _cellxgene_ (pronounced "sell-by-jean") is an interactive data explorer for single-cell transcriptomics datasets, such as those coming from the [Human Cell Atlas](https://humancellatlas.org). Leveraging modern web development techniques to enable fast visualizations of at least 1 million cells, we hope to enable biologists and computational researchers to explore their data, and to demonstrate general, scalable, and reusable patterns for scientific data visualization.
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@ _cellxgene_ (pronounced "sell-by-jean") is an interactive data explorer for sing
 To install _cellxgene_ you need Python 3.6+. We recommend [installing _cellxgene_ into a conda or virtual environment.](https://chanzuckerberg.github.io/cellxgene/faq.html#how-do-i-create-a-python-36-environment-for-cellxgene)
 
 Install the package.
-``` bash
+
+```bash
 pip install cellxgene
 ```
 
 Download an example [anndata](https://anndata.readthedocs.io/en/latest/) file
 
-``` bash
+```bash
 curl -o pbmc3k.h5ad https://raw.githubusercontent.com/chanzuckerberg/cellxgene/master/example-dataset/pbmc3k.h5ad
 ```
 
 Launch _cellxgene_
-``` bash
+
+```bash
 cellxgene launch pbmc3k.h5ad --open
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 [![DOI](https://zenodo.org/badge/105615409.svg)](https://zenodo.org/badge/latestdoi/105615409)
 
-[![PyPI](https://img.shields.io/pypi/v/cellxgene)](https://pypi.org/project/cellxgene/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)](https://pypistats.org/packages/cellxgene)
+[![PyPI](https://img.shields.io/pypi/v/cellxgene)](https://pypi.org/project/cellxgene/) 
+
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/cellxgene)](https://pypistats.org/packages/cellxgene)
 
 [![GitHub last commit](https://img.shields.io/github/last-commit/chanzuckerberg/cellxgene)](https://github.com/chanzuckerberg/cellxgene/pulse)
 


### PR DESCRIPTION
I thought it would be a nice touch to add a few more badges to the readme

Changes:

- In `README.md`
   - Updated DOI badge to zenodo's latest badge
   - Added latest deployment version on PyPi with a link to PyPi
   - Added number of PyPi monthly downloads with link to pypistats.org
   - Added GitHub activity stats to show repo's freshness