### PR TITLE
Fix for s3 region name in data locator

### DIFF
--- a/server/common/data_locator.py
+++ b/server/common/data_locator.py
@@ -39,7 +39,7 @@ class DataLocator:
             self.cname = self.path if self.protocol == "file" else self.uri_or_path
 
         # fsspec.filesystem will throw RuntimeError if the protocol is unsupported
-        if self.protocol == "s3" and app_config.data_locator__s3__region_name:
+        if self.protocol == "s3" and app_config and app_config.data_locator__s3__region_name:
             self.fs = fsspec.filesystem(
                 self.protocol, config_kwargs={"region_name": app_config.data_locator__s3__region_name}
             )


### PR DESCRIPTION
There is a small chicken and egg problem.
The config file could be in s3, therefore when using the DataLocator to
download the config file, we don't yet have an app_config object.
Adding a check to handle this case.