### PR TITLE
Collect all env vars in one, easy-to-find place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,11 @@ smoke-test:
 .PHOHY: fmt
 fmt: fmt-client fmt-py
 
+.PHONY: fmt-client
 fmt-client:
 	cd client && $(MAKE) fmt
 
+.PHONY: fmt
 fmt-py:
 	black .
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include common.mk
+
 BUILDDIR := build
 CLIENTBUILD := $(BUILDDIR)/client
 SERVERBUILD := $(BUILDDIR)/server

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ CLEANFILES :=  $(BUILDDIR)/ client/build build dist cellxgene.egg-info
 
 PART ?= patch
 
-
 # CLEANING
 .PHONY: clean
 clean: clean-lite clean-server clean-client

--- a/client/Makefile
+++ b/client/Makefile
@@ -25,7 +25,7 @@ build:
 
 .PHONY: server-requirements
 server-requirements:
-	virtualenv -p python3.6 ../venv
+	virtualenv -p python3 ../venv
 	source ../venv/bin/activate && \
 		pip install -r ../server/requirements-dev.txt && \
 		yes | pip uninstall cellxgene || true && \
@@ -35,10 +35,13 @@ server-requirements:
 start-frontend:
 	node server/development.js
 
+.PHONY: start-server
+start-server:
+	cellxgene launch -p $(CXG_SERVER_PORT) $(CXG_OPTIONS) $(DATASET)
+
 .PHONY: backend-dev
 backend-dev: server-requirements
-	source ../venv/bin/activate && \
-		cellxgene launch -p $(CXG_SERVER_PORT) $(CXG_OPTIONS) $(DATASET)
+	source ../venv/bin/activate && $(MAKE) start-server
 
 .PHONY: backend-dev-anno
 backend-dev-anno: server-requirements
@@ -62,10 +65,7 @@ test:
 
 .PHONY: smoke-test
 smoke-test:
-	start_server_and_test \
-		'cellxgene launch -p $(CXG_SERVER_PORT) $(DATASET)' \
-		$(CXG_SERVER_PORT) \
-		'$(MAKE) e2e'
+	start_server_and_test '$(MAKE) start-server' $(CXG_SERVER_PORT) '$(MAKE) e2e'
 
 .PHONY: unit-test
 unit-test:
@@ -74,4 +74,3 @@ unit-test:
 # pass remaining commands through to npm run
 %:
 	npm run $(*)
-

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,3 +1,5 @@
+include ../common.mk
+
 .PHONY: clean
 clean:
 	rm -rf node_modules

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,5 +1,9 @@
 include ../common.mk
 
+DATASET := $(if $(DATASET),$(DATASET),../example-dataset/pbmc3k.h5ad)
+
+# Packaging
+
 .PHONY: clean
 clean:
 	rm -rf node_modules
@@ -15,6 +19,57 @@ install:
 .PHONY: build
 build:
 	npm run build
+
+
+# Development convenience methods
+
+.PHONY: server-requirements
+server-requirements:
+	virtualenv -p python3.6 ../venv
+	source ../venv/bin/activate && \
+		pip install -r ../server/requirements-dev.txt && \
+		yes | pip uninstall cellxgene || true && \
+		pip install -e ..
+
+.PHONY: start-frontend
+start-frontend:
+	node server/development.js
+
+.PHONY: backend-dev
+backend-dev: server-requirements
+	source ../venv/bin/activate && \
+		cellxgene launch -p $(CXG_SERVER_PORT) $(CXG_OPTIONS) $(DATASET)
+
+.PHONY: backend-dev-anno
+backend-dev-anno: server-requirements
+	CXG_OPTIONS='--experimental-annotations' $(MAKE) backend-dev
+
+.PHONY: backend-dev-anno-ontology
+backend-dev-anno-ontology: server-requirements
+	CXG_OPTIONS='--experimental-annotations --experimental-annotations-ontology' \
+		$(MAKE) backend-dev
+
+.PHONY: e2e
+e2e:
+	node node_modules/jest/bin/jest.js \
+		--verbose false \
+		--config __tests__/e2e/e2eJestConfig.json \
+		e2e/e2e.test.js
+
+.PHONY: test
+test:
+	node node_modules/jest/bin/jest.js
+
+.PHONY: smoke-test
+smoke-test:
+	start_server_and_test \
+		'cellxgene launch -p $(CXG_SERVER_PORT) $(DATASET)' \
+		$(CXG_SERVER_PORT) \
+		'$(MAKE) e2e'
+
+.PHONY: unit-test
+unit-test:
+	node node_modules/jest/bin/jest.js --testPathIgnorePatterns e2e
 
 # pass remaining commands through to npm run
 %:

--- a/client/__tests__/e2e/config.js
+++ b/client/__tests__/e2e/config.js
@@ -1,5 +1,5 @@
-export const jest_env = process.env.JEST_ENV || "dev";
-export const appPort = process.env.JEST_CXG_PORT || 3000;
+export const jest_env = process.env.JEST_ENV;
+export const appPort = process.env.CXG_SERVER_PORT;
 export const appUrlBase = `http://localhost:${appPort}`;
 export const DEV = jest_env === "dev";
 export const DEBUG = jest_env === "debug";

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -88,6 +88,9 @@ module.exports = {
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({
       __REACT_DEVTOOLS_GLOBAL_HOOK__: "({ isDisabled: true })"
+    }),
+    new webpack.DefinePlugin({
+      "process.env.CXG_SERVER_PORT": JSON.stringify(process.env.CXG_SERVER_PORT),
     })
   ]
 };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6564,6 +6564,11 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
