### PR TITLE
Use `npm ci` instead of `npm install` during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build: clean build-server
 
 .PHONY: build-client
 build-client:
-	cd client && $(MAKE) install build
+	cd client && $(MAKE) ci build
 
 .PHONY: build-server
 build-server: build-client
@@ -122,7 +122,7 @@ release-directly-to-prod: dev-env pydist twine-prod
 
 .PHONY: dev-env
 dev-env:
-	cd client && $(MAKE) install
+	cd client && $(MAKE) ci
 	pip install -r server/requirements-dev.txt
 
 .PHONY: gui-env

--- a/client/Makefile
+++ b/client/Makefile
@@ -2,6 +2,10 @@
 clean:
 	rm -rf node_modules
 
+.PHONY: ci
+ci:
+	npm ci client
+
 .PHONY: install
 install:
 	npm install client


### PR DESCRIPTION
Currently the client build is not reproducible since, each time you run
`make build-client` the package lockfile is updated. This should be
handled separately by `make gen-package-lock` when developers actually
want to update the dependencies.

`npm ci` installs dependencies directly from the lockfile without
updating them, making builds reproducible.

For more see https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json