### PR TITLE
update s3fs requirements

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -17,5 +17,4 @@ PyYAML>=5.3
 scipy>=1.3.0
 requests>=2.22.0
 tiledb>=0.5.3
-# s3fs, issue 313 breaks cellxgene
-s3fs==0.4.0
+s3fs>=0.4.0,!=0.4.1


### PR DESCRIPTION
s3fs issue 303 (dask/s3fs#303) has been resolved in release 0.4.2.  This updates our requirements to work around the bug in 0.4.1.

Fixes #1310 