### PR TITLE
centroid label overlay UX improvements

### DIFF
--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -12,15 +12,17 @@ export default
   labels: state.centroidLabels.labels
 }))
 class CentroidLabels extends PureComponent {
+  // Check to see if centroids have either just been displayed or removed from the overlay
   componentDidUpdate = prevProps => {
-    // obj.keys(obj).length
     const { labels, onDisplayChange } = this.props;
     const prevSize = prevProps.labels.size;
     const { size } = labels;
+
     const displayChangeOff = prevSize > 0 && size === undefined;
     const displayChangeOn = prevSize === undefined && size > 0;
 
     if (displayChangeOn || displayChangeOff) {
+      // Notify overlay layer of display change
       onDisplayChange("centroidLabels", displayChangeOn);
     }
   };

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable jsx-a11y/mouse-events-have-key-events */
-import React, { PureComponent, Component } from "react";
+import React, { PureComponent } from "react";
 import { connect } from "react-redux";
 
 import { categoryLabelDisplayStringLongLength } from "../../../globals";

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -1,6 +1,9 @@
+/* eslint-disable max-classes-per-file */
 /* eslint-disable jsx-a11y/mouse-events-have-key-events */
-import React, { PureComponent } from "react";
+import React, { PureComponent, Component } from "react";
 import { connect } from "react-redux";
+
+import { categoryLabelDisplayStringLongLength } from "../../../globals";
 
 export default
 @connect(state => ({
@@ -41,6 +44,16 @@ class CentroidLabels extends PureComponent {
         fontSize = "18px";
         fontWeight = "800";
       }
+
+      // Mirror LSB middle truncation
+      let label = key;
+      if (label.length > categoryLabelDisplayStringLongLength) {
+        label = `${key.slice(
+          0,
+          categoryLabelDisplayStringLongLength / 2
+        )}…${key.slice(-categoryLabelDisplayStringLongLength / 2)}`;
+      }
+
       labelSVGS.push(
         <g
           // eslint-disable-next-line react/no-array-index-key
@@ -75,7 +88,7 @@ class CentroidLabels extends PureComponent {
             }
             pointerEvents="visiblePainted"
           >
-            {key.length > 20 ? `${key.substr(0, 20)}...` : key}
+            {label}
           </text>
         </g>
       );

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -14,7 +14,7 @@ export default
 class CentroidLabels extends PureComponent {
   // Check to see if centroids have either just been displayed or removed from the overlay
   componentDidUpdate = prevProps => {
-    const { labels, onDisplayChange } = this.props;
+    const { labels, overlayToggled } = this.props;
     const prevSize = prevProps.labels.size;
     const { size } = labels;
 
@@ -23,7 +23,7 @@ class CentroidLabels extends PureComponent {
 
     if (displayChangeOn || displayChangeOff) {
       // Notify overlay layer of display change
-      onDisplayChange("centroidLabels", displayChangeOn);
+      overlayToggled("centroidLabels", displayChangeOn);
     }
   };
 

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -9,6 +9,19 @@ export default
   labels: state.centroidLabels.labels
 }))
 class CentroidLabels extends PureComponent {
+  componentDidUpdate = prevProps => {
+    // obj.keys(obj).length
+    const { labels, onDisplayChange } = this.props;
+    const prevSize = prevProps.labels.size;
+    const { size } = labels;
+    const displayChangeOff = prevSize > 0 && size === undefined;
+    const displayChangeOn = prevSize === undefined && size > 0;
+
+    if (displayChangeOn || displayChangeOff) {
+      onDisplayChange("centroidLabels", displayChangeOn);
+    }
+  };
+
   render() {
     const {
       labels,

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -12,7 +12,7 @@ class GraphOverlayLayer extends PureComponent {
     This component takes its children (assumed in the data coordinate space ([0, 1] range, origin in bottom left corner))
     and transforms itself multiple times resulting in screen space ([0, screenWidth/Height] range, origin in top left corner)
 
-    Children are assigned in the graph component
+    Children are assigned in the graph component and must implement onDisplayChange()
    */
   constructor(props) {
     super(props);
@@ -36,6 +36,13 @@ class GraphOverlayLayer extends PureComponent {
 
   reverseMatrixScaleTransformString = m => {
     return `matrix(${1 / m[0]} 0 0 ${1 / m[4]} 0 0)`;
+  };
+
+  // This is passed to all children, should be called when an overlay's display state is toggled with the overlay name and its new display state in boolean form
+  onDisplayChange = (overlay, displaying) => {
+    this.setState(state => {
+      return { ...state, display: { ...state.display, [overlay]: displaying } };
+    });
   };
 
   render() {

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -108,7 +108,10 @@ class GraphOverlayLayer extends PureComponent {
                   transform={this.matrixToTransformString(modelTF)}
                 >
                   {newChildren.map(child =>
-                    cloneElement(child, { inverseTransform })
+                    cloneElement(child, {
+                      inverseTransform,
+                      onDisplayChange: this.onDisplayChange
+                    })
                   )}
                 </g>
               </g>

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -58,6 +58,9 @@ class GraphOverlayLayer extends PureComponent {
 
     if (!cameraTF) return null;
 
+    const { display } = this.state;
+    const displaying = Object.values(display).some(value => value); // check to see if at least one overlay is currently displayed
+
     const inverseTransform = `${this.reverseMatrixScaleTransformString(
       modelTF
     )} ${this.reverseMatrixScaleTransformString(
@@ -76,7 +79,10 @@ class GraphOverlayLayer extends PureComponent {
         width={responsive.width - graphPaddingRightLeft}
         height={responsive.height}
         pointerEvents="none"
-        style={{ zIndex: 99 }}
+        style={{
+          zIndex: 99,
+          backgroundColor: displaying ? "rgba(255, 255, 255, 0.55)" : ""
+        }}
       >
         <g
           id="canvas-transformation-group-x"

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -38,7 +38,7 @@ class GraphOverlayLayer extends PureComponent {
     return `matrix(${1 / m[0]} 0 0 ${1 / m[4]} 0 0)`;
   };
 
-  // This is passed to all children, should be called when an overlay's display state is toggled with the overlay name and its new display state in boolean form
+  // This is passed to all children, should be called when an overlay's display state is toggled along with the overlay name and its new display state in boolean form
   onDisplayChange = (overlay, displaying) => {
     this.setState(state => {
       return { ...state, display: { ...state.display, [overlay]: displaying } };

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -39,7 +39,7 @@ class GraphOverlayLayer extends PureComponent {
   };
 
   // This is passed to all children, should be called when an overlay's display state is toggled along with the overlay name and its new display state in boolean form
-  onDisplayChange = (overlay, displaying) => {
+  overlayToggled = (overlay, displaying) => {
     this.setState(state => {
       return { ...state, display: { ...state.display, [overlay]: displaying } };
     });
@@ -75,7 +75,7 @@ class GraphOverlayLayer extends PureComponent {
     const newChildren = React.Children.map(children, child =>
       cloneElement(child, {
         inverseTransform,
-        onDisplayChange: this.onDisplayChange
+        overlayToggled: this.overlayToggled
       })
     );
 

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -71,7 +71,13 @@ class GraphOverlayLayer extends PureComponent {
       -(responsive.height - graphPaddingTop)}) scale(2 1) scale(${1 /
       (responsive.width - graphPaddingRightLeft)} 1)`;
 
-    const newChildren = React.Children.toArray(children);
+    // Copy the children passed with the overlay and add the inverse transform and onDisplayChange props
+    const newChildren = React.Children.map(children, child =>
+      cloneElement(child, {
+        inverseTransform,
+        onDisplayChange: this.onDisplayChange
+      })
+    );
 
     return (
       <svg
@@ -107,12 +113,7 @@ class GraphOverlayLayer extends PureComponent {
                   id="model-transformation-group"
                   transform={this.matrixToTransformString(modelTF)}
                 >
-                  {newChildren.map(child =>
-                    cloneElement(child, {
-                      inverseTransform,
-                      onDisplayChange: this.onDisplayChange
-                    })
-                  )}
+                  {newChildren}
                 </g>
               </g>
             </g>

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -14,6 +14,14 @@ class GraphOverlayLayer extends PureComponent {
 
     Children are assigned in the graph component
    */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      display: {}
+    };
+  }
+
   matrixToTransformString = m => {
     /* 
       Translates the gl-matrix mat3 to SVG matrix transform style


### PR DESCRIPTION
Generally improves the UX of the label overlay in two ways:
* Drops opacity of the graph on overlay display
* Consistently truncates long labels

![image](https://user-images.githubusercontent.com/8716829/73701640-0d978680-469f-11ea-9341-7d08e9de76be.png)


---
This PR implements the following changes:
* In `client/src/components/graph/overlays/graphOverlayLayer.js`
   * add display state
   * add callback for changing the display state
   * check display state and change opacity accordingly
* In `client/src/components/graph/overlays/centroidLabels.js`
   * Add truncation check and implementation
   * Check display change and call `onDisplayChange()` if necessary
---
Closes #1121, Closes #1136 