### PR TITLE
fix dataset title clipping

### DIFF
--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -74,7 +74,7 @@ class LeftSideBar extends React.Component {
             display: "inline-block",
             width: "190px",
             marginLeft: "7px",
-            height: "1.1em",
+            height: "1.2em",
             overflow: "hidden",
             wordBreak: "break-all"
           }}


### PR DESCRIPTION
This PR implements a fix that prevents hanging characters from being clipped in the dataset title
---
Fixes #966 