### PR TITLE
Do not over-prune var data cache

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -127,14 +127,14 @@ const doInitialDataLoad = () =>
       Step 2 - load the minimum stuff required to display.
       */
       await Promise.all([
-        layoutFetchAndLoad(dispatch, schema, universe),
-        varAnnotationFetchAndLoad(dispatch, schema, universe)
+        layoutFetchAndLoad(dispatch),
+        varAnnotationFetchAndLoad(dispatch, schema)
       ]);
 
       /*
       Step 3 - load everything else
       */
-      await obsAnnotationFetchAndLoad(dispatch, schema, universe);
+      await obsAnnotationFetchAndLoad(dispatch, schema);
 
       dispatch({
         type: "initial data load complete (universe exists)",

--- a/client/src/components/categorical/category.js
+++ b/client/src/components/categorical/category.js
@@ -90,7 +90,7 @@ class Category extends React.Component {
     // || this.checkbox.indeterminate === false
     if (isChecked) {
       this.toggleNone();
-    } else if (!isChecked) {
+    } else {
       this.toggleAll();
     }
   }

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -422,8 +422,7 @@ class Graph extends React.Component {
       handleEnd,
       handleCancel,
       responsive,
-      this.graphPaddingRightLeft,
-      graphInteractionMode
+      this.graphPaddingRightLeft
     );
 
     return { toolSVG: newToolSVG, tool, container };

--- a/client/src/reducers/controls.js
+++ b/client/src/reducers/controls.js
@@ -1,7 +1,6 @@
 // jshint esversion: 6
 
 import _ from "lodash";
-import * as globals from "../globals";
 import { subsetAndResetGeneLists } from "../util/stateManager/controlsHelpers";
 
 const Controls = (

--- a/client/src/reducers/undoable.js
+++ b/client/src/reducers/undoable.js
@@ -221,15 +221,15 @@ const Undoable = (reducer, undoableKeys, options = {}) => {
     const aType = action.type;
     switch (aType) {
       case "@@undoable/undo": {
-        return undo(currentState, action);
+        return undo(currentState);
       }
 
       case "@@undoable/redo": {
-        return redo(currentState, action);
+        return redo(currentState);
       }
 
       case "@@undoable/clear": {
-        return clear(currentState, action);
+        return clear(currentState);
       }
 
       default: {

--- a/client/src/reducers/undoableConfig.js
+++ b/client/src/reducers/undoableConfig.js
@@ -145,7 +145,7 @@ Signature:  (fsm, event, from) => undoableAction
 const onFsmError = (fsm, event, from) => {
   console.error(`FSM error [event: "${event}", state: "${from}"]`, fsm);
   // In production, try to recover gracefully if we have unexpected state
-  return clear(fsm);
+  return clear();
 };
 
 /*

--- a/client/src/reducers/universe.js
+++ b/client/src/reducers/universe.js
@@ -62,9 +62,7 @@ const Universe = (state = null, action, nextSharedState, prevSharedState) => {
       const { userDefinedGenes, diffexpGenes } = prevSharedState;
       const allTheGenesWeNeed = [
         ...new Set(
-          userDefinedGenes,
-          diffexpGenes,
-          Object.keys(action.expressionData)
+          [userDefinedGenes, diffexpGenes, Object.keys(action.expressionData)].filter(ele => ele).flat()
         )
       ];
       varData = ControlsHelpers.pruneVarDataCache(varData, allTheGenesWeNeed);

--- a/client/src/reducers/world.js
+++ b/client/src/reducers/world.js
@@ -101,15 +101,10 @@ const WorldReducer = (
       const { userDefinedGenes, diffexpGenes } = prevSharedState;
       const allTheGenesWeNeed = [
         ...new Set(
-          userDefinedGenes,
-          diffexpGenes,
-          Object.keys(action.expressionData)
+          [userDefinedGenes, diffexpGenes, Object.keys(action.expressionData)].filter(ele => ele).flat()
         )
       ];
-      unclippedVarData = ControlsHelpers.pruneVarDataCache(
-        unclippedVarData,
-        allTheGenesWeNeed
-      );
+      unclippedVarData = ControlsHelpers.pruneVarDataCache(unclippedVarData, allTheGenesWeNeed);
 
       // at this point, we have the unclipped data in unclippedVarData.
       // Now create clipped.

--- a/client/src/util/stateManager/controlsHelpers.js
+++ b/client/src/util/stateManager/controlsHelpers.js
@@ -172,7 +172,7 @@ export function pruneVarDataCache(varData, needed) {
   */
 
   /*
-  VarDataCacheLowWatermark - this cofig value sets the minimum cache size,
+  VarDataCacheLowWatermark - this config value sets the minimum cache size,
   in columns, below which we don't throw away data.
 
   The value should be high enough so we are caching the maximum which will


### PR DESCRIPTION
There is a bug in how the universe and world gene sets are constructed and passed to `ControlsHelpers.pruneVarDataCache` that causes the var data cache to be over-pruned. This commit fixes the issue.

Consider the following example from the node console that mirrors the bug in the code:

```
❯ node
Welcome to Node.js v13.5.0.
Type ".help" for more information.
> new Set([1], [2], [3])
Set(1) { 1 }
```

What we really want is the set `Set(3) { 1, 2, 3 }`, which can be constructed as:

```
> new Set([].concat([1], [2], [3]))
Set(3) { 1, 2, 3 }
```