### PR TITLE
Rename Makefile target `build-server` to `build-cli`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ clean-%:
 # BUILDING PACKAGE
 
 .PHONY: build
-build: clean build-server
+build: clean build-cli
 	@echo "done"
 
 .PHONY: build-client
 build-client:
 	cd client && $(MAKE) ci build
 
-.PHONY: build-server
-build-server: build-client
+.PHONY: build-cli
+build-cli: build-client
 	git ls-files server/ | cpio -pdm $(BUILDDIR)
 	cp -r client/build/  $(CLIENTBUILD)
 	mkdir -p $(SERVERBUILD)/app/web/static/img

--- a/dev_docs/developer_scripts.md
+++ b/dev_docs/developer_scripts.md
@@ -58,7 +58,7 @@ builds source code
 
 ```
 build - builds whole app client and server
-build-server - makes build dir and moves python and client files
+build-cli - makes build dir and moves python and client files
 build-client - runs webpack build
 build-for-server-dev - builds client and copies output directly into source tree (only for server devlopment)
 ```


### PR DESCRIPTION
The `build-server` makefile target does not actually build the server
module, rather it builds the CLI. Rename this target to make it less
confusing.