### PR TITLE
Remove extra version replacement

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,10 +5,6 @@ current_version = 0.13.0
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:server/cli/cli.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:client/package.json]
 search = "version": "{current_version}"
 replace = "version": "{new_version}"


### PR DESCRIPTION
`make bump` was looking to replace a version string in `server/cli/cli.py` which no longer existed, causing it to crash the release process. This PR fixes this issue.