### PR TITLE
Add configurable `about this dataset` links

### DIFF
--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -7,14 +7,25 @@ import Logo from "../framework/logo";
 @connect(state => ({
   responsive: state.responsive,
   datasetTitle: state.config?.displayNames?.dataset ?? "",
+  aboutLink: state.config?.links?.["about-dataset"],
   scatterplotXXaccessor: state.controls.scatterplotXXaccessor,
   scatterplotYYaccessor: state.controls.scatterplotYYaccessor
 }))
 class LeftSideBar extends React.Component {
   render() {
-    const { datasetTitle } = this.props;
+    const { datasetTitle, aboutLink } = this.props;
 
     const paddingToAvoidScrollBar = 15;
+
+    const displayTitle =
+      datasetTitle.length > globals.datasetTitleMaxCharacterCount
+        ? `${datasetTitle.substring(
+            0,
+            Math.floor(globals.datasetTitleMaxCharacterCount / 2)
+          )}…${datasetTitle.slice(
+            -Math.floor(globals.datasetTitleMaxCharacterCount / 2)
+          )}`
+        : datasetTitle;
 
     return (
       <div
@@ -69,14 +80,7 @@ class LeftSideBar extends React.Component {
           }}
           title={datasetTitle}
         >
-          {datasetTitle.length > globals.datasetTitleMaxCharacterCount
-            ? `${datasetTitle.substring(
-                0,
-                Math.floor(globals.datasetTitleMaxCharacterCount / 2)
-              )}…${datasetTitle.slice(
-                -Math.floor(globals.datasetTitleMaxCharacterCount / 2)
-              )}`
-            : datasetTitle}
+          {aboutLink ? <a href={aboutLink}>{displayTitle}</a> : displayTitle}
         </div>
       </div>
     );

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -7,13 +7,13 @@ import Logo from "../framework/logo";
 @connect(state => ({
   responsive: state.responsive,
   datasetTitle: state.config?.displayNames?.dataset ?? "",
-  aboutLink: state.config?.links?.["about-dataset"],
+  aboutURL: state.config?.links?.["about-dataset"],
   scatterplotXXaccessor: state.controls.scatterplotXXaccessor,
   scatterplotYYaccessor: state.controls.scatterplotYYaccessor
 }))
 class LeftSideBar extends React.Component {
   render() {
-    const { datasetTitle, aboutLink } = this.props;
+    const { datasetTitle, aboutURL } = this.props;
 
     const paddingToAvoidScrollBar = 15;
 
@@ -80,7 +80,7 @@ class LeftSideBar extends React.Component {
           }}
           title={datasetTitle}
         >
-          {aboutLink ? <a href={aboutLink}>{displayTitle}</a> : displayTitle}
+          {aboutURL ? <a href={aboutURL}>{displayTitle}</a> : displayTitle}
         </div>
       </div>
     );

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -38,7 +38,8 @@ import { tooltipHoverOpenDelay } from "../../globals";
   celllist2: state.differential.celllist2,
   libraryVersions: state.config?.library_versions, // eslint-disable-line camelcase
   undoDisabled: state["@@undoable/past"].length === 0,
-  redoDisabled: state["@@undoable/future"].length === 0
+  redoDisabled: state["@@undoable/future"].length === 0,
+  aboutLink: state.config?.links?.["about-dataset"]
 }))
 class MenuBar extends React.Component {
   static isValidDigitKeyEvent(e) {
@@ -267,7 +268,8 @@ class MenuBar extends React.Component {
       clipPercentileMin,
       clipPercentileMax,
       layoutChoice,
-      graphInteractionMode
+      graphInteractionMode,
+      aboutLink
     } = this.props;
     const { pendingClipPercentiles } = this.state;
 
@@ -473,7 +475,10 @@ class MenuBar extends React.Component {
           undoDisabled={undoDisabled}
           redoDisabled={redoDisabled}
         />
-        <InformationMenu libraryVersions={libraryVersions} />
+        <InformationMenu
+          libraryVersions={libraryVersions}
+          aboutLink={aboutLink}
+        />
       </div>
     );
   }

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -14,7 +14,7 @@ function InformationMenu(props) {
                 href={aboutLink}
                 target="_blank"
                 icon="info-sign"
-                text="About This Dataset"
+                text="About this dataset"
               />
             ) : (
               ""

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -3,12 +3,23 @@ import React from "react";
 import { Button, Popover, Menu, MenuItem, Position } from "@blueprintjs/core";
 
 function InformationMenu(props) {
-  const { libraryVersions } = props;
+  const { libraryVersions, aboutLink } = props;
   return (
     <div style={{ marginLeft: 10 }} className="bp3-button-group">
       <Popover
         content={
           <Menu>
+            {aboutLink ? (
+              <MenuItem
+                href={aboutLink}
+                target="_blank"
+                icon="info-sign"
+                text="About This Dataset"
+              />
+            ) : (
+              ""
+            )}
+
             <MenuItem
               href="https://chanzuckerberg.github.io/cellxgene/faq.html"
               target="_blank"

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -13,7 +13,7 @@ function InformationMenu(props) {
               <MenuItem
                 href={aboutLink}
                 target="_blank"
-                icon="info-sign"
+                icon="document-open"
                 text="About this dataset"
               />
             ) : (

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -15,7 +15,8 @@ export const configDefaults = {
   displayNames: {},
   parameters: {
     "max-category-items": 1000
-  }
+  },
+  links: {}
 };
 
 /* colors */

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -33,6 +33,6 @@ class Server:
         self.app.register_blueprint(resources.blueprint)
         self.app.add_url_rule("/", endpoint="index")
 
-    def attach_data(self, data, title="Demo"):
-        self.app.config.update(DATASET_TITLE=title)
+    def attach_data(self, data, title="Demo", about=""):
+        self.app.config.update(DATASET_TITLE=title, ABOUT_DATASET=about)
         self.app.data = data

--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -65,6 +65,9 @@ class ConfigAPI(Resource):
                     "engine": f"cellxgene Scanpy engine version ",
                     "dataset": current_app.config["DATASET_TITLE"],
                 },
+                "links": {
+                    "about-dataset": current_app.config["ABOUT_DATASET"]
+                },
                 "parameters": {
                     "max-category-items": current_app.data.config["max_category_items"]
                 },

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -27,7 +27,8 @@ def common_args(func):
 
     @click.option("--title", "-t", help="Title to display (if omitted will use file name).")
     @click.option("--about",
-                  help="A URL to more information about the dataset.(This must be an absolute URL including HTTP(S) protocol")
+                  help="A URL to more information about the dataset."
+                       "(This must be an absolute URL including HTTP(S) protocol")
     @click.option(
         "--embedding",
         "-e",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -28,7 +28,7 @@ def common_args(func):
     @click.option("--title", "-t", help="Title to display (if omitted will use file name).")
     @click.option("--about",
                   help="A URL to more information about the dataset."
-                       "(This must be an absolute URL including HTTP(S) protocol")
+                       "(This must be an absolute URL including HTTP(S) protocol)")
     @click.option(
         "--embedding",
         "-e",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -224,7 +224,7 @@ def launch(
     server = Server()
 
     server.create_app()
-    server.app.config.update(SCRIPTS=scripts, ABOUT_DATASET=about)
+    server.app.config.update(SCRIPTS=scripts)
 
     if not verbose:
         log = logging.getLogger("werkzeug")
@@ -241,7 +241,7 @@ def launch(
     from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
 
     try:
-        server.attach_data(ScanpyEngine(data_locator, e_args), title=title)
+        server.attach_data(ScanpyEngine(data_locator, e_args), title=title, about=about)
     except ScanpyFileError as e:
         raise click.ClickException(f"{e}")
 

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -6,6 +6,7 @@ from os.path import splitext, basename
 import sys
 import warnings
 import webbrowser
+from urllib.parse import urlparse
 
 import click
 
@@ -198,6 +199,19 @@ def launch(
         lf_name, lf_ext = splitext(experimental_label_file)
         if lf_ext and lf_ext != ".csv":
             raise click.FileError(basename(experimental_label_file), hint="label file type must be .csv")
+            
+    if about:
+        def url_check(url):
+            try:
+                result = urlparse(url)
+                if all([result.scheme, result.netloc]):
+                    return True
+                else:
+                    return False
+            except ValueError:
+                return False
+        if not url_check(about):
+            raise click.ClickException("Incorrect URL specified for --about. (Example format: http://example.com)")
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -220,7 +220,7 @@ def launch(
     server = Server()
 
     server.create_app()
-    server.app.config.update(SCRIPTS=scripts)
+    server.app.config.update(SCRIPTS=scripts, ABOUT_DATASET=about)
 
     if not verbose:
         log = logging.getLogger("werkzeug")
@@ -235,6 +235,7 @@ def launch(
         click.echo(f"[cellxgene] Loading data from {basename(data)}.")
 
     from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
+
 
     try:
         server.attach_data(ScanpyEngine(data_locator, e_args), title=title)

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -203,7 +203,7 @@ def launch(
         lf_name, lf_ext = splitext(experimental_label_file)
         if lf_ext and lf_ext != ".csv":
             raise click.FileError(basename(experimental_label_file), hint="label file type must be .csv")
-            
+
     if about:
         def url_check(url):
             try:

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -215,7 +215,7 @@ def launch(
                 return False
 
         if not url_check(about):
-            raise click.ClickException("Incorrect URL specified for --about. (Example format: http://example.com)")
+            raise click.ClickException("Must provide an absolute URL for --about. (Example format: http://example.com)")
 
     # Setup app
     cellxgene_url = f"http://{host}:{port}"

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -25,6 +25,7 @@ def common_args(func):
     Decorator to contain CLI args that will be common to both CLI and GUI: title and engine args.
     """
     @click.option("--title", "-t", help="Title to display (if omitted will use file name).")
+    @click.option("--about", help="A link to more information about the dataset")
     @click.option(
         "--embedding",
         "-e",
@@ -103,7 +104,7 @@ def parse_engine_args(embedding, obs_names, var_names, max_category_items, diffe
     help="Additional script files to include in html page",
     show_default=True,
 )
-@click.option("--about", help="A link to more information about the dataset")
+
 @common_args
 def launch(
         data,

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -236,7 +236,6 @@ def launch(
 
     from server.app.scanpy_engine.scanpy_engine import ScanpyEngine
 
-
     try:
         server.attach_data(ScanpyEngine(data_locator, e_args), title=title)
     except ScanpyFileError as e:

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -102,6 +102,7 @@ def parse_engine_args(embedding, obs_names, var_names, max_category_items, diffe
     help="Additional script files to include in html page",
     show_default=True,
 )
+@click.option("--about", help="A link to more information about the dataset")
 @common_args
 def launch(
         data,
@@ -117,6 +118,7 @@ def launch(
         diffexp_lfc_cutoff,
         title,
         scripts,
+        about,
         experimental_label_file
 ):
     """Launch the cellxgene data viewer.

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -24,8 +24,10 @@ def common_args(func):
     """
     Decorator to contain CLI args that will be common to both CLI and GUI: title and engine args.
     """
+
     @click.option("--title", "-t", help="Title to display (if omitted will use file name).")
-    @click.option("--about", help="A link to more information about the dataset")
+    @click.option("--about",
+                  help="A URL to more information about the dataset.(This must be an absolute URL including HTTP(S) protocol")
     @click.option(
         "--embedding",
         "-e",
@@ -60,6 +62,7 @@ def common_args(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -104,7 +107,6 @@ def parse_engine_args(embedding, obs_names, var_names, max_category_items, diffe
     help="Additional script files to include in html page",
     show_default=True,
 )
-
 @common_args
 def launch(
         data,
@@ -211,6 +213,7 @@ def launch(
                     return False
             except ValueError:
                 return False
+
         if not url_check(about):
             raise click.ClickException("Incorrect URL specified for --about. (Example format: http://example.com)")
 


### PR DESCRIPTION
This PR introduces configurable link outs to additional information about the dataset.  These links are featured conditionally in place of the dataset name in the top-left corner and in the info menu in the top-right.
![image](https://user-images.githubusercontent.com/8716829/64199338-f417b780-ce3e-11e9-8a26-a64ffafd15c6.png)
![image](https://user-images.githubusercontent.com/8716829/64199349-fb3ec580-ce3e-11e9-8234-ee1372f13bff.png)

----

This PR implements the following changes:
 - Server
   - `cli/launch.py`
     - Add `--about` flag and description
     - Add link validator and raise an exception if fails
     - Pass the link to config
    - `app/rest_api/rest.py`
       - add links field to config JSON
- Client
   - `globals`
      - add empty default for links
  - `informationMenu` component
   - Add a conditionally rendered menu item
  - `menubar` component
    - pass about link as prop to info menu
  - `TopLeftLogoAndTitle` component
    - Conditionally turn the dataset name into a link

----
This PR will close #902 