### PR TITLE
fix non-finite condition in mean/var calculation

### DIFF
--- a/server/compute/diffexp.py
+++ b/server/compute/diffexp.py
@@ -34,6 +34,10 @@ def _mean_var_n(X):
     if fp_err_occurred:
         mean[np.isfinite(mean) == False] = 0  # noqa: E712
         v[np.isfinite(v) == False] = 0  # noqa: E712
+    else:
+        mean[np.isnan(mean)] = 0
+        v[np.isnan(v)] = 0
+
     return mean, v, n
 
 


### PR DESCRIPTION
In cases where the X matrix contains _only_ NaN for an entire feature/gene, the mean/var calculation would fail to treat as it does with other non-finite values.

Fixes #1378 
