### PR TITLE
fix scatterplot hiding

### DIFF
--- a/client/src/components/scatterplot/scatterplot.js
+++ b/client/src/components/scatterplot/scatterplot.js
@@ -381,7 +381,7 @@ class Scatterplot extends React.PureComponent {
       <div
         style={{
           position: "fixed",
-          bottom: minimized ? -height + -margin.top : 0,
+          bottom: minimized ? -height + -margin.top - 2 : 0,
           borderRadius: "3px 3px 0px 0px",
           left: globals.leftSidebarWidth + globals.scatterplotMarginLeft,
           padding: "0px 20px 20px 0px",


### PR DESCRIPTION
Increases the shift distance of the scatterplot while hiding.  Stops the axis from peeking through.
---
fixes #967 