### PR TITLE
Make smoke tests faster, more stable

### DIFF
--- a/client/__tests__/e2e/cellxgeneActions.js
+++ b/client/__tests__/e2e/cellxgeneActions.js
@@ -1,0 +1,196 @@
+import { strict as assert } from "assert";
+
+export const cellxgeneActions = (page, utils) => ({
+
+  async drag(testId, start, end, lasso = false) {
+    const layout = await utils.waitByID(testId);
+    const elBox = await layout.boxModel();
+    const x1 = elBox.content[0].x + start.x;
+    const x2 = elBox.content[0].x + end.x;
+    const y1 = elBox.content[0].y + start.y;
+    const y2 = elBox.content[0].y + end.y;
+    await page.mouse.move(x1, y1);
+    await page.mouse.down();
+    if (lasso) {
+      await page.mouse.move(x2, y1);
+      await page.mouse.move(x2, y2);
+      await page.mouse.move(x1, y2);
+      await page.mouse.move(x1, y1);
+    } else {
+      await page.mouse.move(x2, y2);
+    }
+    await page.mouse.up();
+  },
+
+  async clickOnCoordinate(testId, coord) {
+    const layout = await utils.waitByID(testId);
+    const elBox = await layout.boxModel();
+    const x = elBox.content[0].x + coord.x;
+    const y = elBox.content[0].y + coord.y;
+    await page.mouse.click(x, y);
+  },
+
+  async getAllHistograms(testclass, testIds) {
+    const histTestIds = testIds.map(tid => `histogram-${tid}`);
+    // these load asynchronously, so we need to wait for each histogram individually
+    await utils.waitForAllByIds(histTestIds);
+    const allHistograms = await utils.getAllByClass(testclass);
+    return allHistograms.map(hist => hist.replace(/^histogram-/, ""));
+  },
+
+  async getAllCategoriesAndCounts(category) {
+    await utils.waitByClass("categorical-row");
+    return page.$$eval(
+      `[data-testid="category-${category}"] [data-testclass='categorical-row']`,
+      rows => Object.fromEntries(rows.map(row => {
+        const cat = row.querySelector("[data-testclass='categorical-value']").innerText;
+        const count = row.querySelector("[data-testclass='categorical-value-count']").innerText;
+        return [cat, count];
+      }))
+    );
+  },
+
+  async cellSet(num) {
+    await utils.clickOn(`cellset-button-${num}`);
+    return utils.getOneElementInnerText(`[data-testid='cellset-count-${num}']`);
+  },
+
+  async resetCategory(category) {
+    const checkboxId = `${category}:category-select`;
+    await utils.waitByID(checkboxId);
+    const checkedPseudoclass = await page.$eval(
+      `[data-testid='${checkboxId}']`,
+      el => el.matches(":checked")
+    );
+    if (!checkedPseudoclass) await utils.clickOn(checkboxId);
+    try {
+      const categoryRow = await utils.waitByID(`${category}:category-expand`);
+      const isExpanded = await categoryRow.$("[data-testclass='category-expand-is-expanded']");
+      if (isExpanded) await utils.clickOn(`${category}:category-expand`);
+    } catch {}
+  },
+
+  async calcCoordinate(testId, xAsPercent, yAsPercent) {
+    const el = await utils.waitByID(testId);
+    const size = await el.boxModel();
+    return {
+      x: Math.floor(size.width * xAsPercent),
+      y: Math.floor(size.height * yAsPercent)
+    }
+  },
+
+  async calcDragCoordinates(testId, coordinateAsPercent) {
+    return {
+      start: await this.calcCoordinate(testId, coordinateAsPercent.x1, coordinateAsPercent.y1),
+      end: await this.calcCoordinate(testId, coordinateAsPercent.x2, coordinateAsPercent.y2)
+    };
+  },
+
+  async selectCategory(category, values, reset = true) {
+    if (reset) await this.resetCategory(category);
+    await utils.clickOn(`${category}:category-expand`);
+    await utils.clickOn(`${category}:category-select`);
+    for (const val of values) {
+      await utils.clickOn(`categorical-value-select-${category}-${val}`);
+    }
+  },
+
+  async expandCategory(category) {
+    const expand = await utils.waitByID(`${category}:category-expand`);
+    const notExpanded = await expand.$("[data-testclass='category-expand-is-not-expanded']");
+    if (notExpanded) await utils.clickOn(`${category}:category-expand`);
+  },
+
+  async clip(min = 0, max = 100) {
+    await utils.clickOn("visualization-settings");
+    await utils.clearInputAndTypeInto("clip-min-input", min);
+    await utils.clearInputAndTypeInto("clip-max-input", max);
+    await utils.clickOn("clip-commit");
+  },
+
+  async createCategory(categoryName) {
+    await utils.clickOn("open-annotation-dialog");
+    await utils.typeInto("new-category-name", categoryName);
+    await utils.clickOn("submit-category");
+  },
+
+  async renameCategory(oldCatgoryName, newCategoryName) {
+    await utils.clickOn(`${oldCatgoryName}:see-actions`);
+    await utils.clickOn(`${oldCatgoryName}:edit-category-mode`);
+    await utils.clearInputAndTypeInto(`${oldCatgoryName}:edit-category-name-text`, newCategoryName);
+    await utils.clickOn(`${oldCatgoryName}:submit-category-edit`);
+  },
+
+  async deleteCategory(categoryName) {
+    await utils.clickOn(`${categoryName}:see-actions`);
+    await utils.clickOn(`${categoryName}:delete-category`);
+  },
+
+  async createLabel(categoryName, labelName) {
+    await utils.clickOn(`${categoryName}:see-actions`);
+    await utils.clickOn(`${categoryName}:add-new-label-to-category`);
+    await utils.typeInto(`${categoryName}:new-label-name`, labelName);
+    await utils.clickOn(`${categoryName}:submit-label`);
+  },
+
+  async deleteLabel(categoryName, labelName) {
+    await this.expandCategory(categoryName);
+    await utils.clickOn(`${categoryName}:${labelName}:see-actions`);
+    await utils.clickOn( `${categoryName}:${labelName}:delete-label`);
+  },
+
+  async renameLabel(categoryName, oldLabelName, newLabelName) {
+    await this.expandCategory(categoryName);
+    await utils.clickOn(`${categoryName}:${oldLabelName}:see-actions`);
+    await utils.clickOn(`${categoryName}:${oldLabelName}:edit-label`);
+    await utils.clearInputAndTypeInto(
+      `${categoryName}:${oldLabelName}:edit-label-name`,
+      newLabelName
+    );
+    await utils.clickOn(`${categoryName}:${oldLabelName}:submit-label-edit`);
+  },
+
+  async addGeneToSearch(geneName) {
+    await utils.typeInto("gene-search", geneName);
+    await page.keyboard.press("Enter");
+    await page.waitForSelector(
+      `[data-testid='histogram-${geneName}']`
+    );
+  },
+
+  async subset(coordinatesAsPercent) {
+    // In order to deselect the selection after the subset, make sure we have some clear part
+    // of the scatterplot we can click on
+    assert(coordinatesAsPercent.x2 < 0.99 || coordinatesAsPercent.y2 < 0.99);
+    const lassoSelection = await this.calcDragCoordinates( "layout-graph", coordinatesAsPercent);
+    await this.drag("layout-graph", lassoSelection.start, lassoSelection.end, true );
+    await utils.clickOn("subset-button");
+    const clearCoordinate = await this.calcCoordinate(
+      "layout-graph",
+      0.5,
+      0.99
+    );
+    await this.clickOnCoordinate("layout-graph", clearCoordinate);
+  },
+
+  async setSellSet(cellSet, cellSetNum) {
+    for (const selection of cellSet.filter(sel => sel.kind === "categorical")) {
+      await this.selectCategory(selection.metadata, selection.values, true);
+    }
+    await this.cellSet(cellSetNum);
+  },
+
+  async runDiffExp(cellSet1, cellSet2) {
+    await this.setSellSet(cellSet1, 1);
+    await this.setSellSet(cellSet2, 2);
+    await utils.clickOn("diffexp-button");
+  },
+
+  async bulkAddGenes(geneNames) {
+    await utils.clickOn("section-bulk-add");
+    await utils.typeInto("input-bulk-add", geneNames.join(","));
+    await page.keyboard.press("Enter");
+  }
+});
+
+

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -3,13 +3,13 @@ Smoke test suite that will be run in Travis CI
 
 Tests included in this file are expected to be relatively stable and test core features
  */
