### PR TITLE
CXG performance improvements

### DIFF
--- a/server/common/immutable_kvcache.py
+++ b/server/common/immutable_kvcache.py
@@ -11,14 +11,44 @@ class ImmutableKVCache(MutableMapping):
     def __init__(self, factory):
         self.factory = factory
         self.lock = threading.Lock()
+        self.factory_calls = {}
         self.cache = {}
         super().__init__()
 
     def __getitem__(self, key):
-        if key not in self.cache:
-            with self.lock:
-                if key not in self.cache:
+        if key in self.cache:
+            return self.cache[key]
+
+        # we need to call factory.  First grab the main lock and the per-key CV.
+        factory_calls = None
+        with self.lock:
+            if key in self.cache:
+                return self.cache[key]
+            if key not in self.factory_calls:
+                creation_thr = True
+                self.factory_calls[key] = {'cv': threading.Condition(), 'is_done': False, 'error': None}
+            factory_calls = self.factory_calls[key]
+
+        # with the CV, create the value (or wait for it to be created)
+        cv = factory_calls['cv']
+        with cv:
+            if creation_thr:
+                try:
                     self.cache[key] = self.factory(key)
+                except Exception as e:
+                    factory_calls['error'] = e
+
+                factory_calls['is_done'] = True
+                cv.notify_all()
+            else:
+                """ wait for the value to be available """
+                while not factory_calls['is_done']:
+                    cv.wait()
+
+        with self.lock:
+            if key in self.factory_calls:
+                del self.factory_calls[key]
+
         return self.cache[key]
 
     def __iter__(self):
@@ -33,8 +63,7 @@ class ImmutableKVCache(MutableMapping):
         return self.cache.__contains__(key)
 
     def __delitem__(self, key):
-        with self.lock:
-            del self.cache[key]
+        del self.cache[key]
 
     def __setitem__(self, key, value):
         """ unsupported """

--- a/server/common/immutable_kvcache.py
+++ b/server/common/immutable_kvcache.py
@@ -9,10 +9,10 @@ class ImmutableKVCache(MutableMapping):
     """
 
     def __init__(self, factory):
-        self.factory = factory
-        self.lock = threading.Lock()
-        self.factory_calls = {}
-        self.cache = {}
+        self.factory = factory  # user-provided factory function
+        self.lock = threading.Lock()  # guards factory_calls
+        self.factory_calls = {}  # per-key factory condition variables
+        self.cache = {}  # result cache, indexed by key
         super().__init__()
 
     def __getitem__(self, key):

--- a/server/common/immutable_kvcache.py
+++ b/server/common/immutable_kvcache.py
@@ -21,6 +21,7 @@ class ImmutableKVCache(MutableMapping):
 
         # we need to call factory.  First grab the main lock and the per-key CV.
         factory_calls = None
+        creation_thr = False
         with self.lock:
             if key in self.cache:
                 return self.cache[key]

--- a/server/common/immutable_kvcache.py
+++ b/server/common/immutable_kvcache.py
@@ -1,0 +1,41 @@
+import threading
+from collections.abc import MutableMapping
+
+
+class ImmutableKVCache(MutableMapping):
+    """
+    Guarantees that the factory will be called for each key once, and
+    only once.
+    """
+
+    def __init__(self, factory):
+        self.factory = factory
+        self.lock = threading.Lock()
+        self.cache = {}
+        super().__init__()
+
+    def __getitem__(self, key):
+        if key not in self.cache:
+            with self.lock:
+                if key not in self.cache:
+                    self.cache[key] = self.factory(key)
+        return self.cache[key]
+
+    def __iter__(self):
+        """ weak iter, don't call factory """
+        return self.cache.__iter__()
+
+    def __len__(self):
+        return self.cache.__len__()
+
+    def __contains__(self, key):
+        """ weak contain - don't call factory """
+        return self.cache.__contains__(key)
+
+    def __delitem__(self, key):
+        with self.lock:
+            del self.cache[key]
+
+    def __setitem__(self, key, value):
+        """ unsupported """
+        raise NotImplementedError

