### PR TITLE
crossfilter immutability error

### DIFF
--- a/client/__tests__/util/typedCrossfilter/crossfilter.test.js
+++ b/client/__tests__/util/typedCrossfilter/crossfilter.test.js
@@ -168,6 +168,9 @@ describe("ImmutableTypedCrossfilter", () => {
 
     const p4 = p3.delDimension("quantity");
     expect(p4).not.toBe(p3);
+
+    const p5 = p2.renameDimension("quantity", "Quantity");
+    expect(p5).not.toBe(p2);
   });
 
   test("select all and none", () => {

--- a/client/src/util/typedCrossfilter/crossfilter.js
+++ b/client/src/util/typedCrossfilter/crossfilter.js
@@ -125,20 +125,17 @@ export default class ImmutableTypedCrossfilter {
   }
 
   renameDimension(oldName, newName) {
-    /*
-    rename a dimension
-    */
     const { [oldName]: dim, ...dimensions } = this.dimensions;
     const { data, selectionCache } = this;
-    dim.dim.rename(newName);
-    return new ImmutableTypedCrossfilter(
-      data,
-      {
-        ...dimensions,
-        [newName]: dim
-      },
-      selectionCache
-    );
+    const newDimensions = {
+      ...dimensions,
+      [newName]: {
+        ...dim,
+        name: newName,
+        dim: dim.dim.rename(newName)
+      }
+    };
+    return new ImmutableTypedCrossfilter(data, newDimensions, selectionCache);
   }
 
   select(name, spec) {
@@ -316,8 +313,14 @@ class _ImmutableBaseDimension {
     this.name = name;
   }
 
+  clone() {
+    return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+  }
+
   rename(name) {
-    this.name = name;
+    const d = this.clone();
+    d.name = name;
+    return d;
   }
 
   select(spec) {


### PR DESCRIPTION
Fixes #1001 

The crossfilter dimension objects had one code path that did not respect immutability contracts, and which was made obvious by the recent move to freezing immutable objects. 

Added a test to verify that this code path does not regress.