### PR TITLE
fix centroids when color by continuous 

### DIFF
--- a/client/src/util/centroid.js
+++ b/client/src/util/centroid.js
@@ -37,6 +37,11 @@ const getCoordinatesByCategoricalValues = (
     categoryName
   ];
 
+  // If the coloredBy is not a categorical col
+  if (categoryValueIndices === undefined) {
+    return coordinates;
+  }
+  
   // Check to see if the current category is a user created annotation
   const isUserAnno = schemaObsByName[categoryName].writable;
 


### PR DESCRIPTION
This PR fixed the inability to click the display labels button when a continuous value is being colored by.  Now it does not disable the display labels button while a continuous value is colored and instead displays no labels

---
This PR addresses issue #1212 