### PR TITLE
fix incomplete user category name creation

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -71,8 +71,12 @@ class Categories extends React.Component {
     /* allow empty string */
     if (name === "") return false;
 
-    const { categoricalSelection } = this.props;
-    const allCategoryNames = Object.keys(categoricalSelection);
+    /* 
+    test for uniqueness against *all* annotation names, not just the subset
+    we render as categorical.
+    */
+    const { schema } = this.props;
+    const allCategoryNames = schema.annotations.obs.columns.map(c => c.name);
 
     /* check category name syntax */
     const error = AnnotationsHelpers.annotationNameIsErroneous(name);


### PR DESCRIPTION
User created categories must have a unique name.   The validation code was only checking that the names were unique in the *categorical* obs annotations, and would incorrectly allow a collision with other annotations (eg, continuous annotations).  This would later lead to a crash/error and loss of data.

This PR expands the check to require uniqueness across all obs annotation names.

Fixes #1112 
