### PR TITLE
turn off auto-reload in debug mode

### DIFF
--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -427,6 +427,7 @@ def launch(
             port=app_config.server__port,
             threaded=not app_config.server__debug,
             use_debugger=False,
+            use_reloader=False
         )
     except OSError as e:
         if e.errno == errno.EADDRINUSE:

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -186,10 +186,6 @@ class AppConfig(object):
         self.__check_attr("server__open_browser", bool)
 
         if self.server__port:
-            if self.server__debug:
-                raise ConfigurationError(
-                    "'port' and 'debug' may not be used together (try 'verbose' for error logging)."
-                )
             if not is_port_available(self.server__host, self.server__port):
                 raise ConfigurationError(
                     f"The port selected {self.server__port} is in use, please configure an open port."


### PR DESCRIPTION
this PR changes the behavior of the `--debug` flag for `cellxgene launch`.  Previously, it would auto-reload any files that changed in the project.  This conflicted with port auto-assignment, so --port was mutually exclusive.

This PR makes two changes:
* `--port` and `--debug` can co-exist
* auto-reloading of Python code is disabled

This should resolve the issues with `make backend-dev`