### PR TITLE
Add hover-over highlighting to the scatterplot

### DIFF
--- a/client/src/components/scatterplot/drawPointsRegl.js
+++ b/client/src/components/scatterplot/drawPointsRegl.js
@@ -26,8 +26,7 @@ export default function(regl) {
       bool isNaN, isSelected, isHighlight;
       getFlags(flag, isNaN, isSelected, isHighlight);
 
-      float size = isHighlight ? 8. : isSelected ? 4. : 1.;
-      gl_PointSize = size;
+      gl_PointSize = isHighlight ? 8. : isSelected ? 4. : 1.;
 
       float z = isNaN ? zBottom : (isHighlight ? zTop : zMiddle);
       vec3 xy = projection * vec3(position, 1.);


### PR DESCRIPTION
The main embedding viz has hover-over hightlighting for categorical metadata. This PR does the same for the expression scatterplot.

Fixes #892 

this PR also includes a small performance improvement to the graph component update loop.  It was unnecessarily recreating a JS function each time through the loop.   This is replaced by a single function created a component construction time.