### PR TITLE
disable magical nan parsing in back-end CSV handler

### DIFF
--- a/server/app/scanpy_engine/labels.py
+++ b/server/app/scanpy_engine/labels.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 def read_labels(fname):
     if fname is not None and os.path.exists(fname) and os.path.getsize(fname) > 0:
-        return pd.read_csv(fname, dtype="category", index_col=0, header=0, comment="#")
+        return pd.read_csv(fname, dtype="category", index_col=0, header=0, comment="#", keep_default_na=False)
     else:
         return pd.DataFrame()
 


### PR DESCRIPTION
Fixes #1111 

We use the Pandas read_csv implementation, which includes all sorts of "na" handling for series data.  This fix forces all labels to be treated as generic strings, consistent with the remainder of our label handling (agnostic to any label or cat name semantics).
