### PR TITLE
Avoid race condition in the matrix cache handling.

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -231,7 +231,6 @@ def launch_args(func):
         "--config-file",
         "-c",
         "config_file",
-        is_flag=True,
         default=None,
         show_default=True,
         help="Location to yaml file with configuration settings",

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -53,6 +53,7 @@ class AppConfig(object):
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]
             self.multi_dataset__allowed_matrix_types = dc["multi_dataset"]["allowed_matrix_types"]
+            self.multi_dataset__matrix_cache__max_datasets = dc["multi_dataset"]["matrix_cache"]["max_datasets"]
             self.single_dataset__datapath = dc["single_dataset"]["datapath"]
             self.single_dataset__obs_names = dc["single_dataset"]["obs_names"]
             self.single_dataset__var_names = dc["single_dataset"]["var_names"]
@@ -241,7 +242,8 @@ class AppConfig(object):
     def handle_multi_dataset(self, context):
         self.__check_attr("multi_dataset__dataroot", (type(None), str))
         self.__check_attr("multi_dataset__index", (type(None), bool, str))
-        self.__check_attr("multi_dataset__allowed_matrix_types", (list))
+        self.__check_attr("multi_dataset__allowed_matrix_types", (tuple, list))
+        self.__check_attr("multi_dataset__matrix_cache__max_datasets", int)
 
         if self.multi_dataset__dataroot is None:
             return
@@ -252,6 +254,9 @@ class AppConfig(object):
                 MatrixDataType(mtype)
             except ValueError:
                 raise ConfigurationError(f'Invalid matrix type in "allowed_matrix_types": {mtype}')
+
+        # matrix cache
+        MatrixDataCacheManager.set_max_datasets(self.multi_dataset__matrix_cache__max_datasets)
 
     def handle_user_annotations(self, context):
         self.__check_attr("user_annotations__enable", bool)

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -26,6 +26,11 @@ multi_dataset:
   # A list of allowed matrix types.  If an empty list, then all matrix types are allowed
   allowed_matrix_types: []
 
+  matrix_cache:
+    # The maximum number of datasets that may be opened at one time.  The least recently used dataset
+    # is evicted from the cache first.
+    max_datasets: 5
+
 single_dataset:
   datapath: null
   obs_names: null
@@ -60,6 +65,7 @@ adaptor:
 
   anndata_adaptor:
       backed: false
+
 """
 
 

--- a/server/data_common/matrix_loader.py
+++ b/server/data_common/matrix_loader.py
@@ -117,11 +117,11 @@ class MatrixDataCacheManager(object):
             if data_adaptor is None:
                 while True:
                     # find the last access times for each loader
-                    items = list(self.datasets.items())
-                    sorted(items, key=lambda x: x[1][1])
-                    if len(items) < self.MAX_CACHED:
+                    if len(self.datasets) < self.MAX_CACHED:
                         break
 
+                    items = list(self.datasets.items())
+                    sorted(items, key=lambda x: x[1][1])
                     # close the least recently used loader
                     oldest = items[0]
                     oldest_cache = oldest[1][0]

--- a/server/data_common/matrix_loader.py
+++ b/server/data_common/matrix_loader.py
@@ -28,7 +28,7 @@ class MatrixDataCacheItem(object):
         self.data_lock.r_release()
         return None
 
-    def acquire(self, app_config):
+    def acquire_and_open(self, app_config):
         """returns the data_adaptor if cached.  opens the data_adaptor if not.
         In either case, the a reader lock is taken.  Must call release when
         the data_adaptor is no longer needed"""
@@ -138,7 +138,7 @@ class MatrixDataCacheManager(object):
             if delete_adaptor:
                 delete_adaptor.delete()
             if data_adaptor is None:
-                data_adaptor = cache_item.acquire(app_config)
+                data_adaptor = cache_item.acquire_and_open(app_config)
             yield data_adaptor
         finally:
             cache_item.release()

--- a/server/data_common/rwlock.py
+++ b/server/data_common/rwlock.py
@@ -12,6 +12,8 @@
     Code written by Tyler Neylon at Unbox Research.
 
     This file is public domain.
+
+    Modified to add a w_demote function to convert a writer lock to a reader lock
 """
 
 
@@ -87,6 +89,12 @@ class RWLock(object):
 
     def w_release(self):
         self.w_lock.release()
+
+    def w_demote(self):
+        """demote a write lock to a reader lock"""
+        self.num_r_lock.acquire()
+        self.num_r += 1
+        self.num_r_lock.release()
 
     @contextmanager
     def w_locked(self):

--- a/server/data_common/rwlock.py
+++ b/server/data_common/rwlock.py
@@ -54,15 +54,26 @@ class RWLock(object):
         self.num_r_lock = Lock()
         self.num_r = 0
 
+        # The d_lock is needed to handle the demotion case,
+        # so that the writer can become a reader without releasing the w_lock.
+        # the d_lock is held by the writer, and prevents any other thread from taking the
+        # num_r_lock during that time, which means the writer thread is able to take the
+        # num_r_lock to update the num_r.
+        self.d_lock = Lock()
+
     # ___________________________________________________________________
     # Reading methods.
 
     def r_acquire(self):
+        self.d_lock.acquire()
         self.num_r_lock.acquire()
         self.num_r += 1
+
         if self.num_r == 1:
             self.w_lock.acquire()
+
         self.num_r_lock.release()
+        self.d_lock.release()
 
     def r_release(self):
         assert self.num_r > 0
@@ -70,6 +81,7 @@ class RWLock(object):
         self.num_r -= 1
         if self.num_r == 0:
             self.w_lock.release()
+
         self.num_r_lock.release()
 
     @contextmanager
@@ -85,16 +97,23 @@ class RWLock(object):
     # Writing methods.
 
     def w_acquire(self):
+        self.d_lock.acquire()
         self.w_lock.acquire()
 
     def w_release(self):
         self.w_lock.release()
+        self.d_lock.release()
 
     def w_demote(self):
-        """demote a write lock to a reader lock"""
+        """demote a writer lock to a reader lock"""
+
+        # the d_lock is already held from w_acquire.
+        # releasing the d_lock at the end of this function allows multiple readers.
+        # incrementing num_r makes this thread one of those readers.
         self.num_r_lock.acquire()
         self.num_r += 1
         self.num_r_lock.release()
+        self.d_lock.release()
 
     @contextmanager
     def w_locked(self):


### PR DESCRIPTION
During the MatrixDataCacheItem acquire function there was a
time when the write lock was released and the read lock was taken.
During that time, the dataset could have been deleted, later
result in the MatrixDataCacheManageri data adaptor returning None.

The solution is to demote the writer lock to a reader lock instead
of unlocking and relocking.

Also, when a the cache needs to delete an entry, the delete
is done outside the MatrixDataCacheManager lock.   This operation
only requires the write lock for the MatrixDataCacheItem.

Fixes #1255