### PR TITLE
bump @blueprintjs dependencies

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1655,16 +1655,17 @@
       }
     },
     "@blueprintjs/core": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.18.1.tgz",
-      "integrity": "sha512-G+IhJsN006Mb32NLOrne5TLScxyyd3Id9g2MvfYFq9zuyBcBA5+V/uQy3pTO9vkmuKEz0GLLy8ZbrQ7Us/+zTw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.20.0.tgz",
+      "integrity": "sha512-0ndz/lLMbSgWu1Z5hdpScfMbkQIOFESejsSW7Jjpin7Hmsjr8fRDU1efoVyG1uHBPmA4B6aYh+uShZHcZGJtig==",
       "requires": {
-        "@blueprintjs/icons": "^3.10.0",
+        "@blueprintjs/icons": "^3.12.0",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
         "dom4": "^2.1.5",
         "normalize.css": "^8.0.1",
         "popper.js": "^1.15.0",
+        "react-lifecycles-compat": "^3.0.4",
         "react-popper": "^1.3.3",
         "react-transition-group": "^2.9.0",
         "resize-observer-polyfill": "^1.5.1",
@@ -1672,20 +1673,20 @@
       }
     },
     "@blueprintjs/icons": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.10.0.tgz",
-      "integrity": "sha512-lyAUpkr3qEStPcJpMnxRKuVAPvaRNSce1ySPbkE58zPmD4WBya2gNrWex41xoqRYM0GsiBSwH9CnpY8t6fZKUA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.12.0.tgz",
+      "integrity": "sha512-ERIODstzjBzRIHNqAqyXu4gVsdLyvxAZ0Cp7Dr4+d5BdgDbZYzMYf9ll05daQPOBWaFjLh3lhCRhbfk6MXdD7A==",
       "requires": {
         "classnames": "^2.2",
         "tslib": "~1.9.0"
       }
     },
     "@blueprintjs/select": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.10.0.tgz",
-      "integrity": "sha512-Akm/L5tndrOUuf05od9IJ0WSQgHdbJ4/i2RRoLLH5ZiI8s1OZiCbKJYDSCbCOTviCdZSuL0qkJsBcYhOI/Czeg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.11.2.tgz",
+      "integrity": "sha512-fU0Km6QI/ayWhzYeu9N1gTj0+L0XUO4KB3u2LfJXgj648UGY8F4HX2ETdJ+XPdtsu6TesrIL7ghMQhtLcvafBg==",
       "requires": {
-        "@blueprintjs/core": "^3.18.0",
+        "@blueprintjs/core": "^3.20.0",
         "classnames": "^2.2",
         "tslib": "~1.9.0"
       }
@@ -7406,7 +7407,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -10286,9 +10287,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -10705,7 +10706,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10791,9 +10792,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
-      "integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
+      "integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "create-react-context": "^0.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -32,9 +32,9 @@
     "eslint-scope": "3.7.1"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.18.1",
-    "@blueprintjs/icons": "^3.10.0",
-    "@blueprintjs/select": "^3.10.0",
+    "@blueprintjs/core": "^3.20.0",
+    "@blueprintjs/icons": "^3.12.0",
+    "@blueprintjs/select": "^3.11.2",
     "d3": "^4.10.0",
     "d3-scale-chromatic": "^1.5.0",
     "flatbuffers": "^1.11.0",


### PR DESCRIPTION
This PR bumps all of our BlueprintJS dependencies as follows:
* @blueprintjs/core 3.18.1 -> 3.20.0
* @blueprintjs/icons 3.10.0 -> 3.12.0
* @blueprintjs/select 3.10.0 -> 3.11.2

This fix eliminates console warnings from using renamed/deprecated lifecycle methods.

Note that the following error is still present:
```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: SideEffect(NullComponent)
```

---
Closes #926 