### PR TITLE
Add TOS and Privacy url via config

### DIFF
--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -32,7 +32,9 @@ import UndoRedoReset from "./undoRedo";
   aboutLink: state.config?.links?.["about-dataset"],
   disableDiffexp: state.config?.parameters?.["disable-diffexp"] ?? false,
   diffexpMayBeSlow: state.config?.parameters?.["diffexp-may-be-slow"] ?? false,
-  showCentroidLabels: state.centroidLabels.showLabels
+  showCentroidLabels: state.centroidLabels.showLabels,
+  tosURL: state.config?.about_legal_tos,
+  privacyURL: state.config?.about_legal_privacy
 }))
 class MenuBar extends React.Component {
   static isValidDigitKeyEvent(e) {
@@ -279,7 +281,9 @@ class MenuBar extends React.Component {
       clipPercentileMax,
       graphInteractionMode,
       aboutLink,
-      showCentroidLabels
+      showCentroidLabels,
+      privacyURL,
+      tosURL
     } = this.props;
     const { pendingClipPercentiles } = this.state;
 
@@ -402,6 +406,8 @@ class MenuBar extends React.Component {
         <InformationMenu
           libraryVersions={libraryVersions}
           aboutLink={aboutLink}
+          tosURL={tosURL}
+          privacyURL={privacyURL}
         />
       </div>
     );

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -33,8 +33,8 @@ import UndoRedoReset from "./undoRedo";
   disableDiffexp: state.config?.parameters?.["disable-diffexp"] ?? false,
   diffexpMayBeSlow: state.config?.parameters?.["diffexp-may-be-slow"] ?? false,
   showCentroidLabels: state.centroidLabels.showLabels,
-  tosURL: state.config?.about_legal_tos,
-  privacyURL: state.config?.about_legal_privacy
+  tosURL: state.config?.parameters?.about_legal_tos,
+  privacyURL: state.config?.parameters?.about_legal_privacy
 }))
 class MenuBar extends React.Component {
   static isValidDigitKeyEvent(e) {

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -47,16 +47,16 @@ function InformationMenu(props) {
               }`}
             />
             <MenuItem text="MIT License" />
-            <MenuItem
+            {tosURL ? <MenuItem
               href={tosURL}
               target="_blank"
               text="Terms of Service"
-            />
-            <MenuItem
+            /> : null }
+            {privacyURL ? <MenuItem
               href={privacyURL}
               target="_blank"
               text="Privacy Policy"
-            />
+            /> : null }
           </Menu>
         }
         position={Position.BOTTOM_RIGHT}

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -3,7 +3,7 @@ import React from "react";
 import { Button, Popover, Menu, MenuItem, Position } from "@blueprintjs/core";
 
 function InformationMenu(props) {
-  const { libraryVersions, aboutLink } = props;
+  const { libraryVersions, aboutLink, tosURL, privacyURL } = props;
   return (
     <div style={{}} className="bp3-button-group">
       <Popover
@@ -47,6 +47,16 @@ function InformationMenu(props) {
               }`}
             />
             <MenuItem text="MIT License" />
+            {tosURL ? <MenuItem
+              href={tosURL}
+              target="_blank"
+              text="Terms of Servce"
+            /> : null}
+            {privacyURL ? <MenuItem
+              href={privacyURL}
+              target="_blank"
+              text="Privacy Policy"
+            /> : null}
           </Menu>
         }
         position={Position.BOTTOM_RIGHT}

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -47,16 +47,16 @@ function InformationMenu(props) {
               }`}
             />
             <MenuItem text="MIT License" />
-            {tosURL ? <MenuItem
+            <MenuItem
               href={tosURL}
               target="_blank"
-              text="Terms of Servce"
-            /> : null}
-            {privacyURL ? <MenuItem
+              text="Terms of Service"
+            />
+            <MenuItem
               href={privacyURL}
               target="_blank"
               text="Privacy Policy"
-            /> : null}
+            />
           </Menu>
         }
         position={Position.BOTTOM_RIGHT}


### PR DESCRIPTION
This PR adds, conditioned on their being present in config, two menu items with linkouts to external webpages for `tos` and `privacy`

![image](https://user-images.githubusercontent.com/1770265/77599682-e1002e00-6edb-11ea-8885-0c0c5e1eb099.png)
