### PR TITLE
Remove FAQ link from info menu

### DIFF
--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -21,22 +21,16 @@ function InformationMenu(props) {
             )}
 
             <MenuItem
-              href="https://chanzuckerberg.github.io/cellxgene/faq.html"
+              href="https://chanzuckerberg.github.io/cellxgene/"
               target="_blank"
               icon="help"
-              text="FAQ"
+              text="Help"
             />
             <MenuItem
               href="https://join-cellxgene-users.herokuapp.com/"
               target="_blank"
               icon="chat"
               text="Chat"
-            />
-            <MenuItem
-              href="https://chanzuckerberg.github.io/cellxgene/"
-              target="_blank"
-              icon="book"
-              text="Docs"
             />
             <MenuItem
               href="https://github.com/chanzuckerberg/cellxgene"


### PR DESCRIPTION
With the new docs reorg, we don't have a specific "FAQ" page. I've removed this link from the info menu, and subbed in a "help" link that goes to the main docs page. Happy to adjust as needed!

Fixes #1071