### PR TITLE
load embeddings in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ build-cli: build-client
 build-for-server-dev: clean-server build-client
 	$(call copy_client_assets,client/build,server)
 
+.PHONY: copy-client-assets
+copy-client-assets:
+	$(call copy_client_assets,client/build,server)
+
 # TESTING
 .PHONY: test
 test: unit-test smoke-test

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -81,9 +81,11 @@ function layoutFetchAndLoad(dispatch, schema) {
 
   const plimit = new PromiseLimit(4);
   return Promise.all(
-    embNames.map(e =>
+    // embNames.map(e =>
+    [0].map(e =>
       plimit.add(() => {
-        const url = `${baseURL}?layout-name=${encodeURIComponent(e)}`;
+        // const url = `${baseURL}?layout-name=${encodeURIComponent(e)}`;
+        const url = baseURL;
         return doBinaryRequest(url).then(buffer => {
           const df = Universe.matrixFBSToDataframe(buffer);
           dispatch({

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -81,24 +81,6 @@ function layoutFetchAndLoad(dispatch, schema) {
   const baseURL = `${globals.API.prefix}${globals.API.version}layout/obs`;
 
   const plimit = new PromiseLimit(4);
-  // return Promise.all(
-  //   embNames.map(e =>
-  //     // [0].map(e =>
-  //     plimit.add(() => {
-  //       const url = `${baseURL}?layout-name=${encodeURIComponent(e)}`;
-  //       // const url = baseURL;
-  //       return doBinaryRequest(url).then(buffer => {
-  //         const df = Universe.matrixFBSToDataframe(buffer);
-  //         dispatch({
-  //           type: "universe: column load success",
-  //           dim: "obsLayout",
-  //           dataframe: df
-  //         });
-  //       });
-  //     })
-  //   )
-  // );
-
   return Promise.all(
     embNames.map(e =>
       plimit.add(() => {

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -74,23 +74,26 @@ function varAnnotationFetchAndLoad(dispatch, schema) {
 /*
 return promise fetching layout we need
 */
-function layoutFetchAndLoad(dispatch) {
+function layoutFetchAndLoad(dispatch, schema) {
+  const embeddings = schema?.schema?.layout?.obs ?? [];
+  const embNames = embeddings.map(e => e.name);
+  const baseURL = `${globals.API.prefix}${globals.API.version}layout/obs`;
+
+  const plimit = new PromiseLimit(4);
   return Promise.all(
-    ["layout/obs"]
-      .map(path => {
-        const url = `${globals.API.prefix}${globals.API.version}${path}`;
-        return doBinaryRequest(url);
-      })
-      .map(rqst => rqst.then(buffer => Universe.matrixFBSToDataframe(buffer)))
-      .map(resp =>
-        resp.then(df =>
+    embNames.map(e =>
+      plimit.add(() => {
+        const url = `${baseURL}?layout-name=${encodeURIComponent(e)}`;
+        return doBinaryRequest(url).then(buffer => {
+          const df = Universe.matrixFBSToDataframe(buffer);
           dispatch({
             type: "universe: column load success",
             dim: "obsLayout",
             dataframe: df
-          })
-        )
-      )
+          });
+        });
+      })
+    )
   );
 }
 
@@ -130,7 +133,7 @@ const doInitialDataLoad = () =>
       Step 2 - load the minimum stuff required to display.
       */
       await Promise.all([
-        layoutFetchAndLoad(dispatch),
+        layoutFetchAndLoad(dispatch, schema),
         varAnnotationFetchAndLoad(dispatch, schema)
       ]);
 

--- a/client/src/reducers/world.js
+++ b/client/src/reducers/world.js
@@ -39,14 +39,20 @@ const WorldReducer = (
       /* incremental initial data load - always assumes world == universe */
       const { universe } = nextSharedState;
       const { dim } = action;
+
+      // we don't clip anything except for varData and obsAnnotations
+      let unclipped = state.unclipped;
+      if (dim == "varData" || dim == "obsAnnotations") {
+        unclipped = {
+          ...unclipped,
+          [dim]: universe[dim].clone()
+        };
+      }
       return {
         ...state,
         schema: universe.schema,
         [dim]: universe[dim].clone(),
-        unclipped: {
-          ...state.unclipped,
-          [dim]: universe[dim].clone()
-        }
+        unclipped
       };
     }
 
@@ -106,10 +112,15 @@ const WorldReducer = (
       const { userDefinedGenes, diffexpGenes } = prevSharedState;
       const allTheGenesWeNeed = [
         ...new Set(
-          [userDefinedGenes, diffexpGenes, Object.keys(action.expressionData)].filter(ele => ele).flat()
+          [userDefinedGenes, diffexpGenes, Object.keys(action.expressionData)]
+            .filter(ele => ele)
+            .flat()
         )
       ];
-      unclippedVarData = ControlsHelpers.pruneVarDataCache(unclippedVarData, allTheGenesWeNeed);
+      unclippedVarData = ControlsHelpers.pruneVarDataCache(
+        unclippedVarData,
+        allTheGenesWeNeed
+      );
 
       // at this point, we have the unclipped data in unclippedVarData.
       // Now create clipped.

--- a/server/data_common/data_adaptor.py
+++ b/server/data_common/data_adaptor.py
@@ -331,10 +331,9 @@ class DataAdaptor(metaclass=ABCMeta):
         normalized_layout = normalized_layout.astype(dtype=np.float32)
         return normalized_layout
 
-    def layout_to_fbs_matrix(self):
-        """ same as layout, except returns a flatbuffer """
+    def layout_to_fbs_matrix(self, fields):
         """
-        return all embeddings as a flatbuffer, using the cellxgene matrix fbs encoding.
+        return specified embeddings as a flatbuffer, using the cellxgene matrix fbs encoding.
 
         * returns only first two dimensions, with name {ename}_0 and {ename}_1,
           where {ename} is the embedding name.
@@ -343,8 +342,7 @@ class DataAdaptor(metaclass=ABCMeta):
         * does not support filtering
 
         """
-
-        embeddings = self.get_embedding_names()
+        embeddings = self.get_embedding_names() if fields is None or len(fields) == 0 else fields
         layout_data = []
         with ServerTiming.time(f"layout.query"):
             for ename in embeddings:

--- a/server/test/schema.json
+++ b/server/test/schema.json
@@ -67,6 +67,16 @@
         "name": "umap",
         "type": "float32",
         "dims": ["umap_0", "umap_1"]
+      },
+      {
+        "name": "tsne",
+        "type": "float32",
+        "dims": ["tsne_0", "tsne_1"]
+      },
+      {
+        "name": "pca",
+        "type": "float32",
+        "dims": ["pca_0", "pca_1"]
       }
     ]
   }

--- a/server/test/test_anndata_adaptor.py
+++ b/server/test/test_anndata_adaptor.py
@@ -34,7 +34,7 @@ Test the anndata adaptor using the pbmc3k data set.
 class AdaptorTest(unittest.TestCase):
     def setUp(self):
         args = {
-            "embeddings__names": ["umap"],
+            "embeddings__names": ["umap", "tsne", "pca"],
             "presentation__max_categories": 100,
             "single_dataset__obs_names": None,
             "single_dataset__var_names": None,
@@ -122,15 +122,29 @@ class AdaptorTest(unittest.TestCase):
         check_feature("PUT", "/annotations/obs", False)
 
     def test_layout(self):
-        fbs = self.data.layout_to_fbs_matrix()
+        fbs = self.data.layout_to_fbs_matrix(fields=None)
         layout = decode_fbs.decode_matrix_FBS(fbs)
-        self.assertEqual(layout["n_cols"], 2)
+        self.assertEqual(layout["n_cols"], 6)
         self.assertEqual(layout["n_rows"], 2638)
 
         X = layout["columns"][0]
         self.assertTrue((X >= 0).all() and (X <= 1).all())
         Y = layout["columns"][1]
         self.assertTrue((Y >= 0).all() and (Y <= 1).all())
+
+    def test_layout_fields(self):
+        """ X_pca, X_tsne, X_umap are available """
+        fbs = self.data.layout_to_fbs_matrix(["pca"])
+        layout = decode_fbs.decode_matrix_FBS(fbs)
+        self.assertEqual(layout["n_cols"], 2)
+        self.assertEqual(layout["n_rows"], 2638)
+        self.assertCountEqual(layout["col_idx"], ["pca_0", "pca_1"])
+
+        fbs = self.data.layout_to_fbs_matrix(["tsne", "pca"])
+        layout = decode_fbs.decode_matrix_FBS(fbs)
+        self.assertEqual(layout["n_cols"], 4)
+        self.assertEqual(layout["n_rows"], 2638)
+        self.assertCountEqual(layout["col_idx"], ["tsne_0", "tsne_1", "pca_0", "pca_1"])
 
     def test_annotations(self):
         fbs = self.data.annotation_to_fbs_matrix("obs")


### PR DESCRIPTION
This PR moves our embedding data load from a single big HTTP request for all embeddings to a per-embedding HTTP request.  This should give us more parallelism in deployments that have back-end parallelism, and speed up initial data loading.

Fixes #1365 