+    "after": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
+    },
     "agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
@@ -6804,6 +6809,11 @@
         }
       }
     },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -6875,6 +6885,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -6898,6 +6913,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "aws-sign": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
+      "integrity": "sha1-xVAThWyBlOyFSgy+yQqrWgTOOsU="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -7114,6 +7134,14 @@
         "@babel/plugin-transform-modules-commonjs": "^7.2.0"
       }
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -7175,6 +7203,11 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+      "integrity": "sha1-R030qfLaJOBd8xWMOx2zw81GoVQ="
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -7190,6 +7223,14 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -7201,6 +7242,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
+    },
+    "blob": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz",
+      "integrity": "sha1-uJVivWmUr5W6HoEhVVNjM6ojzyQ="
     },
     "bluebird": {
       "version": "3.7.1",
@@ -7254,6 +7300,14 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "boom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
+      "integrity": "sha1-yM2wQUNZEnQWKMBE7Mcy0dF8Ceo=",
+      "requires": {
+        "hoek": "0.7.x"
+      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -7575,6 +7629,11 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7690,12 +7749,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-more-types": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
       "dev": true
     },
     "chokidar": {
@@ -7823,6 +7876,28 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "client": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client/-/client-0.0.1.tgz",
+      "integrity": "sha1-ZTAeRW3G5fIIphGIY2I0ckK3wrg=",
+      "requires": {
+        "backoff": "^2.4.0",
+        "cookie": "^0.1.2",
+        "getenv": "~0.3.0",
+        "q": "~0.9.7",
+        "restler": "~2.0.1",
+        "socket.io-client": "~1.0.6",
+        "underscore": "^1.6.0",
+        "winston": "^0.7.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+          "integrity": "sha1-armUiksa4hlSzSWIUwpHItQETXw="
+        }
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -7923,6 +7998,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -7943,11 +8023,21 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8040,6 +8130,11 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
+    },
+    "cookie-jar": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
+      "integrity": "sha1-ZOzAasl423leS1KQy+SLo3gUAPo="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -8230,6 +8325,14 @@
         "which": "^1.2.9"
       }
     },
+    "cryptiles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
+      "integrity": "sha1-GlVnNPBtJLo0hirpy55wmjr7/xw=",
+      "requires": {
+        "boom": "0.3.x"
+      }
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -8396,6 +8499,11 @@
         "find-pkg": "^0.1.2",
         "fs-exists-sync": "^0.1.0"
       }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -9030,12 +9138,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -9091,6 +9193,13 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emitter": {
+      "version": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+      "integrity": "sha512-k3Da+QreMb9waaGCHNAHox5QqxnZEYlQmvIVYwQibrI6OpIRyIIyFGgDV5dXRLr1AJ32JLqEh0VxQEq20dFskw==",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -9116,6 +9225,73 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io-client": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
+      "integrity": "sha1-HFpl1cWvbQS0TCLD282Vw57RyYk=",
+      "requires": {
+        "component-emitter": "1.1.2",
+        "component-inherit": "0.0.3",
+        "debug": "0.7.4",
+        "engine.io-parser": "1.0.6",
+        "has-cors": "1.0.3",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.1",
+        "parseqs": "0.0.2",
+        "parseuri": "0.0.2",
+        "ws": "0.4.31",
+        "xmlhttprequest": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+        },
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "nan": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+          "integrity": "sha1-DfGTXKsVNpB17xYK0olBB6oU3C0="
+        },
+        "ws": {
+          "version": "0.4.31",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+          "integrity": "sha1-WkhJ56nM0e1aga60hHyf7fMSKSc=",
+          "requires": {
+            "commander": "~0.6.1",
+            "nan": "~0.3.0",
+            "options": ">=0.0.5",
+            "tinycolor": "0.x"
+          }
+        },
+        "xmlhttprequest": {
+          "version": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
+          "integrity": "sha512-TVSZwoeUQ7OKhb8jnQdSxGFz+lm4MGWmhG0deeYg85VQT74x5LcSrKeXHE0ZIzEycgqQ5mF8r8e1AykA7TpNAQ=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
+      "integrity": "sha1-04gTFDpBHLO5FBMqsFv5nm96JI4=",
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.2",
+        "blob": "0.0.2",
+        "utf8": "2.0.0"
       }
     },
     "enhanced-resolve": {
@@ -10034,21 +10210,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -10920,6 +11081,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -11360,12 +11526,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "from2": {
@@ -12015,6 +12175,11 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "getenv": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-0.3.0.tgz",
+      "integrity": "sha1-se8/l+ncVUZ4KFmyIrVlmgx47qo="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -12073,6 +12238,10 @@
           }
         }
       }
