### PR TITLE
[Merge on next release] Document how to install cellxgene prepare

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -14,6 +14,14 @@ description: Data
 
 `cellxgene prepare` is not meant as a way to formally process or analyze your data. It's simply a utility for quickly wrangling your data into cellxgene-compatible format and computing a "vanilla" embedding so you can try out `cellxgene` and get a general sense of a dataset.
 
+#### How do I install `cellxgene prepare`?
+
+The `cellxgene prepare` command is an optional install that you can install alongside `cellxgene launch` by running
+
+```
+pip install cellxgene[prepare]
+```
+
 #### What input formats does it accept?
 
 Currently, we accept `h5ad` and `loom` files, as well as `10x` directories, and are hoping to accept more formats in the future.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ The output of `cellxgene prepare` is a h5ad file with your computed clusters and
 
 #### I have a directory of 10X-Genomics data with _mtx_ files and I've never used _scanpy_, can I use _cellxgene_?
 
-Yep! This should only take a couple steps. We'll assume your data is in a folder called `data/` and you've successfully installed `cellxgene` with the `louvain` packages as described above. Just run
+Yep! This should only take a couple steps. We'll assume your data is in a folder called `data/` and you've successfully installed `cellxgene` with the `prepare` packages as described above. Just run
 
 ```
 cellxgene prepare data/ --output=data-processed.h5ad --layout=umap
@@ -75,14 +75,6 @@ ENV_NAME=cellxgene
 python3.7 -m venv ${ENV_NAME}
 source ${ENV_NAME}/bin/activate
 pip install cellxgene
-```
-
-#### In my _prepare_ command I received the following error `Warning: louvain module is not installed, no clusters will be calculated. To fix this please install cellxgene with the optional feature louvain enabled`
-
-Louvain clustering requires additional dependencies, so we don't include them by default. For now, you need to specify that you want these packages by using
-
-```
-pip install cellxgene[louvain]
 ```
 
 #### I ran _prepare_ and I'm getting results that look unexpected

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,8 @@ Currently, you can go straight into `cellxgene launch` with your own analyzed da
 
 If your data is in a different format, and/or you still need to perform dimensionality reduction and clustering, `cellxgene` can do that for you with the `prepare` command. `cellxgene prepare` runs `scanpy` under the hood and can read in any format that is currently supported by `scanpy` (including mtx, loom, and more listed [here](https://scanpy.readthedocs.io/en/latest/api/index.html#reading)).
 
+To add `cellxgene prepare` to your cellxgene installation run `pip install cellxgene[prepare]`. 
+
 The output of `cellxgene prepare` is a h5ad file with your computed clusters and tsne/umap projections that can be used in `cellxgene launch`.
 
 #### I have a directory of 10X-Genomics data with _mtx_ files and I've never used _scanpy_, can I use _cellxgene_?

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,7 @@ The `launch` command assumes that the data is stored in the `.h5ad` format from 
 
 The `prepare` command is included to help you format your data. It uses `scanpy` under the hood. This is especially useful if you are starting with raw unanalyzed data and are unfamiliar with `scanpy`.
 
-To install cellxgene prepare alongside cellxgene launch
+To install `cellxgene prepare` alongside `cellxgene launch`
 
 ```
 pip install cellxgene[prepare]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,12 @@ The `launch` command assumes that the data is stored in the `.h5ad` format from 
 
 The `prepare` command is included to help you format your data. It uses `scanpy` under the hood. This is especially useful if you are starting with raw unanalyzed data and are unfamiliar with `scanpy`.
 
+To install cellxgene prepare alongside cellxgene launch
+
+```
+pip install cellxgene[prepare]
+```
+
 To prepare from an existing `.h5ad` file use
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,12 @@ To install `cellxgene prepare` alongside `cellxgene launch`
 pip install cellxgene[prepare]
 ```
 
+If the aforementioned optional package installation fails, you can also install these packages directly:
+
+```
+pip install scanpy>=1.3.7 python-igraph louvain>=0.6
+```
+
 To prepare from an existing `.h5ad` file use
 
 ```
@@ -82,17 +88,6 @@ To see all options call
 cellxgene prepare --help
 ```
 
-**Note**: `cellxgene prepare` will only perform `louvain` clustering if you have the `python-igraph` and `louvain` packages installed. To make sure they are installed alongside `cellxgene` use
-
-```
-pip install cellxgene[louvain]
-```
-
-If the aforementioned optional package installation fails, you can also install these packages directly:
-
-```
-pip install python-igraph louvain>=0.6
-```
 
 ## conda and virtual environments
 


### PR DESCRIPTION
(for after pr #887 merged)

Added documentation to various sites on how to install cellxgene prepare after separating the installation from the main pip install. 