### PR TITLE
[WIP] Patch for anndata 0.7

### DIFF
--- a/server/app/rest_api/rest.py
+++ b/server/app/rest_api/rest.py
@@ -45,7 +45,7 @@ class ConfigAPI(Resource):
                 },
                 "links": {"about-dataset": current_app.config["ABOUT_DATASET"]},
                 "parameters": {**current_app.data.get_config_parameters(uid=cxguid, collection=anno_collection)},
-                "library_versions": {"cellxgene": cellxgene_version, "anndata": anndata_version},
+                "library_versions": {"cellxgene": cellxgene_version, "anndata": str(anndata_version)},
             }
         }
 

--- a/server/app/scanpy_engine/matrix_proxy.py
+++ b/server/app/scanpy_engine/matrix_proxy.py
@@ -38,6 +38,8 @@ class MatrixProxy_anndata_h5py(MatrixProxyView):
             "anndata.h5py.h5sparse.backed_csc_matrix",
             "anndata.h5py.h5sparse.backed_csr_matrix",
             "h5py._hl.dataset.Dataset",
+            "anndata._core.sparse_dataset.backed_csr_matrix",
+            "anndata._core.sparse_dataset.backed_csc_matrix",
         )
 
     @classmethod

--- a/server/app/util/matrix_proxy.py
+++ b/server/app/util/matrix_proxy.py
@@ -73,6 +73,8 @@ class MatrixProxy(_ArrayProxyBase):
         "numpy.ndarray": True,
         "scipy.sparse.csc.csc_matrix": True,
         "scipy.sparse.csr.csr_matrix": True,
+        "anndata._core.sparse_dataset.backed_csr_matrix": "MatrixProxy_anndata_h5py",
+        "anndata._core.sparse_dataset.backed_csc_matrix": "MatrixProxy_anndata_h5py",
     }
     proxy_registry = None
     last_cache_token = None

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,4 @@
-# TEMP anndata 0.7 breaks cellxgene - workaround
-anndata==0.6.22post1
+anndata>=0.6.2
 click>=6.7
 fastobo>=0.6.1
 Flask>=1.0.2


### PR DESCRIPTION
JSON encoding error caused by anndata 0.7.* was due to a change to `type(anndata.__version__)`. 

A bit tricky to find (thanks for the pointer, @bmccandless!), but a simple one-line fix. 

Reverts the temporary pin in the requirements back to `anndata>=0.6.2`.