### PR TITLE
Fix matrix cache race condition

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -231,7 +231,6 @@ def launch_args(func):
         "--config-file",
         "-c",
         "config_file",
-        is_flag=True,
         default=None,
         show_default=True,
         help="Location to yaml file with configuration settings",

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -53,6 +53,7 @@ class AppConfig(object):
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]
             self.multi_dataset__allowed_matrix_types = dc["multi_dataset"]["allowed_matrix_types"]
+            self.multi_dataset__matrix_cache__max_datasets = dc["multi_dataset"]["matrix_cache"]["max_datasets"]
             self.single_dataset__datapath = dc["single_dataset"]["datapath"]
             self.single_dataset__obs_names = dc["single_dataset"]["obs_names"]
             self.single_dataset__var_names = dc["single_dataset"]["var_names"]
@@ -241,7 +242,8 @@ class AppConfig(object):
     def handle_multi_dataset(self, context):
         self.__check_attr("multi_dataset__dataroot", (type(None), str))
         self.__check_attr("multi_dataset__index", (type(None), bool, str))
-        self.__check_attr("multi_dataset__allowed_matrix_types", (list))
+        self.__check_attr("multi_dataset__allowed_matrix_types", (tuple, list))
+        self.__check_attr("multi_dataset__matrix_cache__max_datasets", int)
 
         if self.multi_dataset__dataroot is None:
             return
@@ -252,6 +254,9 @@ class AppConfig(object):
                 MatrixDataType(mtype)
             except ValueError:
                 raise ConfigurationError(f'Invalid matrix type in "allowed_matrix_types": {mtype}')
+
+        # matrix cache
+        MatrixDataCacheManager.set_max_datasets(self.multi_dataset__matrix_cache__max_datasets)
 
     def handle_user_annotations(self, context):
         self.__check_attr("user_annotations__enable", bool)

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -26,6 +26,11 @@ multi_dataset:
   # A list of allowed matrix types.  If an empty list, then all matrix types are allowed
   allowed_matrix_types: []
 
+  matrix_cache:
+    # The maximum number of datasets that may be opened at one time.  The least recently used dataset
+    # is evicted from the cache first.
+    max_datasets: 5
+
 single_dataset:
   datapath: null
   obs_names: null
@@ -60,6 +65,7 @@ adaptor:
 
   anndata_adaptor:
       backed: false
+
 """
 
 

--- a/server/data_common/matrix_loader.py
+++ b/server/data_common/matrix_loader.py
@@ -65,7 +65,7 @@ class MatrixDataCacheManager(object):
     when the context ends.  This class currently implements a simple least recently used cache,
     which can delete a dataset from the cache to make room for a new oneo
 
-    This is the indended usage pattern:
+    This is the intended usage pattern:
 
            m = MatrixDataCacheManager()
            with m.data_adaptor(location, app_config) as data_adaptor:
@@ -77,7 +77,11 @@ class MatrixDataCacheManager(object):
     #  TODO:  This is very simple.  This can be improved by taking into account how much space is actually
     #         taken by each dataset, instead of arbitrarily picking a max datasets to cache.
     #         Also, this should be controlled by a configuration parameter.
-    MAX_CACHED = 3
+    MAX_CACHED = 5
+
+    @staticmethod
+    def set_max_datasets(max_cached):
+        MatrixDataCacheManager.MAX_CACHED = max_cached
 
     # FIXME:   If the number of active datasets exceeds the MAX_CACHED, then each request could
     # lead to a dataset being deleted and a new only being opened: the cache will get thrashed.
@@ -122,11 +126,12 @@ class MatrixDataCacheManager(object):
                 loader = MatrixDataLoader(location, app_config=app_config)
                 cache_item = MatrixDataCacheItem(loader)
                 self.datasets[location] = (cache_item, last_accessed)
-        try:
-            data_adaptor = cache_item.acquire(app_config)
-            yield data_adaptor
-        finally:
-            cache_item.release()
+
+            try:
+                data_adaptor = cache_item.acquire(app_config)
+                yield data_adaptor
+            finally:
+                cache_item.release()
 
 
 class MatrixDataType(Enum):


### PR DESCRIPTION
The simplest fix is to acquire the cache_item lock while holding the matrix cache lock.
This potentially causes a slowdown when a new matrix is loaded for the first time.
However, even with large datasets with is hardly noticable.  If the server finds itself in
the situation where the cache is being thrashed then the solution is to increase the
cache size.

Fixes #1255