### PR TITLE
[EASY] Small documentation fix in prepare

### DIFF
--- a/server/cli/prepare.py
+++ b/server/cli/prepare.py
@@ -84,7 +84,7 @@ def prepare(
         import scanpy as sc
     except ImportError:
         raise click.ClickException(
-            "[cellxgene] cellxgene prepare has not been installed. Please run `pip install cellxgene[prepare]` "
+            "[cellxgene] cellxgene prepare has not been installed. Please run `pip install 'cellxgene[prepare]'` "
             "to install the necessary requirements."
         )
 


### PR DESCRIPTION
*See sample of current behavior below:*
```
venv❯ cellxgene prepare example-dataset/pbmc3k.h5ad
[cellxgene] Starting CLI...
Error: [cellxgene] cellxgene prepare has not been installed. Please run
`pip install cellxgene[prepare]` to install the necessary requirements.

1 venv❯ pip install cellxgene[prepare]
zsh: no matches found: cellxgene[prepare]
```

*Fix:*
Wrap cellxgene[prepare] in single quotes.