### PR TITLE
Clean up main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,12 @@ clean-%:
 
 # BUILDING PACKAGE
 
-.PHONY: build
-build: clean build-cli
-	@echo "done"
-
 .PHONY: build-client
 build-client:
 	cd client && $(MAKE) ci build
 
-.PHONY: build-cli
-build-cli: build-client
+.PHONY: build
+build: clean build-client
 	git ls-files server/ | grep -v 'server/test/' | cpio -pdm $(BUILDDIR)
 	cp -r client/build/  $(CLIENTBUILD)
 	$(call copy_client_assets,$(CLIENTBUILD),$(SERVERBUILD))

--- a/Makefile
+++ b/Makefile
@@ -146,13 +146,6 @@ gen-package-lock:
 
 # INSTALL
 
-# setup.py sucks when you have your library in a separate folder, adding these in to help setup envs
-
-# install from build directory
-.PHONY: install
-install: uninstall
-	cd $(BUILDDIR) && pip install -e .
-
 # install from source tree for development
 .PHONY: install-dev
 install-dev: uninstall

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -99,6 +99,6 @@ If you would like to run the client tests individually, follow the steps below i
 1. For the smoke test run `npm run smoke-test` or `make smoke-test`
 
 ### Tips
-* You can also install/launch the server side code from npm scrips (requires python3.6 with virtualenv) in `client/` directory run `npm run backend-dev`
+* You can also install/launch the server side code from npm scrips (requires python3.6 with virtualenv) with the `scripts/backend_dev` script.
 
 

--- a/dev_docs/developer_scripts.md
+++ b/dev_docs/developer_scripts.md
@@ -9,10 +9,9 @@ Documentation for the `Makefile` targets in the project root directory.
 builds source code
 
 ```
-build - builds whole app client and server
-build-cli - makes build dir and moves python and client files
-build-client - runs webpack build
-build-for-server-dev - builds client and copies output directly into source tree (only for server devlopment)
+build - builds the whole app (client/ source and server/ source packaged together)
+build-client - runs the client webpack build
+build-for-server-dev - builds client and copies output directly into the server source tree (only for server devlopment)
 ```
 
 ### Clean commands
@@ -50,7 +49,6 @@ dev-env - installs requirements and requirments-dev (for building code)
 Installs cellxgene from different locations
 
 ```
-install - installs from local build directory
 install-dev - installs from local source tree
 install-release-test - installs from test pypi
 install-release - installs from pypi


### PR DESCRIPTION
* Remove unnecessary indirect alias for `build-cli`
* Remove target for installing from build. This doesn't work and does not have a known use case.