### PR TITLE
Specify histogram thresholds in fixed-length array

### DIFF
--- a/client/__tests__/util/range.test.js
+++ b/client/__tests__/util/range.test.js
@@ -1,4 +1,4 @@
-import { range, rangeFill } from "../../src/util/range";
+import { range, rangeFill, linspace } from "../../src/util/range";
 
 describe("range", () => {
 	test("no defaults", () => {
@@ -37,6 +37,14 @@ describe("rangefill", () => {
 	test("rangeFill(arr, start, step)", () => {
 		expect(rangeFill(new Int32Array(3), 2, -1)).toMatchObject(
 			new Int32Array([2, 1, 0])
+		);
+	});
+});
+
+describe("linspace", () => {
+	test("linspace(arr, start, step)", () => {
+		expect(linspace(0.0, 2.0, 5)).toMatchObject(
+		    [0.0, 0.5, 1.0, 1.5, 2.0]
 		);
 	});
 });

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -62,7 +62,7 @@ class HistogramBrush extends React.PureComponent {
       .range([this.marginLeft, this.marginLeft + this.width]);
 
     const [xStart, xStop] = histogramCache.x.domain();
-    const histThresholds = linspace(xStart, xStop, numBins);
+    const histThresholds = linspace(xStart, xStop, numBins + 1);
 
     histogramCache.bins = d3
       .histogram()

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -12,6 +12,7 @@ import * as d3 from "d3";
 import memoize from "memoize-one";
 import * as globals from "../../globals";
 import actions from "../../actions";
+import { linspace } from "../../util/range";
 import { makeContinuousDimensionName } from "../../util/nameCreators";
 
 @connect((state, ownProps) => {
@@ -53,15 +54,20 @@ class HistogramBrush extends React.PureComponent {
     const values = col.asArray();
     const summary = col.summarize();
     const { min: domainMin, max: domainMax } = summary;
+    const numBins = 40;
+
     histogramCache.x = d3
       .scaleLinear()
       .domain([domainMin, domainMax])
       .range([this.marginLeft, this.marginLeft + this.width]);
 
+    const [xStart, xStop] = histogramCache.x.domain();
+    const histThresholds = linspace(xStart, xStop, numBins);
+
     histogramCache.bins = d3
       .histogram()
       .domain(histogramCache.x.domain())
-      .thresholds(40)(values);
+      .thresholds(histThresholds)(values);
 
     const yMax = histogramCache.bins
       .map(b => b.length)

--- a/client/src/util/range.js
+++ b/client/src/util/range.js
@@ -43,3 +43,8 @@ export function range(start, stop, step) {
 	const len = Math.max(Math.ceil((stop - start) / step), 0);
 	return _doFill(new Array(len), start, step, len);
 }
+
+export function linspace(start, stop, nsteps) {
+	const delta = (stop - start) / (nsteps - 1).toFixed();
+	return range(0, nsteps, 1).map(i => start + i * delta);
+}


### PR DESCRIPTION
Fixes https://github.com/chanzuckerberg/cellxgene/issues/1082

📊 
<img width="360" alt="Screen Shot 2020-01-02 at 3 53 13 PM" src="//user-images.githubusercontent.com/538456/71700192-0582b900-2d78-11ea-947a-2f23f731ff50.png">

For background, see the following:
* https://github.com/d3/d3-array/issues/46
* https://stackoverflow.com/questions/15880058/d3-js-ticks-function-giving-more-elements-than-needed
