### PR TITLE
Update brushable histogram x-tick number format

### DIFF
--- a/client/__tests__/e2e/data.js
+++ b/client/__tests__/e2e/data.js
@@ -41,7 +41,7 @@ export const datasets = {
         {
           metadata: "n_genes",
           "coordinates-as-percent": { x1: 0.25, y1: 0.5, x2: 0.55, y2: 0.5 },
-          count: "1552"
+          count: "1537"
         }
       ]
     },
@@ -140,8 +140,8 @@ export const datasets = {
       metadata: "n_genes",
       gene: "S100A8",
       "coordinates-as-percent": { x1: 0.25, y1: 0.5, x2: 0.55, y2: 0.5 },
-      count: "392",
-      "gene-cell-count": "421"
+      count: "386",
+      "gene-cell-count": "416"
     }
   }
 };

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -80,8 +80,8 @@ class HistogramBrush extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    this.marginLeft = 3; // Space for 0 tick label on X axis
-    this.marginRight = 40; // space for Y axis & labels
+    this.marginLeft = 12; // Space for 0 tick label on X axis
+    this.marginRight = 52; // space for Y axis & labels
     this.marginBottom = 25; // space for X axis & labels
     this.marginTop = 3;
 
@@ -374,8 +374,8 @@ class HistogramBrush extends React.PureComponent {
       .call(
         d3
           .axisBottom(x)
-          .ticks(5)
-          .tickFormat(d3.format(".0s"))
+          .ticks(4)
+          .tickFormat(d3.format(x.domain().some(n => Math.abs(n) >= 10000) ? ".2e" : ","))
       );
 
     /* Y AXIS */
@@ -387,7 +387,7 @@ class HistogramBrush extends React.PureComponent {
         d3
           .axisRight(y)
           .ticks(3)
-          .tickFormat(d3.format(".0s"))
+          .tickFormat(d3.format(y.domain().some(n => Math.abs(n) >= 10000) ? ".0e" : ","))
       );
 
     /* axis style */


### PR DESCRIPTION
Fixes #1349

## Sub-issues

### Repeating tick mark issue
The issue was that significant digits that differentiated consecutive tick marks were cropped in number string formatting.

**Strategy to fix number formatting**: increase the number of significant digits shown in scientific notation number formatting to 2 (format `.2e`) instead of 1 (format `.1s`).

For more information see https://github.com/d3/d3-format

Note that does not _fully_ fix the issue described in #1349, but rather makes the formatting issue far less likely. It is _still_ possible for this to occur if the difference between two ticks in axes happens in the a significant digit cropped by the scientific notation format.

### `milli` notation (`123m`) is not intuitive
Users reported that using an `m` to denote a number (`trueValue = 0.001 * displayNumber`) was not intuitive. This PR changes the behavior of the formatting logic to use unabbreviated numbers when the domain of a variable is `-10000 < min < max < 10000` and use scientific notation otherwise. We let `d3` determine xticks for decimals since it generally choses values without many significant digits.

## Results

The following are images show improvements over the example problems in #1349:

<img width="442" alt="Screen Shot 2020-04-06 at 5 44 24 PM" src="https://user-images.githubusercontent.com/538456/78625502-10e6f400-7841-11ea-8621-0be8053d50af.png">

_litvinukova20_restricted.processed.h5ad_

<img width="909" alt="Screen Shot 2020-04-06 at 5 42 22 PM" src="https://user-images.githubusercontent.com/538456/78625531-28be7800-7841-11ea-92d3-0f3a4833ca5f.png">

_lukassen20_airway_orig.processed.h5ad_