### PR TITLE
merge louvain and prepare extra requires

### DIFF
--- a/server/cli/prepare.py
+++ b/server/cli/prepare.py
@@ -160,14 +160,7 @@ def prepare(
         sc.pp.neighbors(adata)
 
     def run_louvain(adata):
-        try:
-            sc.tl.louvain(adata)
-        except ModuleNotFoundError:
-            click.echo(
-                "\nWarning: louvain module is not installed, no clusters will be calculated. "
-                "To fix this please install cellxgene with the optional feature louvain enabled: "
-                "`pip install cellxgene[louvain]`"
-            )
+        sc.tl.louvain(adata)
 
     def run_layout(adata):
         if len(unique(adata.obs["louvain"].values)) < 10:

--- a/server/requirements-prepare.txt
+++ b/server/requirements-prepare.txt
@@ -1,1 +1,3 @@
 scanpy>=1.3.7
+python-igraph
+louvain>=0.6

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
     entry_points={"console_scripts": ["cellxgene = server.cli.cli:cli"]},
-    extras_require=dict(prepare=requirements_prepare, louvain=["python-igraph", "louvain>=0.6"], gui=["PySide2>=5.12.3", "cefpython3>=66", "requests"]),
+    extras_require=dict(prepare=requirements_prepare, gui=["PySide2>=5.12.3", "cefpython3>=66", "requests"]),
 )


### PR DESCRIPTION
So one opportunity I saw when separating the install of cellxgene prepare was the ability to merge the special install of the louvain package (currently separated from main install because of license incompatibility) with the special install of the prepare package. Installing `cellxgene[prepare]` should include everything you need to prepare your data.

The problem I'm trying to solve with this is that to get clusters when preparing your data currently you would have to run two special installs
```
pip install cellxgene[prepare]
pip install cellxgene[louvain]
```
OR
```
pip install cellxgene[prepare,louvain]
```

Instead we can merge the two so that a user just has to install
```
pip install cellxgene[prepare]
```


We have moved both to extra requires for different reasons but since they are part of the same command, IMHO they should be installed together. 