--- a/server/data_cxg/cxg_adaptor.py
+++ b/server/data_cxg/cxg_adaptor.py
@@ -397,8 +397,6 @@ class CxgAdaptor(DataAdaptor):
             if return_fields:
                 df = df[return_fields]
 
-            print(df)
-
         with ServerTiming.time(f"annotations.{axis}.encode"):
             fbs = encode_matrix_fbs(df, col_idx=df.columns)
 

--- a/server/data_cxg/cxg_adaptor.py
+++ b/server/data_cxg/cxg_adaptor.py
@@ -335,17 +335,17 @@ class CxgAdaptor(DataAdaptor):
         with ServerTiming.time(f"annotations.{axis}.query"):
             with ServerTiming.time(f"annotations.{axis}.query.open_array"):
                 A = self.open_array(str(axis))
-                if axis == Axis.OBS:
-                    if labels is not None and not labels.empty:
-                        df = pd.DataFrame.from_dict(A[:])
-                        df = df.join(labels, self.get_obs_names())
-                    else:
-                        df = pd.DataFrame.from_dict(A[:])
+            if axis == Axis.OBS:
+                if labels is not None and not labels.empty:
+                    df = pd.DataFrame.from_dict(A[:])
+                    df = df.join(labels, self.get_obs_names())
                 else:
                     df = pd.DataFrame.from_dict(A[:])
+            else:
+                df = pd.DataFrame.from_dict(A[:])
 
-                if fields is not None and len(fields) > 0:
-                    df = df[fields]
+            if fields is not None and len(fields) > 0:
+                df = df[fields]
 
         with ServerTiming.time(f"annotations.{axis}.encode"):
             fbs = encode_matrix_fbs(df, col_idx=df.columns)

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -84,7 +84,7 @@ class EndPoints(object):
         self.assertIsNone(df["row_idx"])
         self.assertEqual(len(df["columns"]), df["n_cols"])
         obs_index_col_name = self.schema["schema"]["annotations"]["obs"]["index"]
-        self.assertListEqual(
+        self.assertCountEqual(
             df["col_idx"],
             [obs_index_col_name, "n_genes", "percent_mito", "n_counts", "louvain"]
             + (["cluster-test"] if self.ANNOTATIONS_ENABLED else []),
@@ -104,7 +104,7 @@ class EndPoints(object):
         self.assertIsNotNone(df["columns"])
         self.assertIsNone(df["row_idx"])
         self.assertEqual(len(df["columns"]), df["n_cols"])
-        self.assertListEqual(df["col_idx"], ["n_genes", "percent_mito"])
+        self.assertCountEqual(df["col_idx"], ["n_genes", "percent_mito"])
 
     def test_get_annotations_obs_error(self):
         endpoint = "annotations/obs"
@@ -157,7 +157,7 @@ class EndPoints(object):
         self.assertIsNone(df["row_idx"])
         self.assertEqual(len(df["columns"]), df["n_cols"])
         var_index_col_name = self.schema["schema"]["annotations"]["var"]["index"]
-        self.assertListEqual(df["col_idx"], [var_index_col_name, "n_cells"])
+        self.assertCountEqual(df["col_idx"], [var_index_col_name, "n_cells"])
 
     def test_get_annotations_var_keys_fbs(self):
         endpoint = "annotations/var"
@@ -173,7 +173,7 @@ class EndPoints(object):
         self.assertIsNotNone(df["columns"])
         self.assertIsNone(df["row_idx"])
         self.assertEqual(len(df["columns"]), df["n_cols"])
-        self.assertListEqual(df["col_idx"], ["n_cells"])
+        self.assertCountEqual(df["col_idx"], ["n_cells"])
 
     def test_get_annotations_var_error(self):
         endpoint = "annotations/var"


### PR DESCRIPTION
Several performance optimizations in this PR, all to the CXG adaptor:
* add better caching to IO intensive or high latency paths, including schema creation, array open, and lsuri.
* do not load entire annotation (obs or var) when requester only wants specific columns
* improve lock concurrency in array handling

In addition, there are some minor test changes to make them insensitive to column ordering in dataframes.