### PR TITLE
update anndata dependency requirement; remove h5py pinned version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,6 +12,4 @@ numpy>=1.15.2
 pandas>=0.24.2
 scipy>=1.3.0
 tables==3.5.1
-# TEMP workaround for https://github.com/theislab/scanpy/issues/832 aka h5py regression
-h5py==2.9.0
 requests>=2.22.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-anndata>=0.6.2
+anndata>=0.7.1
 click>=6.7
 fastobo>=0.6.1
 Flask>=1.0.2


### PR DESCRIPTION
Remove the temporary pinned dependency on h5py.  It is believed the incompatibility is resolved by the 0.7 anndata release.

This also bumps the minimum requirement for anndata to >=0.7.1, as the combination of anndata <= 0.7 and h5py 2.10 will trigger the compat bug.

Fixes #917
