### PR TITLE
work-around for column name encoding bug

### DIFF
--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -442,10 +442,18 @@ def sanitize_df(df):
     df.rename(columns=sanitize_keys(df.keys().tolist()), inplace=True)
 
 
+def sanitize_mapping(mapping):
+    clean_keys = sanitize_keys([k for k in mapping.keys()])
+    for old_key, new_key in clean_keys.items():
+        if old_key != new_key:
+            mapping[new_key] = mapping[old_key]
+            del mapping[old_key]
+
+
 def clean_all_column_names(adata):
     sanitize_df(adata.obs)
     sanitize_df(adata.var)
-    sanitize_df(adata.obsm)
+    sanitize_mapping(adata.obsm)
 
 
 if __name__ == "__main__":

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -411,10 +411,8 @@ def sanitize_keys(keys):
 
     Returned new keys will be both safe and unique.
     """
-    print(keys)
     p = re.compile(r"[^a-zA-Z0-9!\-_\.\*'\(\)&$@=;:\+ ,\?]")
     clean_keys = {k: p.sub('_', k) for k in keys}
-    print(clean_keys)
 
     used_keys = set()
     clean_unique_keys = {}
@@ -433,7 +431,6 @@ def sanitize_keys(keys):
                 clean_unique_keys[k] = candidate_name
                 break
 
-    print(clean_unique_keys)
     for k, v, in clean_unique_keys.items():
         if k != v:
             log(1, f"Renaming {k} to {v}")

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -411,11 +411,13 @@ def sanitize_keys(keys):
 
     Returned new keys will be both safe and unique.
     """
+    print(keys)
     p = re.compile(r"[^a-zA-Z0-9!-_.*'()&$@=;:+ ,?]")
     clean_keys = {k: p.sub('_', k) for k in keys}
+    print(clean_keys)
+
     used_keys = set()
     clean_unique_keys = {}
-
     for k, v in clean_keys.items():
         if v not in used_keys:
             used_keys.add(v)

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -412,7 +412,7 @@ def sanitize_keys(keys):
     Returned new keys will be both safe and unique.
     """
     print(keys)
-    p = re.compile(r"[^a-zA-Z0-9!-_.*'()&$@=;:+ ,?]")
+    p = re.compile(r"[^a-zA-Z0-9!\-_\.\*'\(\)&$@=;:\+ ,\?]")
     clean_keys = {k: p.sub('_', k) for k in keys}
     print(clean_keys)
 

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -395,23 +395,20 @@ def save_metadata(container, metadata):
 
 def sanitize_keys(keys):
     """
-    We need names to be safe to use as S3 object keys or Posix file names.
-
-    Posix reserved characters:  null and '/'
-    S3 guidance: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
-
-    Short term, to be conservative, we are following the AWS S3 guidance, and
-    only allowing:
-        * known safe: [0-9][A-Z][a-z][!-_.*'()]
-        * mostly safe, but assume URL encoding, etc: [&$@=;:+ ,?]
-    Anything outside of these will be replaced with an underscore.
+    We need names to be safe to use as attribute names in tiledb.  See:
+        TileDB-Inc/TileDB#1575
+        TileDB-Inc/TileDB-Py#294
+    This can be entirely removed once they add proper escaping.
 
     Args: list of keys
     Returns: dict of {old_key: new_key, ...}
 
     Returned new keys will be both safe and unique.
+
+    Masking out [~/.] and anything outside the ASCII range.
     """
-    p = re.compile(r"[^a-zA-Z0-9!\-_\.\*'\(\)&$@=;:\+ ,\?]")
+    # p = re.compile(r"[^a-zA-Z0-9!\-_\.\*'\(\)&$@=;:\+ ,\?]")
+    p = re.compile(r"[^ -\.0-\[\]-\}")
     clean_keys = {k: p.sub('_', k) for k in keys}
 
     used_keys = set()

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -439,7 +439,7 @@ def sanitize_keys(keys):
 
 
 def sanitize_df(df):
-    df.rename(columns=sanitize_keys(df.keys.tolist()), inplace=True)
+    df.rename(columns=sanitize_keys(df.keys().tolist()), inplace=True)
 
 
 def clean_all_column_names(adata):

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -427,6 +427,7 @@ def sanitize_keys(keys):
                 used_keys.add(candidate_name)
                 clean_unique_keys[k] = candidate_name
                 break
+            counter += 1
 
     for k, v, in clean_unique_keys.items():
         if k != v:

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -408,7 +408,7 @@ def sanitize_keys(keys):
     Masking out [~/.] and anything outside the ASCII range.
     """
     # p = re.compile(r"[^a-zA-Z0-9!\-_\.\*'\(\)&$@=;:\+ ,\?]")
-    p = re.compile(r"[^ -\.0-\[\]-\}")
+    p = re.compile(r"[^ -\.0-\[\]-\}]")
     clean_keys = {k: p.sub('_', k) for k in keys}
 
     used_keys = set()


### PR DESCRIPTION
Add a work-around to cxgtool for a tiledb bug that does not correctly escape attribute/column names containing a `/`.  These characters will be replaced with an underscore, and then the names will be de-duped in the case that creates duplicate names.