### PR TITLE
[EASY] `make install` should fail if there's no build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ gen-package-lock:
 # install from build directory
 .PHONY: install
 install: uninstall
-	cd $(BUILDDIR); pip install -e .
+	cd $(BUILDDIR) && pip install -e .
 
 # install from source tree for development
 .PHONY: install-dev


### PR DESCRIPTION
Currently, if there is no build directory, the `make install` target will attempt to cd into the build directory, fail, and run `pip install -e .` in the root directory anyway. This causes cellxgene to be installed from the source tree instead of what the user would expect. The difference can be difficult to catch if you aren't scrolling/reading the logs carefully.

This commit changes the behavior such that the `make install` will fail if there is no build directory.