### PR TITLE
Add color mapping to the bar chart

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -334,15 +334,11 @@ class HistogramBrush extends React.PureComponent {
       .attr("class", "histogram-container")
       .attr("transform", `translate(${this.marginLeft},${this.marginTop})`);
 
-    const yMax = d3.max(bins, function (d) { return d.length });
-    const yMin = d3.min(bins, function (d) { return d.length });
-
-    const colorScale = d3.scaleSequential(interpolateCool)
-      .domain([yMin, yMax]);
+    const colorScale = d3.scaleSequential(interpolateCool).domain([0, bins.length]);
 
     const histogramScale = d3
       .scaleLinear()
-      .range([yMin, yMax])
+      .range([1, this.width + this.marginLeft + this.marginRight])
       .domain([
         colorScale.domain()[1],
         colorScale.domain()[0]
@@ -359,7 +355,7 @@ class HistogramBrush extends React.PureComponent {
       .attr("y", d => y(d.length))
       .attr("width", d => Math.abs(x(d.x1) - x(d.x0) - 1))
       .attr("height", d => y(0) - y(d.length))
-      .style("fill", function (d) { return colorScale(histogramScale.invert(d.length)) });
+      .style("fill", function (d) { return colorScale(histogramScale.invert(x(d.x0) + 1)) });
 
     // BRUSH
     // Note the brushable area is bounded by the data on three sides, but goes down to cover the x-axis

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -333,10 +333,22 @@ class HistogramBrush extends React.PureComponent {
       .attr("class", "histogram-container")
       .attr("transform", `translate(${this.marginLeft},${this.marginTop})`);
 
+    const yMax = d3.max(bins, function (d) { return d.length });
+    const yMin = d3.min(bins, function (d) { return d.length });
+
+    const colorScale = d3.scaleSequential(d3.interpolateViridis)
+      .domain([yMin, yMax]);
+
+    const legendscale = d3.scaleLinear()
+      .range([yMin, yMax])
+      .domain([
+        colorScale.domain()[1],
+        colorScale.domain()[0]
+      ]); /* we flip this to make viridis colors dark if high in the color scale */
+
     /* BINS */
     container
       .insert("g", "*")
-      .attr("fill", "#bbb")
       .selectAll("rect")
       .data(bins)
       .enter()
@@ -344,7 +356,8 @@ class HistogramBrush extends React.PureComponent {
       .attr("x", d => x(d.x0) + 1)
       .attr("y", d => y(d.length))
       .attr("width", d => Math.abs(x(d.x1) - x(d.x0) - 1))
-      .attr("height", d => y(0) - y(d.length));
+      .attr("height", d => y(0) - y(d.length))
+      .style("fill", function (d) { return colorScale(legendscale.invert(d.length)) });
 
     // BRUSH
     // Note the brushable area is bounded by the data on three sides, but goes down to cover the x-axis

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -67,7 +67,7 @@ class HistogramBrush extends React.PureComponent {
     histogramCache.binStart = i => domainMin + i * histogramCache.binWidth;
     histogramCache.binEnd = i => domainMin + (i + 1) * histogramCache.binWidth;
 
-    const yMax = Math.max(...histogramCache.bins);
+    const yMax = histogramCache.bins.reduce((l, r) => l > r ? l : r);
 
     histogramCache.y = d3
       .scaleLinear()
@@ -115,7 +115,7 @@ class HistogramBrush extends React.PureComponent {
     if the selection has changed, ensure that the brush correctly reflects
     the underlying selection.
     */
-    if ((dfChanged || rangeChanged) && brushXselection) {
+    if ((dfChanged || rangeChanged || colorSelectionChanged) && brushXselection) {
       const selection = d3.brushSelection(brushXselection.node());
       if (!range && selection) {
         /* no active selection - clear brush */

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -14,6 +14,7 @@ import * as globals from "../../globals";
 import actions from "../../actions";
 import { linspace } from "../../util/range";
 import { makeContinuousDimensionName } from "../../util/nameCreators";
+import { interpolateCool } from "d3-scale-chromatic";
 
 @connect((state, ownProps) => {
   const { isObs, isUserDefined, isDiffExp, field } = ownProps;
@@ -336,10 +337,11 @@ class HistogramBrush extends React.PureComponent {
     const yMax = d3.max(bins, function (d) { return d.length });
     const yMin = d3.min(bins, function (d) { return d.length });
 
-    const colorScale = d3.scaleSequential(d3.interpolateViridis)
+    const colorScale = d3.scaleSequential(interpolateCool)
       .domain([yMin, yMax]);
 
-    const legendscale = d3.scaleLinear()
+    const histogramScale = d3
+      .scaleLinear()
       .range([yMin, yMax])
       .domain([
         colorScale.domain()[1],
@@ -357,7 +359,7 @@ class HistogramBrush extends React.PureComponent {
       .attr("y", d => y(d.length))
       .attr("width", d => Math.abs(x(d.x1) - x(d.x0) - 1))
       .attr("height", d => y(0) - y(d.length))
-      .style("fill", function (d) { return colorScale(legendscale.invert(d.length)) });
+      .style("fill", function (d) { return colorScale(histogramScale.invert(d.length)) });
 
     // BRUSH
     // Note the brushable area is bounded by the data on three sides, but goes down to cover the x-axis

--- a/client/src/reducers/undoableConfig.js
+++ b/client/src/reducers/undoableConfig.js
@@ -241,7 +241,7 @@ debug: set to any falsish value to disable logging of helpful debugging informat
 Set to true or 1 for base logging, high number for more verbosity (currently only 1/true
 or 2).
 */
-const debug = true;
+const debug = false;
 const undoableConfig = {
   debug,
   historyLimit: 50, // maximum history size

--- a/client/src/reducers/undoableConfig.js
+++ b/client/src/reducers/undoableConfig.js
@@ -241,7 +241,7 @@ debug: set to any falsish value to disable logging of helpful debugging informat
 Set to true or 1 for base logging, high number for more verbosity (currently only 1/true
 or 2).
 */
-const debug = false;
+const debug = true;
 const undoableConfig = {
   debug,
   historyLimit: 50, // maximum history size


### PR DESCRIPTION
Finishing up https://github.com/chanzuckerberg/cellxgene/pull/1035

Changes made on top of @Donaldpherman's PR:
* Only color histograms that are selected for colorby
* Reuse binning functions from `util/dataframe/histogram.js`; this fixes an issue with d3 generating near-zero width bins
* Fix/simplify histogram color mapping functions
* Do not attempt to plot bins if the calculated binWidth is zero; this can happen if all dataframe column values are the same
* Refactor the function that draws the histogram a bit

Illustration of fixes to color mapping are below. Each shows the legend scaled against the colored histogram bins.

Before (source @liaprins-czi):
![Screen Shot 2020-03-11 at 11 32 26 AM](https://user-images.githubusercontent.com/538456/76493951-180d1480-63f1-11ea-8e84-a679dcdb4bb7.png)

After (source this PR):
<img width="561" alt="Screen Shot 2020-03-11 at 10 38 15 PM" src="https://user-images.githubusercontent.com/538456/76493984-2bb87b00-63f1-11ea-9be9-857bc8a6c643.png">
