### PR TITLE
Further refine compatibility tests

### DIFF
--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - mweiden/compatibility-test-fixes-pt2
 
 env:
   JEST_ENV: prod

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -39,10 +39,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        # 1. only install the dev requirements on top of what is in the cellxgene pip package
         sudo apt-get update && sudo apt-get install -y libhdf5-serial-dev
-        make pydist install-dist dev-env
+        sed -i 's/-r requirements.txt//' server/requirements-dev.txt
+        pip install -r server/requirements-dev.txt
+        # 2. install cellxgene
+        make pydist install-dist
+        # install anndata
         pip install anndata==${{ matrix.anndata-version }}
-        # workaround for anndata 0.6.22.post1 bug
+        # 3. workaround for anndata 0.6.22.post1 bug
         [[ "0.6.22.post1" = "${{ matrix.anndata-version }}" ]] && pip install h5py==2.9.0 || true
     - name: Tests
       run: make unit-test ${{ matrix.test-suite }}

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd cellxgene
-          sed -i.bu -E 's/^anndata[>=]=[0-9]+.[0-9]+.[0-9]+$/anndata/g' server/requirements.txt
+          sed -i -E 's/^anndata[>=]=[0-9]+.[0-9]+.[0-9]+$/anndata/g' server/requirements.txt
           make pydist install-dist dev-env
           cd ../anndata
           pip install -e .

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -45,9 +45,9 @@ jobs:
         pip install -r server/requirements-dev.txt
         # 2. install cellxgene
         make pydist install-dist
-        # install anndata
+        # 3. install anndata
         pip install anndata==${{ matrix.anndata-version }}
-        # 3. workaround for anndata 0.6.22.post1 bug
+        # workaround for anndata 0.6.22.post1 bug
         [[ "0.6.22.post1" = "${{ matrix.anndata-version }}" ]] && pip install h5py==2.9.0 || true
     - name: Tests
       run: make unit-test ${{ matrix.test-suite }}

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -69,8 +69,14 @@ jobs:
           path: anndata
       - name: Install dependencies
         run: |
+          cd cellxgene
+          # 1. only install the dev requirements on top of what is in the cellxgene pip package
+          make dev-env-client
+          sed -i 's/-r requirements.txt//' server/requirements-dev.txt
+          pip install -r server/requirements-dev.txt
+          # 2. install cellxgene
           pip install --upgrade cellxgene
-          cd cellxgene && make dev-env
+          # 3. install anndata
           cd ../anndata && pip install -e .
       - name: Tests
         run: cd cellxgene && make unit-test ${{ matrix.test-suite }}

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - mweiden/compatibility-test-fixes-pt2
 
 env:
   JEST_ENV: prod

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get install libhdf5-serial-dev
+        sudo apt-get update && sudo apt-get install -y libhdf5-serial-dev
         make pydist install-dist dev-env
         pip install anndata==${{ matrix.anndata-version }}
         # workaround for anndata 0.6.22.post1 bug


### PR DESCRIPTION
* Add an `apt-get update` to make sure that the required `libhdf5-serial-dev` package is installed
* If python requirements (`server/requirements.txt`) are installed as part of `cellxgene` installation, do not reinstall them as part of installing dev requirements (`server/requirements-dev.txt`) needed to run tests
* Add some documentation