### PR TITLE
fix 1090

### DIFF
--- a/client/src/reducers/universe.js
+++ b/client/src/reducers/universe.js
@@ -72,7 +72,7 @@ const Universe = (state = null, action, nextSharedState, prevSharedState) => {
           }
         );
         /* if we are duplicating a non-writable annotation, it may not have an unassigned category */
-        const s = schema.annotations.obsByName[categoryToDuplicate];
+        const s = schema.annotations.obsByName[name];
         if (s.categories.indexOf(unassignedCategoryLabel) === -1) {
           s.categories = s.categories.concat(unassignedCategoryLabel);
         }


### PR DESCRIPTION
The reducer had a bug -- it was adding the conventional 'unassigned' label to the _source_ category, rather than the newly created category.

This only occurred when you create a new category by duplicating an existing, non-user-created category.

Fixes #1090 