+    },
+    "global": {
+      "version": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+      "integrity": "sha512-O91OcV/NbdmQJPHaRu2ekSP7bqFRLWgqSwaJvqHPZHUwmHBagQYTOra29+LnzzG3lZkXH1ANzHzfCxtAPM9HMA=="
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -12216,6 +12385,29 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-binary-data": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
+      "integrity": "sha1-4QdJ+4eCilLflvQIZYfrSgOWZDk=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+      "integrity": "sha1-UCrLmzEE2sM90mMOry+IiwuvTLM=",
+      "requires": {
+        "global": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12299,6 +12491,17 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hawk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+      "integrity": "sha1-mzYd7pWpMWQObVBOBWCaj8OsRdI=",
+      "requires": {
+        "boom": "0.3.x",
+        "cryptiles": "0.1.x",
+        "hoek": "0.7.x",
+        "sntp": "0.1.x"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -12315,6 +12518,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoek": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
+      "integrity": "sha1-YPvZBFV1Qc0rh5Wr8wihs3cOFVo="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -12602,6 +12810,11 @@
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -18742,6 +18955,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json3": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+      "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s="
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -18799,12 +19017,6 @@
       "requires": {
         "package-json": "^4.0.0"
       }
-    },
-    "lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
-      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -19103,12 +19315,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -19665,6 +19871,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -19951,6 +20162,11 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -20142,6 +20358,30 @@
       "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
+    "parsejson": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+      "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+      "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+      "integrity": "sha1-20GHjy1pZHGL6HCzFAlz2Ak74VY=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -20221,15 +20461,6 @@
         }
       }
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3"
-      }
-    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -20299,6 +20530,11 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
     },
     "pn": {
       "version": "1.1.0",
@@ -20424,6 +20660,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
       "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
       "dev": true
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -20597,15 +20838,6 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "ps-tree": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "dev": true,
-      "requires": {
-        "event-stream": "=3.3.4"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -20738,6 +20970,11 @@
           }
         }
       }
+    },
+    "q": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
     },
     "qs": {
       "version": "6.7.0",
@@ -21406,6 +21643,11 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restler": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-2.0.1.tgz",
+      "integrity": "sha1-WT49T6xrk/r/ocXtDKl/o0IgeMg="
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -22018,6 +22260,66 @@
         }
       }
     },
