### PR TITLE
Update legal characters for labels

### DIFF
--- a/client/src/components/categorical/categorical.js
+++ b/client/src/components/categorical/categorical.js
@@ -93,7 +93,7 @@ class Categories extends React.Component {
       "empty-string": "Blank names not allowed",
       duplicate: "Name must be unique",
       "trim-spaces": "Leading and trailing spaces not allowed",
-      "illegal-characters": "Only alphanumeric, underscore and period allowed",
+      "illegal-characters": "Only alphanumeric and special characters (-_.) allowed",
       "multi-space-run": "Multiple consecutive spaces not allowed"
     };
     const errorMessage = errorMessageMap[err] ?? "error";

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -200,6 +200,9 @@ class Category extends React.Component {
     /* allow empty string */
     if (name === "") return false;
 
+    /* allow any term in the ontology */
+    if (this.props.ontology.terms.includes(name)) return false;
+
     /* check for label syntax errors */
     const error = AnnotationsHelpers.annotationNameIsErroneous(name);
     if (error) return error;
@@ -257,7 +260,7 @@ class Category extends React.Component {
       "empty-string": "Blank names not allowed",
       duplicate: "Category name must be unique",
       "trim-spaces": "Leading and trailing spaces not allowed",
-      "illegal-characters": "Only alphanumeric, underscore and period allowed",
+      "illegal-characters": "Only alphanumeric and special characters (-_.) allowed",
       "multi-space-run": "Multiple consecutive spaces not allowed"
     };
     const errorMessage = errorMessageMap[err] ?? "error";

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -201,7 +201,9 @@ class Category extends React.Component {
     if (name === "") return false;
 
     /* allow any term in the ontology */
-    if (this.props.ontology.termSet.has(name)) return false;
+    const { ontology } = this.props;
+    const termInOntology = ontology?.termSet.has(name) ?? false;
+    if (termInOntology) return false;
 
     /* check for label syntax errors */
     const error = AnnotationsHelpers.annotationNameIsErroneous(name);

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -201,7 +201,7 @@ class Category extends React.Component {
     if (name === "") return false;
 
     /* allow any term in the ontology */
-    if (this.props.ontology.terms.includes(name)) return false;
+    if (this.props.ontology.termSet.has(name)) return false;
 
     /* check for label syntax errors */
     const error = AnnotationsHelpers.annotationNameIsErroneous(name);
@@ -260,7 +260,8 @@ class Category extends React.Component {
       "empty-string": "Blank names not allowed",
       duplicate: "Category name must be unique",
       "trim-spaces": "Leading and trailing spaces not allowed",
-      "illegal-characters": "Only alphanumeric and special characters (-_.) allowed",
+      "illegal-characters":
+        "Only alphanumeric and special characters (-_.) allowed",
       "multi-space-run": "Multiple consecutive spaces not allowed"
     };
     const errorMessage = errorMessageMap[err] ?? "error";

--- a/client/src/components/categorical/value.js
+++ b/client/src/components/categorical/value.js
@@ -106,7 +106,7 @@ class CategoryValue extends React.Component {
       "empty-string": "Blank names not allowed",
       duplicate: "Label must be unique",
       "trim-spaces": "Leading and trailing spaces not allowed",
-      "illegal-characters": "Only alphanumeric, underscore and period allowed",
+      "illegal-characters": "Only alphanumeric and special characters (-_.) allowed",
       "multi-space-run": "Multiple consecutive spaces not allowed"
     };
     const errorMessage = errorMessageMap[err] ?? "error";

--- a/client/src/reducers/ontology.js
+++ b/client/src/reducers/ontology.js
@@ -3,6 +3,7 @@ const Ontology = (
   state = {
     enabled: false, // are ontology terms enabled?
     terms: null, // an array of term names, eg, ['cell', 'lung cell', ...]
+    termSet: null, // a Set object containing all terms, for fast lookup
     loading: true
   },
   action
@@ -12,11 +13,13 @@ const Ontology = (
       const enabled =
         action.config?.parameters?.annotations_cell_ontology_enabled;
       const terms = action.config?.parameters?.annotations_cell_ontology_terms;
+      const termSet = new Set(terms);
       return {
         ...state,
         loading: false,
         enabled,
-        terms
+        terms,
+        termSet
       };
     default:
       return state;

--- a/client/src/util/stateManager/annotationsHelpers.js
+++ b/client/src/util/stateManager/annotationsHelpers.js
@@ -183,7 +183,7 @@ export function createWritableAnnotationDimensions(world, crossfilter) {
 	return crossfilter;
 }
 
-const legalCharacters = /^(\w|[ .])+$/;
+const legalCharacters = /^(\w|[ .()-])+$/;
 export function annotationNameIsErroneous(name) {
 	/*
 	Validate the name - return:
@@ -193,10 +193,9 @@ export function annotationNameIsErroneous(name) {
 	Tests:
 	0. must be string, non-null
 	1. no leading or trailing spaces
-	2. only accept alpha, numeric, underscore, period and space
+	2. only accept alpha, numeric, underscore, period, parens, hyphen and space
 	3. no runs of multiple spaces
 	*/
-
 	if (name === "") {
 		return "empty-string";
 	}

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -340,7 +340,7 @@ def launch(
             click.echo("Warning: --experimental-annotations-file ignored as --annotations not enabled.")
         if experimental_annotations_output_dir is not None:
             click.echo("Warning: --experimental-annotations-output-dir ignored as --annotations not enabled.")
-        if experimental_annotations_ontology is not None:
+        if experimental_annotations_ontology:
             click.echo("Warning: --experimental-annotations-ontology ignored as --annotations not enabled.")
         if experimental_annotations_ontology_obo is not None:
             click.echo("Warning: --experimental-annotations-ontology-obo ignored as --annotations not enabled.")


### PR DESCRIPTION
This PR makes two changes:
* custom annotations category names and labels may contain additional characters `/^(\w|[ .()-])+$/`
* if ontology suggest is enabled, allow use of any term in the ontology even if it has characters not legal in user-specified labels

Fixes #1113 


Open issue:

- [ ] **We still validate user input when they enter a label (i.e., not an ontology term), and still restrict to a subset of all characters.**
There is an outstanding bug on @colinmegill's annotation branch where no labels are being checked if ontologies are enabled. Will wait to merge until this is fixed.
