### PR TITLE
do in-app compression only for CLI

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -4,8 +4,6 @@ import logging
 
 from flask import Flask, redirect, current_app, make_response, render_template, abort
 from flask import Blueprint, request, send_from_directory
-from flask_caching import Cache
-from flask_compress import Compress
 from flask_cors import CORS
 from flask_restful import Api, Resource
 
@@ -208,10 +206,6 @@ class Server:
         self.app = Flask(__name__, static_folder="../common/web/static")
         self.app.json_encoder = Float32JSONEncoder
 
-        self.cache = Cache(config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 860_000})
-        self.cache.init_app(self.app)
-
-        Compress(self.app)
         CORS(self.app, supports_credentials=True)
 
         # enable session data

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,6 @@ anndata>=0.6.20
 click>=6.7
 fastobo>=0.6.1
 Flask>=1.0.2
-Flask-Caching>=1.4.0
 Flask-Compress>=1.4.0
 Flask-Cors>=3.0.6
 Flask-RESTful>=0.3.6


### PR DESCRIPTION
In-app compression of HTTP responses is now enabled only for the CLI,  which uses the flask dev HTTP server.  When being launched as a WSGI server, no compression is done on the assumption that it will be handled by the httpd.

Also deleted old dead code related to an unused HTTP response caching module.