### PR TITLE
category and label name validation updates

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -67,42 +67,42 @@ class Categories extends React.Component {
     return false if this is a LEGAL/acceptable category name or NULL/empty string,
     or return an error type.
     */
-    if (!name) return false;
+
+    /* allow empty string */
+    if (name === "") return false;
 
     const { categoricalSelection } = this.props;
     const allCategoryNames = Object.keys(categoricalSelection);
 
+    /* check category name syntax */
+    const error = AnnotationsHelpers.annotationNameIsErroneous(name);
+    if (error) {
+      return error;
+    }
+
+    /* disallow duplicates */
     if (allCategoryNames.indexOf(name) !== -1) {
       return "duplicate";
     }
 
-    if (!AnnotationsHelpers.isLegalAnnotationName(name)) {
-      return "characters";
-    }
-
+    /* otherwise, no error */
     return false;
   };
 
   categoryNameErrorMessage = name => {
     const err = this.categoryNameError(name);
     if (err === false) return null;
-    if (err === "duplicate") {
-      return (
-        <span>
-          <span style={{ fontStyle: "italic" }}>{name}</span> already exists -
-          no duplicates allowed
-        </span>
-      );
-    }
-    if (err === "characters") {
-      return (
-        <span>
-          <span style={{ fontStyle: "italic" }}>{name}</span> contains illegal
-          characters. Hint: use alpha-numeric and underscore
-        </span>
-      );
-    }
-    return err;
+
+    const errorMessageMap = {
+      /* map error code to human readable error message */
+      "empty-string": "Blank names not allowed",
+      duplicate: "Name must be unique",
+      "trim-spaces": "Leading and trailing spaces not allowed",
+      "illegal-characters": "Only alphanumeric, underscore and period allowed",
+      "multi-space-run": "Multiple consecutive spaces not allowed"
+    };
+    const errorMessage = errorMessageMap[err] ?? "error";
+    return <span>{errorMessage}</span>;
   };
 
   render() {

--- a/client/src/util/stateManager/annotationsHelpers.js
+++ b/client/src/util/stateManager/annotationsHelpers.js
@@ -183,7 +183,35 @@ export function createWritableAnnotationDimensions(world, crossfilter) {
 	return crossfilter;
 }
 
-const legalNames = /^\w+$/;
-export function isLegalAnnotationName(name) {
-	return legalNames.test(name);
+const legalCharacters = /^(\w|[ .])+$/;
+export function annotationNameIsErroneous(name) {
+	/*
+	Validate the name - return:
+	* false - a valid name
+	* string - a named error, indicating why it was invalid.
+
+	Tests:
+	0. must be string, non-null
+	1. no leading or trailing spaces
+	2. only accept alpha, numeric, underscore, period and space
+	3. no runs of multiple spaces
+	*/
+
+	if (name === "") {
+		return "empty-string";
+	}
+	if (name[0] === " " || name[name.length - 1] === " ") {
+		return "trim-spaces";
+	}
+	if (!legalCharacters.test(name)) {
+		return "illegal-characters";
+	}
+	for (let i = 1, l = name.length; i < l; i += 1) {
+		if (name[i] === " " && name[i - 1] === " ") {
+			return "multi-space-run";
+		}
+	}
+
+	/* all is well!  Indicte not erroneous with a false */
+	return false;
 }


### PR DESCRIPTION
Related to #1037 - several changes:
* name validation for category and label now supports the scheme noted in #1037 
* error messages updated for new categories
* general cleanup of error handling motivated by increased number of error types and messages

In addition, fixes a state handling bug in Value -- it would fail to update its state when properties changed.  This fixes a bug where the components would get confused (bad state values) when their order & properties were changed by the parent `Flip` component.