### PR TITLE
User cannot edit multiple category names

### DIFF
--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -102,6 +102,7 @@ class Category extends React.Component {
 
   activateEditCategoryMode = () => {
     const { dispatch, metadataField } = this.props;
+
     dispatch({
       type: "annotation: activate category edit mode",
       data: metadataField
@@ -378,6 +379,7 @@ class Category extends React.Component {
                       />
                       <MenuItem
                         icon="edit"
+                        disabled={annotations.isEditingCategoryName}
                         data-testclass="activateEditCategoryMode"
                         data-testid={`activateEditCategoryMode-${metadataField}`}
                         onClick={this.activateEditCategoryMode}


### PR DESCRIPTION
Fixes #974

Edit is disabled if there is already a category label being edited...

![image](https://user-images.githubusercontent.com/1770265/67803066-84dad000-fa49-11e9-8754-17130dbe35c4.png)