### PR TITLE
fix url launching on Heroku deployments

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,9 @@
       "description": "Link to dataset",
       "value": "https://cellxgene-example-data.czi.technology/pbmc3k.h5ad",
       "required": "true"
+    },
+    "OPTIONS": {
+      "description": "Options to pass to cellxgene (i.e. `--title \"My Dataset\" --about \"https://www.google.com\""
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "cellxgene",
   "description": "An interactive explorer for single-cell transcriptomics data",
-  "repository": "https://github.com/chanzuckerberg/cellxgene/tree/seve/fix-heroku",
+  "repository": "https://github.com/chanzuckerberg/cellxgene",
   "logo": "https://cellxgene-example-data.czi.technology/favicon.png",
   "keywords": [
     "scientific",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "cellxgene",
   "description": "An interactive explorer for single-cell transcriptomics data",
-  "repository": "https://github.com/chanzuckerberg/cellxgene/",
+  "repository": "https://github.com/chanzuckerberg/cellxgene/tree/seve/fix-heroku",
   "logo": "https://cellxgene-example-data.czi.technology/favicon.png",
   "keywords": [
     "scientific",

--- a/app.json
+++ b/app.json
@@ -16,9 +16,6 @@
       "description": "Link to dataset",
       "value": "https://cellxgene-example-data.czi.technology/pbmc3k.h5ad",
       "required": "true"
-    },
-    "OPTIONS": {
-      "description": "Options to pass to cellxgene (i.e. `--title \"My Dataset\" --about \"https://www.google.com\""
     }
   }
 }

--- a/docs/posts/hosted.md
+++ b/docs/posts/hosted.md
@@ -42,7 +42,7 @@ If you know of other solutions, drop us a note and we'll add to this list.
 
 Clicking on the following button will forward you to Heroku to begin the deployment process:
 
-<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene/tree/heroku">
+<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene">
  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 

--- a/experiments/heroku/README.md
+++ b/experiments/heroku/README.md
@@ -4,7 +4,7 @@
 
 Clicking on the following button will forward you to Heroku to begin the deployment process:
 
-<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene/tree/seve/fix-heroku">
+<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene">
  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 

--- a/experiments/heroku/README.md
+++ b/experiments/heroku/README.md
@@ -4,7 +4,7 @@
 
 Clicking on the following button will forward you to Heroku to begin the deployment process:
 
-<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene/tree/heroku">
+<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene">
  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 

--- a/experiments/heroku/README.md
+++ b/experiments/heroku/README.md
@@ -4,7 +4,7 @@
 
 Clicking on the following button will forward you to Heroku to begin the deployment process:
 
-<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene">
+<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene/tree/seve/fix-heroku">
  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: experiments/heroku/Dockerfile
 run:
-  web: cellxgene launch $DATASET $OPTIONS --host 0.0.0.0 --port $PORT
+  web: cellxgene launch $DATASET --host 0.0.0.0 --port $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: experiments/heroku/Dockerfile
 run:
-  web: cellxgene launch $DATASET --host 0.0.0.0 --port $PORT $OPTIONS
+  web: cellxgene launch $DATASET $OPTIONS --host 0.0.0.0 --port $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: experiments/heroku/Dockerfile
 run:
-  web: curl -o dataset.h5ad $DATASET && cellxgene launch dataset.h5ad --host 0.0.0.0 --port $PORT
+  web: cellxgene launch $DATASET --host 0.0.0.0 --port $PORT

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: experiments/heroku/Dockerfile
 run:
-  web: cellxgene launch $DATASET --host 0.0.0.0 --port $PORT
+  web: cellxgene launch $DATASET --host 0.0.0.0 --port $PORT $OPTIONS


### PR DESCRIPTION
Altered the Heroku setup to use the functionality of #920 and have deployed cellxgene to be launched via a URL instead of cURLing the provided link. 