### PR TITLE
CORS and CSP headers

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -42,11 +42,11 @@ start-server:
 
 .PHONY: backend-dev
 backend-dev: server-requirements
-	source ../venv/bin/activate && $(MAKE) start-server
+	source ../venv/bin/activate && CXG_OPTIONS='--debug' $(MAKE) start-server
 
 .PHONY: backend-dev-anno-ontology
 backend-dev-anno-ontology: server-requirements
-	CXG_OPTIONS='--experimental-annotations-ontology' \
+	CXG_OPTIONS='--experimental-annotations-ontology --debug' \
 		$(MAKE) backend-dev
 
 .PHONY: test

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -4,8 +4,8 @@ import logging
 
 from flask import Flask, redirect, current_app, make_response, render_template, abort
 from flask import Blueprint, request, send_from_directory
-from flask_cors import CORS
 from flask_restful import Api, Resource
+from flask_cors import CORS
 
 from http import HTTPStatus
 
@@ -204,9 +204,8 @@ class Server:
     def __init__(self, matrix_data_cache_manager, annotations, app_config):
 
         self.app = Flask(__name__, static_folder="../common/web/static")
+        self._before_adding_routes(app_config)
         self.app.json_encoder = Float32JSONEncoder
-
-        CORS(self.app, supports_credentials=True)
 
         # enable session data
         self.app.permanent_session_lifetime = datetime.timedelta(days=50 * 365)
@@ -238,3 +237,7 @@ class Server:
         self.app.matrix_data_cache_manager = matrix_data_cache_manager
         self.app.annotations = annotations
         self.app.app_config = app_config
+
+    def _before_adding_routes(self, app_config):
+        """ will be called before routes are added.  Subclass protocol """
+        pass

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -4,8 +4,6 @@ import logging
 
 from flask import Flask, redirect, current_app, make_response, render_template, abort
 from flask import Blueprint, request, send_from_directory
-from flask_caching import Cache
-from flask_compress import Compress
 from flask_cors import CORS
 from flask_restful import Api, Resource
 
@@ -208,10 +206,6 @@ class Server:
         self.app = Flask(__name__, static_folder="../common/web/static")
         self.app.json_encoder = Float32JSONEncoder
 
-        self.cache = Cache(config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 860_000})
-        self.cache.init_app(self.app)
-
-        Compress(self.app)
         CORS(self.app, supports_credentials=True)
 
         # enable session data

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -5,7 +5,6 @@ import logging
 from flask import Flask, redirect, current_app, make_response, render_template, abort
 from flask import Blueprint, request, send_from_directory
 from flask_restful import Api, Resource
-from flask_cors import CORS
 
 from http import HTTPStatus
 

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -7,6 +7,7 @@ import webbrowser
 
 import click
 from flask_compress import Compress
+from flask_cors import CORS
 
 from server.common.utils import sort_options
 from server.common.errors import DatasetAccessError, ConfigurationError
@@ -274,8 +275,11 @@ class CliLaunchServer(Server):
     """
     the CLI runs a local web server, and needs to enable a few more features.
     """
+
     def __init__(self, matrix_data_cache_manager, annotations, app_config):
         super().__init__(matrix_data_cache_manager, annotations, app_config)
+
+    def _before_adding_routes(self, app_config):
         self.app.config["COMPRESS_MIMETYPES"] = [
             "text/html",
             "text/css",
@@ -284,8 +288,9 @@ class CliLaunchServer(Server):
             "application/javascript",
             "application/octet-stream",
         ]
-        compress = Compress(self.app)
-        compress.init_app(self.app)
+        Compress(self.app)
+        if app_config.server__debug:
+            CORS(self.app, supports_credentials=True)
 
 
 @sort_options

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -7,10 +7,7 @@ import webbrowser
 
 import click
 from flask_compress import Compress
-<<<<<<< HEAD
 from flask_cors import CORS
