### PR TITLE
add cache control headers

### DIFF
--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -198,6 +198,7 @@ class AppConfig(object):
         self.__check_attr("server__open_browser", bool)
         self.__check_attr("server__force_https", bool)
         self.__check_attr("server__flask_secret_key", (type(None), str))
+        self.__check_attr("server__generate_cache_control_headers", bool)
 
         if self.server__port:
             if not is_port_available(self.server__host, self.server__port):

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -66,6 +66,7 @@ class AppConfig(object):
             self.server__about_legal_privacy = dc["server"]["about_legal_privacy"]
             self.server__force_https = dc["server"]["force_https"]
             self.server__flask_secret_key = dc["server"]["flask_secret_key"]
+            self.server__generate_cache_control_headers = dc["server"]["generate_cache_control_headers"]
 
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -14,6 +14,7 @@ server:
   about_legal_privacy: null
   force_https: false
   flask_secret_key: null
+  generate_cache_control_headers: false
 
 presentation:
   max_categories: 1000


### PR DESCRIPTION
This PR adds cache control headers to all routes.

They are enabled/disabled by a new configuration variable, `generate_cache_control_headers` which is off by default for backward compatibility in the CLI.

When it is on, the `Cache-Control` header is set as follows:
* the `/health` sets `no-cache`
* all PUT & POST routes set `no-cache`
* GET routes will set `public, max-age=3600`