-import { appUrlBase, DEBUG, DATASET } from "./config";
+import { appUrlBase, DATASET } from "./config";
 import { setupTestBrowser } from "./puppeteerUtils";
 import { datasets } from "./data";
 
-let browser, page, utils, cxgActions, spy;
+let browser, page, utils, cxgActions;
 const browserViewport = { width: 1280, height: 960 };
-let data = datasets[DATASET];
+const data = datasets[DATASET];
 
 beforeAll(async () => {
     [browser, page, utils, cxgActions] = await setupTestBrowser(browserViewport);
@@ -25,8 +25,8 @@ afterAll(() => {
 
 describe("did launch", () => {
   test("page launched", async () => {
-    let el = await utils.getOneElementInnerHTML("[data-testid='header']");
-    expect(el).toBe(data.title);
+    const element = await utils.getOneElementInnerHTML("[data-testid='header']");
+    expect(element).toBe(data.title);
   });
 });
 
@@ -34,9 +34,7 @@ describe("metadata loads", () => {
   test("categories and values from dataset appear", async () => {
     for (const label in data.categorical) {
       await utils.waitByID(`category-${label}`);
-      const categoryName = await utils.getOneElementInnerText(
-        `[data-testid="category-${label}"]`
-      );
+      const categoryName = await utils.getOneElementInnerText(`[data-testid="category-${label}"]`);
       expect(categoryName).toMatch(label);
       await utils.clickOn(`${label}:category-expand`);
       const categories = await cxgActions.getAllCategoriesAndCounts(label);
@@ -84,9 +82,7 @@ describe("cell selection", () => {
       await utils.clickOn(`${cellset.metadata}:category-expand`);
       await utils.clickOn(`${cellset.metadata}:category-select`);
       for (const val of cellset.values) {
-        await utils.clickOn(
-          `categorical-value-select-${cellset.metadata}-${val}`
-        );
+        await utils.clickOn(`categorical-value-select-${cellset.metadata}-${val}`);
       }
       const cellCount = await cxgActions.cellSet(1);
       expect(cellCount).toBe(cellset.count);
@@ -108,17 +104,12 @@ describe("cell selection", () => {
 });
 
 describe("gene entry", () => {
-  test("search for single gene", async () => {
-    await cxgActions.addGeneToSearch(data.genes.search);
-  });
+  test("search for single gene", async () => cxgActions.addGeneToSearch(data.genes.search));
 
   test("bulk add genes", async () => {
     const testGenes = data.genes.bulkadd;
     await cxgActions.bulkAddGenes(testGenes);
-    const allHistograms = await cxgActions.getAllHistograms(
-      "histogram-user-gene",
-      testGenes
-    );
+    const allHistograms = await cxgActions.getAllHistograms("histogram-user-gene", testGenes);
     expect(allHistograms).toEqual(expect.arrayContaining(testGenes));
     expect(allHistograms.length).toEqual(testGenes.length);
   });

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -114,10 +114,7 @@ describe("gene entry", () => {
 
   test("bulk add genes", async () => {
     const testGenes = data.genes.bulkadd;
-    await utils.clickOn("section-bulk-add");
-    await utils.typeInto("input-bulk-add", testGenes.join(","));
-    await page.keyboard.press("Enter");
-
+    await cxgActions.bulkAddGenes(testGenes);
     const allHistograms = await cxgActions.getAllHistograms(
       "histogram-user-gene",
       testGenes
@@ -182,54 +179,47 @@ describe("subset", () => {
   });
 
   test("undo selection appends the top diff exp genes to user defined genes", async () => {
-    const userDefinedGenes = ["ACD", "AAR2", "AATF", "ARSG"];
+    const userDefinedGenes = data.genes.bulkadd;
     const diffExpGenes = data.diffexp["gene-results"];
-    for (const userDefinedGene of userDefinedGenes) {
-      await cxgActions.addGeneToSearch(userDefinedGene);
-    }
+    await cxgActions.bulkAddGenes(userDefinedGenes);
     const userDefinedHistograms = await cxgActions.getAllHistograms("histogram-user-gene", userDefinedGenes);
-    expect(userDefinedHistograms).toStrictEqual(userDefinedGenes);
+    expect(userDefinedHistograms).toEqual(expect.arrayContaining(userDefinedGenes));
     await cxgActions.subset({x1: 0.15, y1: 0.10, x2: 0.98, y2: 0.98});
     await cxgActions.runDiffExp(data.diffexp.cellset1, data.diffexp.cellset2);
     const diffExpHistograms = await cxgActions.getAllHistograms("histogram-diffexp", diffExpGenes);
-    expect(diffExpHistograms).toStrictEqual(diffExpGenes);
+    expect(diffExpHistograms).toEqual(expect.arrayContaining(diffExpGenes));
     await utils.clickOn("reset-subset-button");
     const expected = [].concat(userDefinedGenes, diffExpGenes);
     const userDefinedHistogramsAfterSubset = await cxgActions.getAllHistograms(
       "histogram-user-gene",
       expected
     );
-    expect(userDefinedHistogramsAfterSubset).toStrictEqual(expected);
+    expect(userDefinedHistogramsAfterSubset).toEqual(expect.arrayContaining(expected));
   });
 
   test("subset selection appends the top diff exp genes to user defined genes", async () => {
-    const userDefinedGenes = ["ACD", "AAR2", "AATF", "ARSG"];
+    const userDefinedGenes = data.genes.bulkadd;
     const diffExpGenes = data.diffexp["gene-results"];
-    for (const userDefinedGene of userDefinedGenes) {
-      await cxgActions.addGeneToSearch(userDefinedGene);
-    }
+    await cxgActions.bulkAddGenes(userDefinedGenes);
     const userDefinedHistograms = await cxgActions.getAllHistograms("histogram-user-gene", userDefinedGenes);
-    expect(userDefinedHistograms).toStrictEqual(userDefinedGenes);
+    expect(userDefinedHistograms).toEqual(expect.arrayContaining(userDefinedGenes));
     await cxgActions.subset({x1: 0.15, y1: 0.10, x2: 0.98, y2: 0.98});
     await cxgActions.runDiffExp(data.diffexp.cellset1, data.diffexp.cellset2);
     const diffExpHistograms = await cxgActions.getAllHistograms("histogram-diffexp", diffExpGenes);
-    expect(diffExpHistograms).toStrictEqual(diffExpGenes);
+    expect(diffExpHistograms).toEqual(expect.arrayContaining(diffExpGenes));
     await cxgActions.subset({x1: 0.16, y1: 0.11, x2: 0.97, y2: 0.97});
     const expected = [].concat(userDefinedGenes, diffExpGenes);
     const userDefinedHistogramsAfterSubset = await cxgActions.getAllHistograms(
       "histogram-user-gene",
       expected
     );
-    expect(userDefinedHistogramsAfterSubset).toStrictEqual(expected);
+    expect(userDefinedHistogramsAfterSubset).toEqual(expect.arrayContaining(expected));
   });
 });
 
 describe("scatter plot", () => {
   test("scatter plot appears", async () => {
-    const testGenes = data.scatter.genes;
-    await utils.clickOn("section-bulk-add");
-    await utils.typeInto("input-bulk-add", Object.values(testGenes).join(","));
-    await page.keyboard.press("Enter");
+    await cxgActions.bulkAddGenes(Object.values(data.scatter.genes));
     await utils.clickOn(`plot-x-${data.scatter.genes.x}`);
     await utils.clickOn(`plot-y-${data.scatter.genes.y}`);
     await utils.waitByID("scatterplot");

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -4,15 +4,15 @@ Smoke test suite that will be run in Travis CI
 Tests included in this file are expected to be relatively stable and test core features
  */
 import { appUrlBase, DATASET } from "./config";
-import { setupTestBrowser } from "./puppeteerUtils";
+import { setupTestBrowser } from "./testBrowser";
 import { datasets } from "./data";
 
 let browser, page, utils, cxgActions;
-const browserViewport = { width: 1280, height: 960 };
 const data = datasets[DATASET];
 
 beforeAll(async () => {
-    [browser, page, utils, cxgActions] = await setupTestBrowser(browserViewport);
+  const browserViewport = { width: 1280, height: 960 };
+  [browser, page, utils, cxgActions] = await setupTestBrowser(browserViewport);
 });
 
 beforeEach(async () => {
@@ -20,7 +20,7 @@ beforeEach(async () => {
 });
 
 afterAll(() => {
-  browser.close();
+  if (browser !== undefined) browser.close();
 });
 
 describe("did launch", () => {
@@ -278,6 +278,6 @@ describe("ui elements don't error", () => {
       panCoords.end,
       false
     );
-    await page.evaluate(`window.scrollBy(0, 1000);`);
+    await page.evaluate("window.scrollBy(0, 1000);");
   });
 });

--- a/client/__tests__/e2e/puppeteerUtils.js
+++ b/client/__tests__/e2e/puppeteerUtils.js
@@ -1,24 +1,21 @@
-import {DEBUG, DEV} from "./config";
-import puppeteer from "puppeteer";
-import { strict as assert } from "assert";
+export const puppeteerUtils = page => ({
 
-export const puppeteerUtils = puppeteerPage => ({
   async waitByID(testId, props = {}) {
-    return puppeteerPage.waitForSelector(`[data-testid='${testId}']`, props);
+    return page.waitForSelector(`[data-testid='${testId}']`, props);
   },
 
   async waitByClass(testClass, props = {}) {
-    return puppeteerPage.waitForSelector(`[data-testclass='${testClass}']`, props);
+    return page.waitForSelector(`[data-testclass='${testClass}']`, props);
   },
 
   async waitForAllByIds(testIds) {
     await Promise.all(
-      testIds.map(testId => puppeteerPage.waitForSelector(`[data-testid='${testId}']`))
+      testIds.map(testId => page.waitForSelector(`[data-testid='${testId}']`))
     );
   },
 
   async getAllByClass(testClass) {
-    return puppeteerPage.$$eval(
+    return page.$$eval(
       `[data-testclass=${testClass}]`,
       eles => eles.map(ele => ele.dataset.testid)
     );
@@ -30,9 +27,9 @@ export const puppeteerUtils = puppeteerPage => ({
     await this.waitByID(testId);
     const selector = `[data-testid='${testId}']`;
     // type ahead can be annoying if you don't pause before you type
-    await puppeteerPage.click(selector);
-    await puppeteerPage.waitFor(200);
-    await puppeteerPage.type(selector, text);
+    await page.click(selector);
+    await page.waitFor(200);
+    await page.type(selector, text);
   },
 
   async clearInputAndTypeInto(testId, text) {
@@ -40,266 +37,28 @@ export const puppeteerUtils = puppeteerPage => ({
     const selector = `[data-testid='${testId}']`;
     // only works for text without special characters
     // type ahead can be annoying if you don't pause before you type
-    await puppeteerPage.click(selector);
-    await puppeteerPage.waitFor(200);
+    await page.click(selector);
+    await page.waitFor(200);
     // select all
-    await puppeteerPage.click(selector, { clickCount: 3 });
-    await puppeteerPage.keyboard.press("Backspace");
-    await puppeteerPage.type(selector, text);
+    await page.click(selector, { clickCount: 3 });
+    await page.keyboard.press("Backspace");
+    await page.type(selector, text);
   },
 
   async clickOn(testId, options={}) {
     await this.waitByID(testId);
-    await puppeteerPage.click(`[data-testid='${testId}']`, options);
-    await puppeteerPage.waitFor(50);
+    await page.click(`[data-testid='${testId}']`, options);
+    await page.waitFor(50);
   },
 
   async getOneElementInnerHTML(selector) {
-    await puppeteerPage.waitForSelector(selector);
-    return puppeteerPage.$eval(selector, el => el.innerHTML);
+    await page.waitForSelector(selector);
+    return page.$eval(selector, el => el.innerHTML);
   },
 
   async getOneElementInnerText(selector) {
-    await puppeteerPage.waitForSelector(selector);
-    return puppeteerPage.$eval(selector, el => el.innerText);
+    await page.waitForSelector(selector);
+    return page.$eval(selector, el => el.innerText);
   }
 });
 
-export const cellxgeneActions = puppeteerPage => ({
-
-  async drag(testId, start, end, lasso = false) {
-    const layout = await puppeteerUtils(puppeteerPage).waitByID(testId);
-    const elBox = await layout.boxModel();
-    const x1 = elBox.content[0].x + start.x;
-    const x2 = elBox.content[0].x + end.x;
-    const y1 = elBox.content[0].y + start.y;
-    const y2 = elBox.content[0].y + end.y;
-    await puppeteerPage.mouse.move(x1, y1);
-    await puppeteerPage.mouse.down();
-    if (lasso) {
-      await puppeteerPage.mouse.move(x2, y1);
-      await puppeteerPage.mouse.move(x2, y2);
-      await puppeteerPage.mouse.move(x1, y2);
-      await puppeteerPage.mouse.move(x1, y1);
-    } else {
-      await puppeteerPage.mouse.move(x2, y2);
-    }
-    await puppeteerPage.mouse.up();
-  },
-
-  async clickOnCoordinate(testId, coord) {
-    const layout = await puppeteerUtils(puppeteerPage).waitByID(testId);
-    const elBox = await layout.boxModel();
-    const x = elBox.content[0].x + coord.x;
-    const y = elBox.content[0].y + coord.y;
-    await puppeteerPage.mouse.click(x, y);
-  },
-
-  async getAllHistograms(testclass, testIds) {
-    const histTestIds = testIds.map(tid => `histogram-${tid}`);
-    // these load asynchronously, so we need to wait for each histogram individually
-    await puppeteerUtils(puppeteerPage).waitForAllByIds(histTestIds);
-    const allHistograms = await puppeteerUtils(puppeteerPage).getAllByClass(
-      testclass
-    );
-    return allHistograms.map(hist => hist.replace(/^histogram-/, ""));
-  },
-
-  async getAllCategoriesAndCounts(category) {
-    await puppeteerUtils(puppeteerPage).waitByClass("categorical-row");
-    return puppeteerPage.$$eval(
-      `[data-testid="category-${category}"] [data-testclass='categorical-row']`,
-      rows => Object.fromEntries(rows.map(row => {
-          const cat = row.querySelector("[data-testclass='categorical-value']").innerText;
-          const count = row.querySelector("[data-testclass='categorical-value-count']").innerText;
-          return [cat, count];
-        }))
-    );
-  },
-
-  async cellSet(num) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`cellset-button-${num}`);
-    return utils.getOneElementInnerText(`[data-testid='cellset-count-${num}']`);
-  },
-
-  async resetCategory(category) {
-    const checkboxId = `${category}:category-select`;
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.waitByID(checkboxId);
-    const checkedPseudoclass = await puppeteerPage.$eval(
-      `[data-testid='${checkboxId}']`,
-      el => el.matches(":checked")
-    );
-    if (!checkedPseudoclass) await utils.clickOn(checkboxId);
-    try {
-      const categoryRow = await utils.waitByID(`${category}:category-expand`);
-      const isExpanded = await categoryRow.$("[data-testclass='category-expand-is-expanded']");
-      if (isExpanded) await utils.clickOn(`${category}:category-expand`);
-    } catch {}
-  },
-
-  async calcCoordinate(testId, xAsPercent, yAsPercent) {
-    const el = await puppeteerUtils(puppeteerPage).waitByID(testId);
-    const size = await el.boxModel();
-    return {
-      x: Math.floor(size.width * xAsPercent),
-      y: Math.floor(size.height * yAsPercent)
-    }
-  },
-
-  async calcDragCoordinates(testId, coordinateAsPercent) {
-    return {
-      start: await this.calcCoordinate(testId, coordinateAsPercent.x1, coordinateAsPercent.y1),
-      end: await this.calcCoordinate(testId, coordinateAsPercent.x2, coordinateAsPercent.y2)
-    };
-  },
-
-  async selectCategory(category, values, reset = true) {
-    if (reset) await this.resetCategory(category);
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${category}:category-expand`);
-    await utils.clickOn(`${category}:category-select`);
-    for (const val of values) {
-      await utils.clickOn(`categorical-value-select-${category}-${val}`);
-    }
-  },
-
-  async expandCategory(category) {
-    const utils = puppeteerUtils(puppeteerPage);
-    const expand = await utils.waitByID(`${category}:category-expand`);
-    const notExpanded = await expand.$("[data-testclass='category-expand-is-not-expanded']");
-    if (notExpanded) await utils.clickOn(`${category}:category-expand`);
-  },
-
-  async clip(min = 0, max = 100) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn("visualization-settings");
-    await utils.clearInputAndTypeInto("clip-min-input", min);
-    await utils.clearInputAndTypeInto("clip-max-input", max);
-    await utils.clickOn("clip-commit");
-  },
-
-  async createCategory(categoryName) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn("open-annotation-dialog");
-    await utils.typeInto("new-category-name", categoryName);
-    await utils.clickOn("submit-category");
-  },
-
-  async renameCategory(oldCatgoryName, newCategoryName) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${oldCatgoryName}:see-actions`);
-    await utils.clickOn(`${oldCatgoryName}:edit-category-mode`);
-    await utils.clearInputAndTypeInto(`${oldCatgoryName}:edit-category-name-text`, newCategoryName);
-    await utils.clickOn(`${oldCatgoryName}:submit-category-edit`);
-  },
-
-  async deleteCategory(categoryName) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${categoryName}:see-actions`);
-    await utils.clickOn(`${categoryName}:delete-category`);
-  },
-
-  async createLabel(categoryName, labelName) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${categoryName}:see-actions`);
-    await utils.clickOn(`${categoryName}:add-new-label-to-category`);
-    await utils.typeInto(`${categoryName}:new-label-name`, labelName);
-    await utils.clickOn(`${categoryName}:submit-label`);
-  },
-
-  async deleteLabel(categoryName, labelName) {
-    await this.expandCategory(categoryName);
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${categoryName}:${labelName}:see-actions`);
-    await utils.clickOn( `${categoryName}:${labelName}:delete-label`);
-  },
-
-  async renameLabel(categoryName, oldLabelName, newLabelName) {
-    await this.expandCategory(categoryName);
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn(`${categoryName}:${oldLabelName}:see-actions`);
-    await utils.clickOn(`${categoryName}:${oldLabelName}:edit-label`);
-    await utils.clearInputAndTypeInto(
-      `${categoryName}:${oldLabelName}:edit-label-name`,
-      newLabelName
-    );
-    await puppeteerUtils(puppeteerPage).clickOn(`${categoryName}:${oldLabelName}:submit-label-edit`);
-  },
-
-  async addGeneToSearch(geneName) {
-    await puppeteerUtils(puppeteerPage).typeInto("gene-search", geneName);
-    await puppeteerPage.keyboard.press("Enter");
-    await puppeteerPage.waitForSelector(
-      `[data-testid='histogram-${geneName}']`
-    );
-  },
-
-  async subset(coordinatesAsPercent) {
-    // In order to deselect the selection after the subset, make sure we have some clear part
-    // of the scatterplot we can click on
-    assert(coordinatesAsPercent.x2 < 0.99 || coordinatesAsPercent.y2 < 0.99);
-    const lassoSelection = await this.calcDragCoordinates( "layout-graph", coordinatesAsPercent);
-    await this.drag("layout-graph", lassoSelection.start, lassoSelection.end, true );
-    await puppeteerUtils(puppeteerPage).clickOn("subset-button");
-    const clearCoordinate = await this.calcCoordinate(
-      "layout-graph",
-      0.5,
-      0.99
-    );
-    await this.clickOnCoordinate("layout-graph", clearCoordinate);
-  },
-
-  async setSellSet(cellSet, cellSetNum) {
-    for (const selection of cellSet) {
-      if (selection.kind === "categorical") {
-        await this.selectCategory(selection.metadata, selection.values, true);
-      }
-    }
-    await this.cellSet(cellSetNum);
-  },
-
-  async runDiffExp(cellSet1, cellSet2) {
-    await this.setSellSet(cellSet1, 1);
-    await this.setSellSet(cellSet2, 2);
-    await puppeteerUtils(puppeteerPage).clickOn("diffexp-button");
-  },
-
-  async bulkAddGenes(geneNames) {
-    const utils = puppeteerUtils(puppeteerPage);
-    await utils.clickOn("section-bulk-add");
-    await utils.typeInto("input-bulk-add", geneNames.join(","));
-    await puppeteerPage.keyboard.press("Enter");
-  }
-});
-
-export async function setupTestBrowser(browserViewport) {
-  const browserParams = DEV
-      ? { headless: false, slowMo: 5 }
-      : DEBUG
-          ? { headless: false, slowMo: 100, devtools: true }
-          : {};
-  const browser = await puppeteer.launch(browserParams);
-  const page = await browser.pages().then(pages => pages[0]);
-  await page.setViewport(browserViewport);
-  if (DEV || DEBUG) {
-    page.on("console", async msg => {
-      // If there is a console.error but an error is not thrown, this will ensure the test fails
-      if (msg.type() === "error") {
-        const errorMsgText = await Promise.all(
-            // TODO can we do this without internal properties?
-            msg.args().map(arg => arg._remoteObject.description)
-        );
-        throw new Error(`Console error: ${errorMsgText}`);
-      }
-      console.log(`PAGE LOG: ${msg.text()}`);
-    });
-  }
-  page.on("pageerror", err => {
-    throw new Error(`Console error: ${err}`);
-  });
-  const utils = puppeteerUtils(page);
-  const cxgActions = cellxgeneActions(page);
-  return [browser, page, utils, cxgActions];
-}

--- a/client/__tests__/e2e/testBrowser.js
+++ b/client/__tests__/e2e/testBrowser.js
@@ -1,0 +1,35 @@
+import puppeteer from "puppeteer";
+import { DEBUG, DEV } from "./config";
+import { puppeteerUtils } from "./puppeteerUtils";
+import { cellxgeneActions } from "./cellxgeneActions";
+
+export async function setupTestBrowser(browserViewport) {
+  const browserParams = DEV
+    ? { headless: false, slowMo: 5 }
+    : DEBUG
+      ? { headless: false, slowMo: 100, devtools: true }
+      : {};
+  const browser = await puppeteer.launch(browserParams);
+  const page = await browser.pages().then(pages => pages[0]);
+  await page.setViewport(browserViewport);
+  if (DEV || DEBUG) {
+    page.on("console", async msg => {
+      // If there is a console.error but an error is not thrown, this will ensure the test fails
+      if (msg.type() === "error") {
+        const errorMsgText = await Promise.all(
+          // TODO can we do this without internal properties?
+          msg.args().map(arg => arg._remoteObject.description)
+        );
+        throw new Error(`Console error: ${errorMsgText}`);
+      }
+      console.log(`PAGE LOG: ${msg.text()}`);
+    });
+  }
+  page.on("pageerror", err => {
+    throw new Error(`Console error: ${err}`);
+  });
+  const utils = puppeteerUtils(page);
+  const cxgActions = cellxgeneActions(page, utils);
+  return [browser, page, utils, cxgActions];
+}
+


### PR DESCRIPTION
## Need
Primary goal of this PR is to fix [a heisenbug that occurs only in CI](https://github.com/chanzuckerberg/cellxgene/pull/1191/checks?check_run_id=485516637).

## Approach
Through the investigation I made the following changes/refactors (some of which are tangential to the original issue):
* Bulk add genes in the `undo selection appends the top diff exp genes to user defined genes` and `subset selection appends the top diff exp genes to user defined genes` tests
* Refactor some of the methods in `puppeteerUtils` and `cellxgeneActions` to have better functional style
* Better modularize test helpers by moving `cellxgeneActions` and `setupTestBrowser` out of `puppeteerUtils.js` and into their own files.

## Benefits
1. It's not 100% clear to me that I have fixed the original issue in CI. All the runs of CI that I've triggered as part of this PR have passed. It's possible that there was a hiccup in the GithubActions runner... 🤞
1. The test helpers are a little cleaner and more modular.