-=======
->>>>>>> master
 
 from server.common.utils import sort_options
 from server.common.errors import DatasetAccessError, ConfigurationError

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -52,6 +52,7 @@ class AppConfig(object):
             self.server__open_browser = dc["server"]["open_browser"]
             self.server__about_legal_tos = dc["server"]["about_legal_tos"]
             self.server__about_legal_privacy = dc["server"]["about_legal_privacy"]
+            self.server__force_https = dc["server"]["force_https"]
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]
             self.multi_dataset__allowed_matrix_types = dc["multi_dataset"]["allowed_matrix_types"]

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -12,6 +12,7 @@ server:
   open_browser: false
   about_legal_tos: null
   about_legal_privacy: null
+  force_https: false
 
 presentation:
   max_categories: 1000

--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -34,10 +34,7 @@ class WSGIServer(Server):
         super().__init__(matrix_data_cache_manager, annotations, app_config)
 
     def _before_adding_routes(self, app_config):
-        csp = {
-            "default-src": "'self' 'unsafe-inline' 'unsafe-eval'",
-            "img-src": ["'self'", "data:"]
-        }
+        csp = {"default-src": "'self' 'unsafe-inline' 'unsafe-eval'", "img-src": ["'self'", "data:"]}
         Talisman(self.app, force_https=app_config.server__force_https, content_security_policy=csp)
 
 

--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import logging
+from flask_talisman import Talisman
 
 if os.path.isdir("/opt/python/log"):
     # This is the standard location where Amazon EC2 instances store the application logs.
@@ -27,6 +28,19 @@ except Exception:
     logging.critical("Exception importing server modules", exc_info=True)
     sys.exit(1)
 
+
+class WSGIServer(Server):
+    def __init__(self, matrix_data_cache_manager, annotations, app_config):
+        super().__init__(matrix_data_cache_manager, annotations, app_config)
+
+    def _before_adding_routes(self, app_config):
+        csp = {
+            "default-src": "'self' 'unsafe-inline' 'unsafe-eval'",
+            "img-src": ["'self'", "data:"]
+        }
+        Talisman(self.app, force_https=app_config.server__force_https, content_security_policy=csp)
+
+
 try:
     dataroot = os.getenv("CXG_DATAROOT")
     app_config = AppConfig()
@@ -38,7 +52,7 @@ try:
 
     if dataroot:
         logging.info(f"Configuration from CXG_DATAROOT")
-        app_config.update(multi_dataset__dataroot=dataroot,)
+        app_config.update(multi_dataset__dataroot=dataroot)
 
     # features are unsupported in the current hosted server
     app_config.update(
@@ -52,7 +66,7 @@ try:
     app_config.complete_config(matrix_data_cache_manager, logging.info)
     user_annotations = app_config.user_annotations
 
-    server = Server(matrix_data_cache_manager, user_annotations, app_config)
+    server = WSGIServer(matrix_data_cache_manager, user_annotations, app_config)
 
     debug = False
     application = server.app

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,7 @@ Flask-Compress>=1.4.0
 Flask-Cors>=3.0.6
 Flask-RESTful>=0.3.6
 flask-server-timing>=0.1.2
+flask-talisman>=0.7.0
 flatbuffers>=1.10.0
 flatten-dict>=0.2.0
 fsspec>=0.4.4

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,6 @@ anndata>=0.6.20
 click>=6.7
 fastobo>=0.6.1
 Flask>=1.0.2
-Flask-Caching>=1.4.0
 Flask-Compress>=1.4.0
 Flask-Cors>=3.0.6
 Flask-RESTful>=0.3.6


### PR DESCRIPTION
Added both CORS and CSP header generation.  Note:
* CLI server (`cellxgene launch`) will accept cross-origin requests when run in --debug mode, allowing continued use of separate hot-loading server for developer workflow.
* CLI server does not set CSP headers
* WSGI server (eb/app.py) sets CSP headers
* a new configuration param server.force_https will redirect all requests to HTTPs.  Default off, expected to be set in a hosted environment.

Fixes #1237 
