### PR TITLE
enable camera interaction on centroids

### DIFF
--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -749,7 +749,11 @@ class Graph extends React.Component {
               graphPaddingRightLeft={this.graphPaddingRightLeft}
               graphPaddingTop={this.graphPaddingTop}
               responsive={responsive}
-              handleCanvasEvent={this.handleCanvasEvent}
+              handleCanvasEvent={
+                graphInteractionMode === "zoom"
+                  ? this.handleCanvasEvent
+                  : undefined
+              }
             >
               <CentroidLabels />
             </GraphOverlayLayer>

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -749,6 +749,7 @@ class Graph extends React.Component {
               graphPaddingRightLeft={this.graphPaddingRightLeft}
               graphPaddingTop={this.graphPaddingTop}
               responsive={responsive}
+              handleCanvasEvent={this.handleCanvasEvent}
             >
               <CentroidLabels />
             </GraphOverlayLayer>

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -53,7 +53,8 @@ class GraphOverlayLayer extends PureComponent {
       responsive,
       graphPaddingRightLeft,
       graphPaddingTop,
-      children
+      children,
+      handleCanvasEvent
     } = this.props;
 
     if (!cameraTF) return null;
@@ -89,6 +90,8 @@ class GraphOverlayLayer extends PureComponent {
           zIndex: 99,
           backgroundColor: displaying ? "rgba(255, 255, 255, 0.55)" : ""
         }}
+        onMouseMove={handleCanvasEvent}
+        onWheel={handleCanvasEvent}
       >
         <g
           id="canvas-transformation-group-x"


### PR DESCRIPTION
Previously if the mouse cursor was over a centroid label and the user attempted to pan or zoom the label would capture the mouse action and prevent camera functionality.

This PR simply passes the handleCanvasEvent function to the graph overlay layer allowing the layer to pass the interactions upwards while also performing its own functionality.  

Originally I passed the mouse events through the reducers(c53f716), but found this method simpler and just as effective.