### PR TITLE
reformat lsb for annotations in large datasets

### DIFF
--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -289,7 +289,7 @@ class CategoryValue extends React.Component {
             margin: 0,
             padding: 0,
             userSelect: "none",
-            width: globals.leftSidebarWidth - 130,
+            width: globals.leftSidebarWidth - 145,
             display: "flex",
             justifyContent: "space-between"
           }}

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -70,8 +70,8 @@ export const leftSidebarSectionHeading = {
   letterSpacing: ".05em"
 };
 export const leftSidebarSectionPadding = 10;
-export const categoryLabelDisplayStringLongLength = 35;
-export const categoryLabelDisplayStringShortLength = 15;
+export const categoryLabelDisplayStringLongLength = 27;
+export const categoryLabelDisplayStringShortLength = 11;
 
 /* various timing-related behaviors */
 export const tooltipHoverOpenDelay = 1000; /* ms delay before a tooltip displays */


### PR DESCRIPTION
This PR implements a fix that prevents values from wrapping onto a second line when the # of cells attributed to a value is too large.

This was done by reducing the amount of allocated space to the value name + occupancy/mini-histogram

---
Fixes #1014 