### PR TITLE
pin h5py to 2.9.0 to temporarily work around regression

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,3 +10,5 @@ numpy>=1.15.2
 pandas>=0.23.1
 scipy>=1.1.0
 tables==3.5.1
+# TEMP workaround for https://github.com/theislab/scanpy/issues/832 aka h5py regression
+h5py==2.9.0


### PR DESCRIPTION
This PR temporarily pins h5py to 2.9.0 to work around a regression in reading older anndata files.

See https://github.com/theislab/scanpy/issues/832

Will need to be unpinned at some point.