### PR TITLE
Undo feature: fix case where previous state has no state filter

### DIFF
--- a/client/src/reducers/undoable.js
+++ b/client/src/reducers/undoable.js
@@ -208,6 +208,7 @@ const Undoable = (reducer, undoableKeys, options = {}) => {
     };
     return nextState;
   }
+
   return (
     currentState = {
       [pastKey]: [],

--- a/client/src/reducers/undoable.js
+++ b/client/src/reducers/undoable.js
@@ -85,6 +85,7 @@ const Undoable = (reducer, undoableKeys, options = {}) => {
     );
     const newPast = [...past];
     const newState = newPast.pop();
+    const newStateFilterState = newState[filterStateKey];
     const newFuture = push(future, currentUndoableState);
     const nextState = {
       ...currentState,
@@ -93,6 +94,7 @@ const Undoable = (reducer, undoableKeys, options = {}) => {
       [futureKey]: newFuture,
       [pendingKey]: null
     };
+    nextState[filterStateKey] = newStateFilterState;
     return nextState;
   }
 
@@ -206,7 +208,6 @@ const Undoable = (reducer, undoableKeys, options = {}) => {
     };
     return nextState;
   }
-
   return (
     currentState = {
       [pastKey]: [],

--- a/client/src/reducers/undoableConfig.js
+++ b/client/src/reducers/undoableConfig.js
@@ -170,6 +170,8 @@ const actionFilter = debug => (state, action, prevFilterState) => {
   }
   if (
     debounceOnActions.has(actionType) &&
+    prevFilterState !== undefined &&
+    prevFilterState.prevAction !== undefined &&
     shallowObjectEq(action, prevFilterState.prevAction)
   ) {
     return { [actionKey]: "skip", [stateKey]: filterState };


### PR DESCRIPTION
Fixes https://github.com/chanzuckerberg/cellxgene/issues/1099

When the previous state that the undo feature is trying to roll back to
has no filter state, merging javascript dictionaries result in keeping
the current state filter, preventing the `actionFilter` from saving the
new state.