### PR TITLE
fix perf regression introduced by user anno changes

### DIFF
--- a/client/src/components/categorical/occupancy.js
+++ b/client/src/components/categorical/occupancy.js
@@ -10,7 +10,7 @@ import {
 } from "@blueprintjs/core";
 
 @connect()
-class Occupancy extends React.Component {
+class Occupancy extends React.PureComponent {
   _WIDTH = 100;
 
   _HEIGHT = 11;

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -191,7 +191,8 @@ class CategoryValue extends React.Component {
     const worldChange = props.world !== nextProps.world;
     const colorAccessorChange = props.colorAccessor !== nextProps.colorAccessor;
     const annotationsChange = props.annotations !== nextProps.annotations;
-    const crossfilterChange = props.crossfilter !== nextProps.crossfilter;
+    const crossfilterChange =
+      props.isUserAnno && props.crossfilter !== nextProps.crossfilter;
     const editingLabel = state.editedLabelText !== nextState.editedLabelText;
 
     return (
@@ -554,9 +555,7 @@ class CategoryValue extends React.Component {
                         data-testclass="handleDeleteValue"
                         data-testid={`handleDeleteValue-${metadataField}`}
                         onClick={this.handleDeleteValue}
-                        text={`Delete this label, and reassign all cells to type '${
-                          globals.unassignedCategoryLabel
-                        }'`}
+                        text={`Delete this label, and reassign all cells to type '${globals.unassignedCategoryLabel}'`}
                       />
                     ) : null}
                   </Menu>


### PR DESCRIPTION
PR #1015 introduced a significant performance degradation in the category rendering code.  This resolves the most common cases where it causes problems:
* Occupancy component made pure
* shouldComponentUpdate in Value component now understands that the selection state will only affect rendering for metadata categories that are editable (the selection state helps build the context menu, and nothing else).