### PR TITLE
reduce dot scaling upon zoom

### DIFF
--- a/client/src/components/graph/drawPointsRegl.js
+++ b/client/src/components/graph/drawPointsRegl.js
@@ -31,7 +31,7 @@ export default function(regl) {
       getFlags(flag, isNaN, isSelected, isHighlight);
 
       float size = pointSize(nPoints, minViewportDimension, isSelected, isHighlight);
-      gl_PointSize = size * pow(distance, 1.2);
+      gl_PointSize = size * pow(distance, 0.5);
 
       float z = isNaN ? zBottom : (isHighlight ? zTop : zMiddle);
       vec3 xy = projView * vec3(position, 1.);

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -194,11 +194,7 @@ class Graph extends React.Component {
 
   componentDidMount() {
     // setup canvas, webgl draw function and camera
-    const camera = _camera(this.reglCanvas, {
-      pan: true,
-      scale: true,
-      rotate: false
-    });
+    const camera = _camera(this.reglCanvas);
     const regl = _regl(this.reglCanvas);
     const drawPoints = _drawPoints(regl);
 


### PR DESCRIPTION
Fixes #958 

Reduce the rate of point size scaling with zoom in the main graph.   Previously, dot size would scale faster than white space (distance between points).  Now this is reversed, and dot size scales slower, increasing the "spread" between dots as you zoom in.

This PR also removed a bit of obsolete/unused code related to camera setup.