### PR TITLE
update deprecated Pandas API

### DIFF
--- a/server/app/util/fbs/matrix.py
+++ b/server/app/util/fbs/matrix.py
@@ -95,7 +95,7 @@ def serialize_typed_array(builder, source_array, encoding_info):
         if MatrixProxy.ismatrixproxy(arr) or sparse.issparse(arr):
             arr = arr.toarray()
         elif isinstance(arr, pd.Series):
-            arr = arr.get_values()
+            arr = arr.to_numpy()
         if arr.dtype != as_type:
             arr = arr.astype(as_type)
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,7 +8,7 @@ Flask-RESTful>=0.3.6
 flatbuffers>=1.10.0
 fsspec>=0.4.4
 numpy>=1.15.2
-pandas>=0.23.1
+pandas>=0.24.2
 scipy>=1.3.0
 tables==3.5.1
 # TEMP workaround for https://github.com/theislab/scanpy/issues/832 aka h5py regression


### PR DESCRIPTION
Fixes #982 

Pandas.Series.get_values() is now deprecated.  Updated to use supported interface.

This also bumps our dependency on Pandas to 0.24.2