### PR TITLE
clear color-by mode when current category is deleted

### DIFF
--- a/client/src/reducers/colors.js
+++ b/client/src/reducers/colors.js
@@ -53,6 +53,18 @@ const ColorsReducer = (
       };
     }
 
+    case "annotation: delete category": {
+      const { colorAccessor } = state;
+      if (action.metadataField != colorAccessor) {
+        return state;
+      }
+      /* else reset */
+      return {
+        ...state,
+        ...ColorHelpers.resetColors(prevSharedState.world)
+      };
+    }
+
     case "reset colorscale": {
       return {
         ...state,


### PR DESCRIPTION
Fixes #1011 

Reset color-by mode when user deletes the current color-by category.