### PR TITLE
pin anndata to 0.6.22post1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,5 @@
-anndata>=0.6.20
+# TEMP anndata 0.7 breaks cellxgene - workaround
+anndata==0.6.22post1
 click>=6.7
 Flask>=1.0.2
 Flask-Caching>=1.4.0


### PR DESCRIPTION
the 0.7 AnnData release breaks cellxgene.  This change pins the anndata package to 0.6.22post1, the most recent which is compatible.

related #1123 