### PR TITLE
fix bulk add failing on first gene in world

### DIFF
--- a/client/src/components/geneExpression/index.js
+++ b/client/src/components/geneExpression/index.js
@@ -177,7 +177,7 @@ class GeneExpression extends React.Component {
 
           const indexOfGene = upperWorldGenes.get(upperGene);
 
-          if (!indexOfGene) {
+          if (indexOfGene === undefined) {
             return keepAroundErrorToast(
               `${
                 genes[upperGenes.get(upperGene)]


### PR DESCRIPTION
If a user attempted entering the gene found at index 0 in `world.varAnnotations.col(varIndexName).asArray()`, `handleBulkAddClick()` would incorrectly mark the gene as not existing in the dataset.

Fixed by changing the assertion from `(!index)` to `(index === undefined)`

---

closes #953 