### PR TITLE
[EASY] fix bad matplotlib library by installing scanpy first

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,10 +6,10 @@ Flask-Compress>=1.4.0
 Flask-Cors>=3.0.6
 Flask-RESTful>=0.3.6
 flatbuffers>=1.10.0
+scanpy>=1.3.7
 matplotlib>=2.2
 numpy>=1.15.2
 pandas>=0.23.1
-scanpy>=1.3.7
 scipy>=1.1.0
 scikit-learn>=0.19.1,!=0.20.0
 tables==3.5.1


### PR DESCRIPTION
Fixes #877 

I moved scanpy above matplotlib so that it controls the version installed. I feel that this is a better alternative than pinning our own matplotlib version which would then need to be updated when scanpy fixes their issue with newer matplotlib versions.  

We should make a point release when this gets merged. Installation of cellxgene is currently broken.