### PR TITLE
Use blueprint "disable" property to indicate disabled buttons

### DIFF
--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -241,9 +241,7 @@ class Category extends React.Component {
             <Button
               data-testclass="colorby"
               data-testid={`colorby-${metadataField}`}
-              onClick={() => {
-                if (!isTruncated) this.handleColorChange();
-              }}
+              onClick={this.handleColorChange}
               active={colorAccessor === metadataField}
               intent={colorAccessor === metadataField ? "primary" : "none"}
               disabled={isTruncated}

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -244,8 +244,9 @@ class Category extends React.Component {
               onClick={() => {
                 if (!isTruncated) this.handleColorChange();
               }}
-              active={colorAccessor === metadataField || isTruncated}
-              intent={colorAccessor === metadataField && !isTruncated ? "primary" : "none"}
+              active={colorAccessor === metadataField}
+              intent={colorAccessor === metadataField ? "primary" : "none"}
+              disabled={isTruncated}
               icon="tint"
             />
           </Tooltip>

--- a/client/src/components/menubar/subset.js
+++ b/client/src/components/menubar/subset.js
@@ -20,11 +20,9 @@ function Subset(props) {
       >
         <AnchorButton
           data-testid="subset-button"
-          active={!subsetPossible}
+          disabled={!subsetPossible}
           icon="pie-chart"
-          onClick={() => {
-            if (subsetPossible) handleSubset();
-          }}
+          onClick={handleSubset}
         />
       </Tooltip>
       <Tooltip
@@ -34,11 +32,9 @@ function Subset(props) {
       >
         <AnchorButton
           data-testid="reset-subset-button"
-          active={!subsetResetPossible}
+          disabled={!subsetResetPossible}
           icon="full-circle"
-          onClick={() => {
-            if (subsetResetPossible) handleSubsetReset();
-          }}
+          onClick={handleSubsetReset}
         />
       </Tooltip>
     </ButtonGroup>


### PR DESCRIPTION
Responding to https://github.com/chanzuckerberg/cellxgene/pull/1191#issuecomment-594693946

Disabled ColorBy button:
<img width="364" alt="Screen Shot 2020-03-04 at 4 48 28 PM" src="https://user-images.githubusercontent.com/538456/75937197-14015580-5e39-11ea-97e7-1e4c400354ef.png">

Disabled Subset and ResetSubset:
<img width="483" alt="Screen Shot 2020-03-04 at 5 04 19 PM" src="https://user-images.githubusercontent.com/538456/75937890-0f3da100-5e3b-11ea-93c2-ce34f18c0f7e.png">
