### PR TITLE
[EASY] Add a flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [flake8]
 max-line-length = 120
 ignore = E203, W503
-exclude =
-    server/data_common/fbs/NetEncoding/
+exclude = server/data_common/fbs/NetEncoding/,.git,__pycache__,venv,server/venv,old,build,dist,server/data_common/fbs/NetEncoding


### PR DESCRIPTION
This excludes directories which should not be linted. This
1. makes the lint test more representative of what is run in CI
2. is faster