+    "sntp": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
+      "integrity": "sha1-XvSBuVGnspr/30r9fyaDj8ESD4Q=",
+      "requires": {
+        "hoek": "0.7.x"
+      }
+    },
+    "socket.io-client": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
+      "integrity": "sha1-yGyz5QerL5baRQC9NPz0ah6d/l4=",
+      "requires": {
+        "component-bind": "1.0.0",
+        "component-emitter": "1.1.2",
+        "debug": "0.7.4",
+        "engine.io-client": "1.3.1",
+        "has-binary-data": "0.1.1",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.2",
+        "socket.io-parser": "2.2.0",
+        "to-array": "0.1.3"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
+      "integrity": "sha1-JglgH1nmp/q0NqU749Mz+7/L0wo=",
+      "requires": {
+        "debug": "0.7.4",
+        "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+        "isarray": "0.0.1",
+        "json3": "3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -22120,15 +22422,6 @@
       "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -22170,125 +22463,16 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
-    },
-    "start-server-and-test": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.10.6.tgz",
-      "integrity": "sha512-Gr/TDePT4JczaoBiKZLZRIWmYgRcoGcFQePtPEHEvZFUuxbdUqTZozx8dqrlKl/67+pipg5OOtBH21U1oJXJIQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.7.1",
-        "check-more-types": "2.24.0",
-        "debug": "4.1.1",
-        "execa": "2.1.0",
-        "lazy-ass": "1.6.0",
-        "ps-tree": "1.2.0",
-        "wait-on": "3.3.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "execa": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^3.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -22331,15 +22515,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {
@@ -22943,6 +23118,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -22957,6 +23137,11 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
+    },
+    "to-array": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz",
+      "integrity": "sha1-1F2txjY0F/YPKEdP6lDs3btPSZE="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -23190,6 +23375,11 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -23479,6 +23669,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz",
+      "integrity": "sha1-ec5Z7O2HSAnKuacfxxAsfUXUEY0="
     },
     "util": {
       "version": "0.11.1",
@@ -24051,6 +24246,98 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "winston": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+      "integrity": "sha1-euMTunP83C7LSqL5zURugphncmY=",
+      "requires": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "pkginfo": "0.3.x",
+        "request": "2.16.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+        },
+        "forever-agent": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
+          "integrity": "sha1-4cJcetROCcOPIzh2x2/MJP+EOx8="
+        },
+        "form-data": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+          "integrity": "sha1-2zRaU3jYau6x7V1VO4aawZLS9e0=",
+          "requires": {
+            "async": "~0.2.7",
+            "combined-stream": "~0.0.4",
+            "mime": "~1.2.2"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
+          "integrity": "sha1-nbew5TDH8onF6MhDKvGRwv91pbM="
+        },
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "oauth-sign": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
+          "integrity": "sha1-oOahcV2u0GLzIrYit/5a/RA1tuI="
+        },
+        "qs": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+          "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q="
+        },
+        "request": {
+          "version": "2.16.6",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+          "integrity": "sha1-hy/kRa5y3iZrN4edatfclI+gHK0=",
+          "requires": {
+            "aws-sign": "~0.2.0",
+            "cookie-jar": "~0.2.0",
+            "forever-agent": "~0.2.0",
+            "form-data": "~0.0.3",
+            "hawk": "~0.10.2",
+            "json-stringify-safe": "~3.0.0",
+            "mime": "~1.2.7",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.2.0",
+            "qs": "~0.5.4",
+            "tunnel-agent": "~0.2.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
+          "integrity": "sha1-aFPCr7GyEJ5FYp5JK9419Fnqaeg="
+        }
       }
     },
     "word-wrap": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,20 +5,11 @@
   "description": "cellxgene is a web application for the interactive exploration of single cell sequence data.",
   "repository": "https://github.com/chanzuckerberg/cellxgene",
   "scripts": {
-    "backend-dev": "python3.6 -m venv cellxgene && source cellxgene/bin/activate && yes | pip uninstall cellxgene || true && pip install -e .. && cellxgene launch ",
-    "backend-dev-anno-ontology": "python3.6 -m venv cellxgene && source cellxgene/bin/activate && yes | pip uninstall cellxgene || true && pip install -e .. && cellxgene launch --experimental-annotations --experimental-annotations-ontology",
-    "backend-dev-anno": "python3.6 -m venv cellxgene && source cellxgene/bin/activate && yes | pip uninstall cellxgene || true && pip install -e .. && cellxgene launch --experimental-annotations",
-    "build": "npm run clean && webpack --config configuration/webpack/webpack.config.prod.js",
     "clean": "rimraf build",
+    "build": "npm run clean && webpack --config configuration/webpack/webpack.config.prod.js",
     "dev": "npm run clean && webpack --config configuration/webpack/webpack.config.dev.js",
-    "e2e": "node node_modules/jest/bin/jest.js --verbose false --config __tests__/e2e/e2eJestConfig.json e2e/e2e.test.js",
     "fmt": "eslint --fix src",
-    "lint": "eslint src",
-    "smoke-test": "start-server-and-test start-server-for-test :5000 e2e",
-    "start": "node server/development.js",
-    "start-server-for-test": "cellxgene launch -p 5000 ../example-dataset/pbmc3k.h5ad",
-    "test": "node node_modules/jest/bin/jest.js",
-    "unit-test": "node node_modules/jest/bin/jest.js --testPathIgnorePatterns e2e"
+    "lint": "eslint src"
   },
   "engineStrict": true,
   "engines": {
@@ -37,6 +28,7 @@
     "@blueprintjs/core": "^3.22.3",
     "@blueprintjs/icons": "^3.13.0",
     "@blueprintjs/select": "^3.11.2",
+    "client": "0.0.1",
     "d3": "^4.10.0",
     "d3-scale-chromatic": "^1.5.0",
     "flatbuffers": "^1.11.0",
@@ -101,7 +93,6 @@
     "puppeteer": "^2.1.1",
     "rimraf": "^3.0.1",
     "serve-favicon": "^2.3.0",
-    "start-server-and-test": "^1.10.6",
     "style-loader": "^1.1.3",
     "sw-precache-webpack-plugin": "^1.0.0",
     "url-loader": "^3.0.0",

--- a/client/server/development.js
+++ b/client/server/development.js
@@ -11,7 +11,7 @@ var utils = require("./utils");
 
 process.env.NODE_ENV = "development";
 
-var PORT = process.env.PORT || 3000;
+const CLIENT_PORT = process.env.CXG_CLIENT_PORT;
 
 // Set up compiler
 var compiler = webpack(config);
@@ -22,7 +22,7 @@ compiler.plugin("invalid", () => {
 });
 
 compiler.plugin("done", stats => {
-  utils.formatStats(stats, PORT);
+  utils.formatStats(stats, CLIENT_PORT);
 });
 
 // Launch server
@@ -43,7 +43,7 @@ app.get("*", (req, res) => {
   res.sendFile(path.resolve("index.html"));
 });
 
-app.listen(PORT, err => {
+app.listen(CLIENT_PORT, err => {
   if (err) {
     console.log(err);
     return;

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -1,4 +1,5 @@
 import { Colors } from "@blueprintjs/core";
+import { dispatchNetworkErrorMessageToUser } from "./util/actionHelpers";
 
 /* if a categorical metadata field has more options than this, truncate */
 export const maxCategoricalOptionsToDisplay = 100;
@@ -77,15 +78,23 @@ export const categoryLabelDisplayStringShortLength = 11;
 export const tooltipHoverOpenDelay = 1000; /* ms delay before a tooltip displays */
 export const tooltipHoverOpenDelayQuick = 500;
 
-const serverPort = process.env.CXG_SERVER_PORT || 5005;
+let _API;
 
-let _API = {
-  // prefix: "http://api.clustering.czi.technology/api/",
-  // prefix: "http://tabulamuris.cxg.czi.technology/api/",
-  // prefix: "http://api-staging.clustering.czi.technology/api/",
-  prefix: `http://localhost:${serverPort}/api/`,
-  version: "v0.2/"
-};
+if (window.CELLXGENE && window.CELLXGENE.API) {
+  _API = window.CELLXGENE.API;
+} else {
+  if (process.env.CXG_SERVER_PORT === undefined) {
+    const errorMessage = "Please set the CXG_SERVER_PORT environment variable.";
+    dispatchNetworkErrorMessageToUser(errorMessage);
+    throw new Error(errorMessage);
+  }
+  _API = {
+    // prefix: "http://api.clustering.czi.technology/api/",
+    // prefix: "http://tabulamuris.cxg.czi.technology/api/",
+    // prefix: "http://api-staging.clustering.czi.technology/api/",
+    prefix: `http://localhost:${process.env.CXG_SERVER_PORT}/api/`,
+    version: "v0.2/"
+  };
+}
 
-if (window.CELLXGENE && window.CELLXGENE.API) _API = window.CELLXGENE.API;
 export const API = _API;

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -77,11 +77,13 @@ export const categoryLabelDisplayStringShortLength = 11;
 export const tooltipHoverOpenDelay = 1000; /* ms delay before a tooltip displays */
 export const tooltipHoverOpenDelayQuick = 500;
 
+const serverPort = process.env.CXG_SERVER_PORT || 5005;
+
 let _API = {
   // prefix: "http://api.clustering.czi.technology/api/",
   // prefix: "http://tabulamuris.cxg.czi.technology/api/",
   // prefix: "http://api-staging.clustering.czi.technology/api/",
-  prefix: "http://localhost:5005/api/",
+  prefix: `http://localhost:${serverPort}/api/`,
   version: "v0.2/"
 };
 

--- a/common.mk
+++ b/common.mk
@@ -1,7 +1,7 @@
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 PATH := $(PATH):$(PROJECT_ROOT)/scripts
 
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := env PATH='$(PATH)' /bin/bash
 
 # get_or_else_dev_env_default
 # - If a variable is defined, return its value

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,19 @@
+PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
+PATH := $(PATH):$(PROJECT_ROOT)/scripts
+
+SHELL := env PATH=$(PATH) /bin/bash
+
+# get_or_else_dev_env_default
+# - If a variable is defined, return its value
+# - Else return the default value from environment.dev
+define get_or_else_dev_env_default
+$(if $($(1)),$($(1)),$(shell sed -n 's/$(1)=\(.*\)/\1/p' < $(PROJECT_ROOT)/environment.default))
+endef
+
+export CXG_SERVER_PORT := $(call get_or_else_dev_env_default,CXG_SERVER_PORT)
+export CXG_CLIENT_PORT := $(call get_or_else_dev_env_default,CXG_CLIENT_PORT)
+export JEST_ENV := $(call get_or_else_dev_env_default,JEST_ENV)
+
+export CXG_SERVER_PORT
+export CXG_CLIENT_PORT
+export JEST_ENV

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -9,36 +9,42 @@
 
 **All instructions are expected to be run from the top level cellxgene directory unless otherwise specified.**
 
+### Environment
+
+* To load the development environment: `source environment.dev`
+* To load the CI environment: `source environment.ci`
+
 ## Running test suite
 Client and server tests run on Travis CI for every push, PR, and commit to master on github. End to end tests run nightly on master only. 
 
 ### Unit tests
 Steps to run the all unit tests:
 1. Start in the project root directory
+1. [Load an environment](#Environment)
 1. `make dev-env`
 1. `make unit-test`
 
 ### End to end tests
 
-End to end tests use two env variables:
-* `JEST_ENV` - environment to run end to end tests. Default `dev`
-    * `prod` - run headless with no slowdown, chromium will not open.
-    * `dev` - opens chromimum, runs tests with minimal slowdown, close on exit.
-    * `debug` - opens chromium, runs tests with 100ms slowdown, dev tools open, chrome stays open on exit.
-* `JEST_CXG_PORT` - port that end to end tests are being run on. Default `3000` (client hosted port).
+To run E2E tests:
+1. [Load an environment](#Environment)
+1. `cd client` and `make smoke-test`
 
-On CI the end to end tests are run with `JEST_ENV` set to `prod` using the `smoke-test` make target.
-
-To run end to end tests as they will be run on CI use the following command:
-```
-JEST_ENV=prod JEST_CXG_PORT=5000 make pydist install-dist dev-env smoke-test
-```
+The `JEST_ENV` environment variable enables the following E2E test options:
+* `dev` - opens chromimum, runs tests with minimal slowdown, close on exit.
+* `debug` - opens chromium, runs tests with 100ms slowdown, dev tools open, chrome stays open on exit.
+* `prod` - run headless with no slowdown, chromium will not open.
 
 Run end to end tests interactively during development
 1. cellxgene should be installed as [specified in client dev](#install-1)
 1. Follow [launch](#launch-1) instructions for client dev with dataset `example-dataset/pbmc3k`
 1. Run `npm run e2e` or `make e2e` from the `client` directory
 1. To debug a failing test `export JEST_ENV='debug'` and re-run.
+
+To run end to end tests _exactly_ as they will be run on CI use the following command:
+```
+source environment.ci && make pydist install-dist dev-env smoke-test
+```
 
 ## Server dev
 ### Install

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -11,8 +11,9 @@
 
 ### Environment
 
-* To load the development environment: `source environment.dev`
-* To load the CI environment: `source environment.ci`
+For all `make` commands, `common.mk` automatically checks whether required environment variables are set and, if they are not set, assigns them default values from `environment.default`.
+
+You can set these environment variables manually with the `export` shell command, as in `export JEST_ENV=debug`.
 
 ## Running test suite
 Client and server tests run on Travis CI for every push, PR, and commit to master on github. End to end tests run nightly on master only. 
@@ -20,15 +21,12 @@ Client and server tests run on Travis CI for every push, PR, and commit to maste
 ### Unit tests
 Steps to run the all unit tests:
 1. Start in the project root directory
-1. [Load an environment](#Environment)
 1. `make dev-env`
 1. `make unit-test`
 
 ### End to end tests
 
-To run E2E tests:
-1. [Load an environment](#Environment)
-1. `cd client` and `make smoke-test`
+To run E2E tests, run `cd client` and `make smoke-test`
 
 The `JEST_ENV` environment variable enables the following E2E test options:
 * `dev` - opens chromimum, runs tests with minimal slowdown, close on exit.
@@ -43,7 +41,7 @@ Run end to end tests interactively during development
 
 To run end to end tests _exactly_ as they will be run on CI use the following command:
 ```
-source environment.ci && make pydist install-dist dev-env smoke-test
+JEST_ENV=prod make pydist install-dist dev-env smoke-test
 ```
 
 ## Server dev

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -24,6 +24,11 @@ Steps to run the all unit tests:
 1. `make dev-env`
 1. `make unit-test`
 
+To run unit tests for the `client` code only:
+1. Start in the project root directory
+1. `cd client`
+1. `make unit-test`
+
 ### End to end tests
 
 To run E2E tests, run `cd client` and `make smoke-test`

--- a/dev_docs/developer_scripts.md
+++ b/dev_docs/developer_scripts.md
@@ -1,56 +1,8 @@
-## Node scripts in package.json
+# Developer convenience methods
 
-#### backend-dev
+## Makefile
 
-**About** This scripts enables FE developers to run the rest API necessary to back the development server for the front end. It is intended to ensure that the FE developer gets the current version of the backend with a single command and no knowledge of python necessary. It creates and activates a virtual environment and installs cellxgene from the current branch.
-
-**Requires** Python3.6 - `virtual-env`, `pip`
-
-**Usage** `npm run backend-dev <dataset>` then you can launch the node development server to serve the current state of the FE `npm run start`
-
-**Tips** Developers will probably want to run this in parallel with the node dev server. You can either do this by running each in a separate termanial window or by running `backend-dev` in the background (add an `&` at the end of the command to run in the background: `npm run backend-dev <dataset> &`).
-
-**Breakdown**
-
-| command                                  | purpose                                                   |
-| ---------------------------------------- | --------------------------------------------------------- |
-| python3.6 -m venv cellxgene              | creates cellxgene virtual environment                     |
-| source cellxgene/bin/activate            | activates virtual environment                             |
-| yes \| pip uninstall cellxgene \|\| true | uninstalls cellxgene (if installed)                       |
-| pip install -e ..                        | installs current local version of cellxgene               |
-| cellxgene launch                         | launches cellxgene (must supply dataset as last parameter |
-
-### Test scripts
-
-#### test
-
-**About** Run test locally. In order for this command to succeed you will need to give it a specific unit test to run. It won't pass if you run all tests as may be expected. This is because the unit tests and end to end (e2e) tests require different testing environments.
-
-**Usage** `npm run test <test file or pattern>`
-
-#### unit-test
-
-**About** Runs all unit tests. It excludes any tests in the e2e folder. This is used by travis to run unit tests.
-
-**Usage** `npm run unit-test`
-
-#### smoke-test
-
-**About** Starts backend development server and runs end to end tests. This is what travis runs. It depends on the `e2e` and the `start-server-for-test` node scripts. One starts the server, the other runs the tests. If developing a front-end feature and just checking if tests pass, this is probabaly the one you want to run.
-
-**Requirements** Must set env variable for port. In terminal `export JEST_ENV='dev'`, `source environment.dev` or `source environment.ci`
-
-**Usage** `npm run smoke-test`
-
-#### e2e
-
-**About** Runs backend tests without starting the server. You will need to start the rest api separately with the pbmc3k.h5ad file.
-
-**Requirements** Must set env variable for port. In terminal either `source environment.dev` or `source environment.ci`.
-
-**Usage** `npm run e2e`
-
-## makefile
+Documentation for the `Makefile` targets in the project root directory.
 
 ### Build commands
 
@@ -118,3 +70,65 @@ gui-spec-windows - creates the initial spec file for windows, do not run unless 
 gui-build-osx - builds the app from the osx spec file
 gui-build-windows - builds the app from the windows spec file
 ```
+## Client Makefile
+
+The following phony `make` targets in `client/Makefile` are convenience methods for getting you up and developing.
+
+### Runner scripts
+
+#### start-frontend
+
+**About** Serve the current client javascript independently from the `server` code.
+
+**Requires**
+* The server to be running. Best way to do this is with `make backend-dev`
+* `make ci` to install the necessary node modules
+
+**Usage** `make start-frontend`
+
+#### backend-dev
+
+**About** This script enables FE developers to run the REST API necessary to back the development server for the front end. It is intended to ensure that the FE developer gets the current version of the backend with a single command and no knowledge of python necessary. It creates and activates a virtual environment and installs cellxgene from the current branch.
+
+**Requires** Python3.6 - `virtual-env`, `pip`
+
+**Usage** `make backend-dev`. Optionally, you can then launch the node development server to serve the current state of the FE with `make start-frontend`. You can also select a specific dataset using `DATASET=<dataset path> make backend-dev`.
+
+**Tips** Developers will probably want to run this in parallel with the node dev server. You can either do this by running each in a separate termanial window or by running `backend-dev` in the background (add an `&` at the end of the command to run in the background: `DATASET=<dataset> make backend-dev &`).
+
+**Breakdown**
+
+| command                                  | purpose                                                   |
+| ---------------------------------------- | --------------------------------------------------------- |
+| python3.6 -m venv cellxgene              | creates cellxgene virtual environment                     |
+| source cellxgene/bin/activate            | activates virtual environment                             |
+| yes \| pip uninstall cellxgene \|\| true | uninstalls cellxgene (if installed)                       |
+| pip install -e ..                        | installs current local version of cellxgene               |
+| cellxgene launch                         | launches cellxgene (must supply dataset as last parameter |
+
+### Test scripts
+
+#### test
+
+**About** Run test locally. In order for this command to succeed you will need to give it a specific unit test to run. It won't pass if you run all tests as may be expected. This is because the unit tests and end to end (e2e) tests require different testing environments.
+
+**Usage** `make test`
+
+#### unit-test
+
+**About** Runs all unit tests. It excludes any tests in the e2e folder. This is used by travis to run unit tests.
+
+**Usage** `make unit-test`
+
+#### smoke-test
+
+**About** Starts backend development server and runs end to end tests. This is what travis runs. It depends on the `e2e` and the `backend-dev` targets. One starts the server, the other runs the tests. If developing a front-end feature and just checking if tests pass, this is probabaly the one you want to run.
+
+**Usage** `make smoke-test`
+
+#### e2e
+
+**About** Runs backend tests without starting the server. You will need to start the rest api separately with the pbmc3k.h5ad file. Note you can use the `JEST_ENV` environment variable to change how JEST runs in the browser.
+
+**Usage** `make e2e`
+

--- a/dev_docs/developer_scripts.md
+++ b/dev_docs/developer_scripts.md
@@ -92,7 +92,10 @@ The following phony `make` targets in `client/Makefile` are convenience methods 
 
 **Requires** Python3.6 - `virtual-env`, `pip`
 
-**Usage** `make backend-dev`. Optionally, you can then launch the node development server to serve the current state of the FE with `make start-frontend`. You can also select a specific dataset using `DATASET=<dataset path> make backend-dev`.
+**Usage** `make backend-dev`. Optionally, you can then launch the node development server to serve the current state of
+the FE with `make start-frontend`. You can also select a specific dataset using `DATASET=<dataset path> make backend-dev`.
+You can also use `CXG_OPTIONS` to pass options to the `cellxgene launch` command, as in
+`CXG_OPTIONS='--experimental-annotations --experimental-annotations-file annotations.csv' make backend-dev`.
 
 **Tips** Developers will probably want to run this in parallel with the node dev server. You can either do this by running each in a separate termanial window or by running `backend-dev` in the background (add an `&` at the end of the command to run in the background: `DATASET=<dataset> make backend-dev &`).
 
@@ -103,8 +106,8 @@ The following phony `make` targets in `client/Makefile` are convenience methods 
 | python3.6 -m venv cellxgene              | creates cellxgene virtual environment                     |
 | source cellxgene/bin/activate            | activates virtual environment                             |
 | yes \| pip uninstall cellxgene \|\| true | uninstalls cellxgene (if installed)                       |
-| pip install -e ..                        | installs current local version of cellxgene               |
-| cellxgene launch                         | launches cellxgene (must supply dataset as last parameter |
+| pip install -e .                        | installs current local version of cellxgene               |
+| cellxgene launch                         | launches cellxgene (must supply dataset as last parameter) |
 
 ### Test scripts
 

--- a/dev_docs/developer_scripts.md
+++ b/dev_docs/developer_scripts.md
@@ -38,7 +38,7 @@
 
 **About** Starts backend development server and runs end to end tests. This is what travis runs. It depends on the `e2e` and the `start-server-for-test` node scripts. One starts the server, the other runs the tests. If developing a front-end feature and just checking if tests pass, this is probabaly the one you want to run.
 
-**Requirements** Must set env variable for port. In terminal `export JEST_ENV='dev'` `export JEST_CXG_PORT=5000`
+**Requirements** Must set env variable for port. In terminal `export JEST_ENV='dev'`, `source environment.dev` or `source environment.ci`
 
 **Usage** `npm run smoke-test`
 
@@ -46,7 +46,7 @@
 
 **About** Runs backend tests without starting the server. You will need to start the rest api separately with the pbmc3k.h5ad file.
 
-**Requirements** Must set env variable for port. In terminal `export JEST_ENV='dev'` `export JEST_CXG_PORT=5000`
+**Requirements** Must set env variable for port. In terminal either `source environment.dev` or `source environment.ci`.
 
 **Usage** `npm run e2e`
 

--- a/environment.default
+++ b/environment.default
@@ -1,0 +1,6 @@
+# Default environment variables for cellxgene development
+set -a
+CXG_SERVER_PORT=5000
+CXG_CLIENT_PORT=3000
+JEST_ENV=dev
+set +a

--- a/environment.default
+++ b/environment.default
@@ -1,6 +1,4 @@
 # Default environment variables for cellxgene development
-set -a
-CXG_SERVER_PORT=5000
+CXG_SERVER_PORT=5005
 CXG_CLIENT_PORT=3000
 JEST_ENV=dev
-set +a

--- a/scripts/await_port
+++ b/scripts/await_port
@@ -5,22 +5,35 @@ import socket
 import sys
 import time
 
-parser = argparse.ArgumentParser(description='Wait for a port to be available.')
+# await_port
+#
+# Functionality:
+# 1. Wait for a process to be listening on a port - await_port will poll the address with a bind request and close it
+#    until another process takes the address.
+# 2. Wait for a port to be free - await_port will poll the address with a bind request and close it until the port is
+#    free.
+
+parser = argparse.ArgumentParser(description='Wait for a port either to be bound to or to be free.')
 parser.add_argument('port', type=int, help='port to wait for')
-parser.add_argument('--sleep-increment', type=int, default=1.0, help='sleep duration in between checks of the port')
+parser.add_argument('--sleep-increment', type=int, default=2.0, help='sleep duration in between checks of the port')
 parser.add_argument('--timeout', type=int, default=20.0, help='How long should we wait before timing out?')
-parser.add_argument('--await-active', default=False, action='store_true', help='Wait for the port to be active or free?')
+parser.add_argument('--await-free', default=False, action='store_true',
+                    help='Wait for the port to be active or free?')
 
 args = parser.parse_args()
 
 start = time.time()
 
-port_in_use = True
+port_in_use = None
+
+desired_state = 'free' if args.await_free else 'in use'
+
 
 def condition_reached(port_in_use):
-    return port_in_use if args.await_active else not port_in_use
+    return not port_in_use if args.await_free else port_in_use
 
-while not condition_reached(port_in_use):
+
+while True:
     # halt if we've reached the timeout
     elapsed = time.time() - start
     if elapsed > args.timeout:
@@ -32,10 +45,14 @@ while not condition_reached(port_in_use):
             s.bind(('localhost', args.port))
             port_in_use = False
         except socket.error as e:
-            if e.errno == errno.EADDRINUSE:
-                print(f"Waiting for port {args.port} to be available... sleeping for {args.sleep_increment} seconds.")
-                time.sleep(args.sleep_increment)
-            else:
+            if e.errno != errno.EADDRINUSE:
                 raise e
+            port_in_use = True
 
-print(f"Port {args.port} is {'active' if args.await_active else 'free'}!")
+    if condition_reached(port_in_use):
+        break
+
+    print(f"Waiting for port {args.port} to be {desired_state}... sleeping for {args.sleep_increment} seconds.")
+    time.sleep(args.sleep_increment)
+
+print(f"Port {args.port} is {desired_state}!")

--- a/scripts/await_port
+++ b/scripts/await_port
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import argparse
+import errno
+import socket
+import sys
+import time
+
+parser = argparse.ArgumentParser(description='Wait for a port to be available.')
+parser.add_argument('port', type=int, help='port to wait for')
+parser.add_argument('--sleep-increment', type=int, default=1.0, help='sleep duration in between checks of the port')
+parser.add_argument('--timeout', type=int, default=20.0, help='How long should we wait before timing out?')
+parser.add_argument('--await-active', default=False, action='store_true', help='Wait for the port to be active or free?')
+
+args = parser.parse_args()
+
+start = time.time()
+
+port_in_use = True
+
+def condition_reached(port_in_use):
+    return port_in_use if args.await_active else not port_in_use
+
+while not condition_reached(port_in_use):
+    # halt if we've reached the timeout
+    elapsed = time.time() - start
+    if elapsed > args.timeout:
+        print(f"Timed out while waiting for port {args.port}")
+        sys.exit(1)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(('localhost', args.port))
+            port_in_use = False
+        except socket.error as e:
+            if e.errno == errno.EADDRINUSE:
+                print(f"Waiting for port {args.port} to be available... sleeping for {args.sleep_increment} seconds.")
+                time.sleep(args.sleep_increment)
+            else:
+                raise e
+
+print(f"Port {args.port} is {'active' if args.await_active else 'free'}!")

--- a/scripts/start_server_and_test
+++ b/scripts/start_server_and_test
@@ -18,11 +18,11 @@ eval "$START_SERVER_SCRIPT &"
 SERVER_PID=$!
 
 function finish {
-  kill $SERVER_PID
+  kill $SERVER_PID || true
 }
 
 trap finish EXIT
 
-await_port --await-active "$PORT"
+await_port "$PORT"
 
 eval "$TEST_SCRIPT"

--- a/scripts/start_server_and_test
+++ b/scripts/start_server_and_test
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# start_server_and_test
+# Replicates the basic functionality of the start-server-and-test npm package
+# https://www.npmjs.com/package/start-server-and-test
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: start_server_and_test \'[start server script]\' [port] \'[test script]\'"
+  exit 1
+fi
+
+START_SERVER_SCRIPT="$1"
+PORT="$2"
+TEST_SCRIPT="$3"
+
+eval "$START_SERVER_SCRIPT &"
+SERVER_PID=$!
+
+function finish {
+  kill $SERVER_PID
+}
+
+trap finish EXIT
+
+await_port --await-active "$PORT"
+
+eval "$TEST_SCRIPT"

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,3 +1,5 @@
+include ../common.mk
+
 .PHONY: clean
 clean:
 	rm -f app/web/templates/index.html

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -19,7 +19,7 @@ from server.app.util.ontology import load_obo, OntologyLoadFailure
 
 # anything bigger than this will generate a special message
 BIG_FILE_SIZE_THRESHOLD = 100 * 2 ** 20  # 100MB
-DEFAULT_SERVER_PORT = int(environ.get('CXG_SERVER_PORT')) if environ.get('CXG_SERVER_PORT') else 5005
+DEFAULT_SERVER_PORT = int(environ.get('CXG_SERVER_PORT', '5005'))
 
 
 def common_args(func):

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -1,7 +1,7 @@
 import errno
 import functools
 import logging
-from os import devnull, mkdir
+from os import devnull, mkdir, environ
 from os.path import splitext, basename, isdir
 import sys
 import warnings
@@ -19,6 +19,7 @@ from server.app.util.ontology import load_obo, OntologyLoadFailure
 
 # anything bigger than this will generate a special message
 BIG_FILE_SIZE_THRESHOLD = 100 * 2 ** 20  # 100MB
+DEFAULT_SERVER_PORT = int(environ.get('CXG_SERVER_PORT')) if environ.get('CXG_SERVER_PORT') else 5005
 
 
 def common_args(func):
@@ -202,6 +203,7 @@ def parse_engine_args(
     "--port",
     "-p",
     metavar="<port>",
+    default=DEFAULT_SERVER_PORT,
     show_default=True,
     help="Port to run server on. If not specified cellxgene will find an available port.",
 )
@@ -333,7 +335,7 @@ def launch(
                 f"The port selected {port} is in use, please specify an open port using the --port flag."
             )
     else:
-        port = find_available_port(host)
+        port = find_available_port(host, DEFAULT_SERVER_PORT)
 
     if not experimental_annotations:
         if experimental_annotations_file is not None:


### PR DESCRIPTION
Past state:
* Default environement variables were stored in `client/package.json`, `client/__tests__/e2e/config.js`, `client/server/development.js`, `client/src/globals.js`, and `server/cli/launch.py`
* Constants that should have been linked--like the cellxgene server port during testing--were repeated.

With this commit:
* All environment variables are parameterized
* All environment variables are packaged in default env files
* `make` targets (replacing npm scripts) keep everything locked together

NOTE: _These changes change development flow. FE developers will have to use `make` commands instead of `npm` commands._ To ease the transition most commands are the same, all you have to do is use `make <command>` instead of `npm run <command>`. For more, see the [developer scripts](https://github.com/chanzuckerberg/cellxgene/blob/a5d1b6463d2c35af32ec84404b8f70ecb687ae25/dev_docs/developer_scripts.md) documentation.