### PR TITLE
add context sensitivity to annotation "label" menu item

### DIFF
--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -17,7 +17,7 @@ import * as globals from "../../globals";
 import styles from "./categorical.css";
 import { Tooltip } from "@blueprintjs/core";
 
-import { AnnotationsHelpers as AH } from "../../util/stateManager";
+import { AnnotationsHelpers } from "../../util/stateManager";
 
 @connect(state => ({
   categoricalSelection: state.categoricalSelection,
@@ -188,12 +188,19 @@ class CategoryValue extends React.Component {
     const { crossfilter, world } = this.props;
 
     // 1. no cells selected?
-    if (crossfilter.countSelected() == 0) {
+    if (crossfilter.countSelected() === 0) {
       return true;
     }
     // 2. all selected cells already have the label
     const mask = crossfilter.allSelectedMask();
-    if (AH.allHaveLabelByMask(world.obsAnnotations, category, value, mask)) {
+    if (
+      AnnotationHelpers.allHaveLabelByMask(
+        world.obsAnnotations,
+        category,
+        value,
+        mask
+      )
+    ) {
       return true;
     }
     // else, don't disable

--- a/client/src/reducers/crossfilter.js
+++ b/client/src/reducers/crossfilter.js
@@ -3,8 +3,8 @@ import _ from "lodash";
 import Crossfilter from "../util/typedCrossfilter";
 import {
   World,
-  ControlsHelpers as CH,
-  AnnotationsHelpers as AH
+  ControlsHelpers,
+  AnnotationsHelpers
 } from "../util/stateManager";
 import {
   layoutDimensionName,
@@ -37,13 +37,16 @@ const CrossfilterReducerBase = (
       const { userDefinedGenes, diffexpGenes } = prevSharedState.controls;
       const { world } = nextSharedState;
       let { crossfilter } = prevSharedState.resetCache;
-      crossfilter = CH.createGeneDimensions(
+      crossfilter = ControlsHelpers.createGeneDimensions(
         userDefinedGenes,
         diffexpGenes,
         world,
         crossfilter
       );
-      crossfilter = AH.createWritableAnnotationDimensions(world, crossfilter);
+      crossfilter = AnnotationsHelpers.createWritableAnnotationDimensions(
+        world,
+        crossfilter
+      );
       return crossfilter;
     }
 
@@ -57,7 +60,7 @@ const CrossfilterReducerBase = (
         world,
         layoutChoice.currentDimNames
       );
-      crossfilter = CH.createGeneDimensions(
+      crossfilter = ControlsHelpers.createGeneDimensions(
         userDefinedGenes,
         diffexpGenes,
         world,

--- a/client/src/reducers/world.js
+++ b/client/src/reducers/world.js
@@ -1,8 +1,8 @@
 import { unassignedCategoryLabel } from "../globals";
 import {
   World,
-  ControlsHelpers as CH,
-  AnnotationsHelpers as AH
+  ControlsHelpers,
+  AnnotationsHelpers
 } from "../util/stateManager";
 import clip from "../util/clip";
 import quantile from "../util/quantile";
@@ -92,7 +92,7 @@ const WorldReducer = (
           Object.keys(action.expressionData)
         )
       ];
-      unclippedVarData = CH.pruneVarDataCache(
+      unclippedVarData = ControlsHelpers.pruneVarDataCache(
         unclippedVarData,
         allTheGenesWeNeed
       );
@@ -208,7 +208,7 @@ const WorldReducer = (
       /* set all values to to new label */
       const unclipped = {
         ...state.unclipped,
-        obsAnnotations: AH.setLabelByValue(
+        obsAnnotations: AnnotationsHelpers.setLabelByValue(
           state.unclipped.obsAnnotations,
           metadataField,
           oldLabelName,
@@ -229,7 +229,7 @@ const WorldReducer = (
       /* set all values to unassigned in obsAnnotations */
       const unclipped = {
         ...state.unclipped,
-        obsAnnotations: AH.setLabelByValue(
+        obsAnnotations: AnnotationsHelpers.setLabelByValue(
           state.unclipped.obsAnnotations,
           metadataField,
           label,
@@ -249,7 +249,7 @@ const WorldReducer = (
       const mask = crossfilter.allSelectedMask();
       const unclipped = {
         ...state.unclipped,
-        obsAnnotations: AH.setLabelByMask(
+        obsAnnotations: AnnotationsHelpers.setLabelByMask(
           state.unclipped.obsAnnotations,
           metadataField,
           mask,

--- a/client/src/util/stateManager/annotationsHelpers.js
+++ b/client/src/util/stateManager/annotationsHelpers.js
@@ -137,7 +137,7 @@ export function allHaveLabelByMask(df, colName, label, mask) {
 	// False if not.
 	const col = df.col(colName);
 	if (!col) return false;
-	if (df.length != mask.length)
+	if (df.length !== mask.length)
 		throw new InternalError("mismatch on mask length");
 
 	for (let i = 0; i < df.length; i += 1) {

--- a/client/src/util/stateManager/annotationsHelpers.js
+++ b/client/src/util/stateManager/annotationsHelpers.js
@@ -132,6 +132,22 @@ export function setLabelByMask(df, colName, mask, label) {
 	return ndf;
 }
 
+export function allHaveLabelByMask(df, colName, label, mask) {
+	// return true if all rows as indicated by mask have the colname set to label.
+	// False if not.
+	const col = df.col(colName);
+	if (!col) return false;
+	if (df.length != mask.length)
+		throw new InternalError("mismatch on mask length");
+
+	for (let i = 0; i < df.length; i += 1) {
+		if (mask[i]) {
+			if (col.iget(i) !== label) return false;
+		}
+	}
+	return true;
+}
+
 export function worldToUniverseMask(worldMask, worldObsAnnotations, nObs) {
 	/*
 	given world seleciton mask, return a selection mask for entire universe 


### PR DESCRIPTION
Fixes #972 

Changes requested from UI review:
1. annotation value (label) context menu will enable/disable "re-label" option.  It is disabled if:
    * no cells are selected
    * all selected cells are already labelled with this this value
2. performance improvements to typedCrossfilter to remove jank from this operation (caching of state derived from current selection)
3. the small formatting (italic 'unassigned') change mentioned in #972 
4. removed hardwired `unknown` string and replaced with the globally configured `unassigned` value for a labels.

