### PR TITLE
remove pinned tables Python dependency

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,7 +13,6 @@ numpy>=1.16.0
 packaging>=20.0
 pandas>=0.24.2
 scipy>=1.3.0
-tables==3.5.1
 requests>=2.22.0
 tiledb>=0.5.3
 s3fs>=0.4.0


### PR DESCRIPTION
Resolves issues running on Python 3.8.

Remove an obsolete pinned dependency of anndata/h5py, added a long time ago as a work-around for an issue with Python 3.7.  It now causes failure to install on Python3.8.