### PR TITLE
create annotations output dir if it does not exist

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -1,7 +1,7 @@
 import errno
 import functools
 import logging
-from os import devnull
+from os import devnull, mkdir
 from os.path import splitext, basename, isdir
 import sys
 import warnings
@@ -298,8 +298,10 @@ def launch(
                 raise click.FileError(basename(experimental_annotations_file), hint="annotation file type must be .csv")
 
         if experimental_annotations_output_dir is not None and not isdir(experimental_annotations_output_dir):
-            raise click.ClickException('--experimental-annotations-output-dir must specify an existing directory. '
-                                       f'"{experimental_annotations_output_dir}" does not exist.')
+            try:
+                mkdir(experimental_annotations_output_dir)
+            except OSError:
+                raise click.ClickException("Unable to create directory specified by --experimental-annotations-output-dir")
 
     if about:
         def url_check(url):

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -301,7 +301,8 @@ def launch(
             try:
                 mkdir(experimental_annotations_output_dir)
             except OSError:
-                raise click.ClickException("Unable to create directory specified by --experimental-annotations-output-dir")
+                raise click.ClickException("Unable to create directory specified by "
+                                           "--experimental-annotations-output-dir")
 
     if about:
         def url_check(url):


### PR DESCRIPTION
If the directory specified by --experimental-annotations-output-dir does not exist, create it.