### PR TITLE
add config and init for server timings

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -4,6 +4,7 @@ import logging
 from flask import Flask, redirect, current_app, make_response, render_template, abort
 from flask import Blueprint, request
 from flask_restful import Api, Resource
+from server_timing import Timing as ServerTiming
 
 from http import HTTPStatus
 
@@ -235,6 +236,8 @@ class Server:
         self.app = Flask(__name__, static_folder="../common/web/static")
         self._before_adding_routes(app_config)
         self.app.json_encoder = Float32JSONEncoder
+        if app_config.server__server_timing_headers:
+            ServerTiming(self.app, force_debug=True)
 
         # enable session data
         self.app.permanent_session_lifetime = datetime.timedelta(days=50 * 365)

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -202,6 +202,7 @@ class AppConfig(object):
         self.__check_attr("server__force_https", bool)
         self.__check_attr("server__flask_secret_key", (type(None), str))
         self.__check_attr("server__generate_cache_control_headers", bool)
+        self.__check_attr("server__server_timing_headers", bool)
 
         if self.server__port:
             if not is_port_available(self.server__host, self.server__port):

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -67,6 +67,7 @@ class AppConfig(object):
             self.server__force_https = dc["server"]["force_https"]
             self.server__flask_secret_key = dc["server"]["flask_secret_key"]
             self.server__generate_cache_control_headers = dc["server"]["generate_cache_control_headers"]
+            self.server__server_timing_headers = dc["server"]["server_timing_headers"]
 
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -15,6 +15,7 @@ server:
   force_https: false
   flask_secret_key: null
   generate_cache_control_headers: false
+  server_timing_headers: false
 
 presentation:
   max_categories: 1000


### PR DESCRIPTION
this PR adds a config to enable/disable the generation of Server-Timing headers.  They are off by default.

Fixes #1276 
