### PR TITLE
better handle long dataset titles

### DIFF
--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -61,14 +61,12 @@ class LeftSideBar extends React.Component {
             position: "relative",
             top: -2,
             display: "inline-block",
-            marginLeft: 7,
-            width: 170,
-            overflow: "hidden"
+            marginLeft: 7
           }}
           title={datasetTitle}
         >
-          {datasetTitle.length > 15
-            ? `${datasetTitle.substring(0, 6)}...${datasetTitle.slice(-6)}`
+          {datasetTitle.length > 29
+            ? `${datasetTitle.substring(0, 14)}…${datasetTitle.slice(-14)}`
             : datasetTitle}
         </div>
       </div>

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -41,7 +41,8 @@ class LeftSideBar extends React.Component {
             userSelect: "none"
           }}
         >
-          cell<span
+          cell
+          <span
             style={{
               position: "relative",
               top: 1,
@@ -50,7 +51,8 @@ class LeftSideBar extends React.Component {
             }}
           >
             ×
-          </span>gene
+          </span>
+          gene
         </span>
         <div
           data-testid="header"
@@ -65,7 +67,9 @@ class LeftSideBar extends React.Component {
           }}
           title={datasetTitle}
         >
-          {datasetTitle}
+          {datasetTitle.length > 15
+            ? `${datasetTitle.substring(0, 6)}...${datasetTitle.slice(-6)}`
+            : datasetTitle}
         </div>
       </div>
     );

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -59,7 +59,7 @@ class LeftSideBar extends React.Component {
           style={{
             fontSize: 14,
             position: "relative",
-            top: -2,
+            top: -6,
             display: "inline-block",
             width: "190px",
             marginLeft: "7px",

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -61,7 +61,11 @@ class LeftSideBar extends React.Component {
             position: "relative",
             top: -2,
             display: "inline-block",
-            marginLeft: 7
+            width: "190px",
+            marginLeft: "7px",
+            height: "1.1em",
+            overflow: "hidden",
+            wordBreak: "break-all"
           }}
           title={datasetTitle}
         >

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -69,8 +69,13 @@ class LeftSideBar extends React.Component {
           }}
           title={datasetTitle}
         >
-          {datasetTitle.length > 29
-            ? `${datasetTitle.substring(0, 14)}…${datasetTitle.slice(-14)}`
+          {datasetTitle.length > globals.datasetTitleMaxCharacterCount
+            ? `${datasetTitle.substring(
+                0,
+                Math.floor(globals.datasetTitleMaxCharacterCount / 2)
+              )}…${datasetTitle.slice(
+                -Math.floor(globals.datasetTitleMaxCharacterCount / 2)
+              )}`
             : datasetTitle}
         </div>
       </div>

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -47,6 +47,8 @@ export const maxParagraphWidth = 600;
 export const cellxgeneTitleLeftPadding = 14;
 export const cellxgeneTitleTopPadding = 7;
 
+export const datasetTitleMaxCharacterCount = 25;
+
 export const maxControlsWidth = 800;
 
 export const graphMargin = { top: 20, right: 10, bottom: 30, left: 40 };


### PR DESCRIPTION
This PR better handles long dataset titles by truncating the middle of the title if the length exceeds 29 characters.

![image](https://user-images.githubusercontent.com/8716829/64460232-bde06f00-d0ae-11e9-9b6c-f0c5abd12d26.png)

---

This will close #871