### PR TITLE
add GET routes for expression data

### DIFF
--- a/client/src/reducers/controls.js
+++ b/client/src/reducers/controls.js
@@ -20,8 +20,6 @@ const Controls = (
     scatterplotXXaccessor: null, // just easier to read
     scatterplotYYaccessor: null,
     graphRenderCounter: 0 /* integer as <Component key={graphRenderCounter} - a change in key forces a remount */,
-    __storedStateForCelllist1__: null /* will need procedural control of brush ie., brush.extent https://bl.ocks.org/micahstubbs/3cda05ca68cba260cb81 */,
-    __storedStateForCelllist2__: null
   },
   action,
   nextSharedState,
@@ -62,7 +60,7 @@ const Controls = (
           universeExists &&
           embeddingsExist &&
           varAnnotationsIndexExists
-        )
+        ),
       };
     }
     case "initial data load complete (universe exists)": {
@@ -71,38 +69,42 @@ const Controls = (
         ...state,
         loading: false,
         error: null,
-        resettingInterface: false
+        resettingInterface: false,
       };
     }
     case "reset World to eq Universe": {
-      const [ newUserDefinedGenes, newDiffExpGenes ] = subsetAndResetGeneLists(state);
+      const [newUserDefinedGenes, newDiffExpGenes] = subsetAndResetGeneLists(
+        state
+      );
       return {
         ...state,
         resettingInterface: false,
         userDefinedGenes: newUserDefinedGenes,
-        diffexpGenes: newDiffExpGenes
+        diffexpGenes: newDiffExpGenes,
       };
     }
     case "set World to current selection": {
-      const [ newUserDefinedGenes, newDiffExpGenes ] = subsetAndResetGeneLists(state);
+      const [newUserDefinedGenes, newDiffExpGenes] = subsetAndResetGeneLists(
+        state
+      );
       return {
         ...state,
         loading: false,
         error: null,
         userDefinedGenes: newUserDefinedGenes,
-        diffexpGenes: newDiffExpGenes
+        diffexpGenes: newDiffExpGenes,
       };
     }
     case "request user defined gene started": {
       return {
         ...state,
-        userDefinedGenesLoading: true
+        userDefinedGenesLoading: true,
       };
     }
     case "request user defined gene error": {
       return {
         ...state,
-        userDefinedGenesLoading: false
+        userDefinedGenesLoading: false,
       };
     }
     case "request user defined gene success": {
@@ -113,50 +115,49 @@ const Controls = (
       return {
         ...state,
         userDefinedGenes: _userDefinedGenes,
-        userDefinedGenesLoading: false
+        userDefinedGenesLoading: false,
       };
     }
     case "request differential expression success": {
       const { world } = prevSharedState;
       const varIndexName = world.schema.annotations.var.index;
       const _diffexpGenes = [];
-      action.data.forEach(d => {
+      action.data.forEach((d) => {
         _diffexpGenes.push(world.varAnnotations.at(d[0], varIndexName));
       });
       return {
         ...state,
-        diffexpGenes: _diffexpGenes
+        diffexpGenes: _diffexpGenes,
       };
     }
     case "clear differential expression": {
       return {
         ...state,
-        diffexpGenes: []
+        diffexpGenes: [],
       };
     }
     case "clear user defined gene": {
       const { userDefinedGenes } = state;
       const newUserDefinedGenes = _.filter(
         userDefinedGenes,
-        d => d !== action.data
+        (d) => d !== action.data
       );
       return {
         ...state,
-        userDefinedGenes: newUserDefinedGenes
+        userDefinedGenes: newUserDefinedGenes,
       };
     }
     case "clear all user defined genes": {
       return {
         ...state,
-        userDefinedGenes: []
+        userDefinedGenes: [],
       };
     }
-    case "expression load error":
     case "initial data load error": {
       return {
         ...state,
         loading: false,
-        error: action.error
+        error: action.error,
       };
     }
 
@@ -166,24 +167,24 @@ const Controls = (
     case "change graph interaction mode":
       return {
         ...state,
-        graphInteractionMode: action.data
+        graphInteractionMode: action.data,
       };
     case "change opacity deselected cells in 2d graph background":
       return {
         ...state,
-        opacityForDeselectedCells: action.data
+        opacityForDeselectedCells: action.data,
       };
     case "increment graph render counter": {
       const c = state.graphRenderCounter + 1;
       return {
         ...state,
-        graphRenderCounter: c
+        graphRenderCounter: c,
       };
     }
     case "interface reset started": {
       return {
         ...state,
-        resettingInterface: true
+        resettingInterface: true,
       };
     }
 
@@ -193,18 +194,18 @@ const Controls = (
     case "set scatterplot x":
       return {
         ...state,
-        scatterplotXXaccessor: action.data
+        scatterplotXXaccessor: action.data,
       };
     case "set scatterplot y":
       return {
         ...state,
-        scatterplotYYaccessor: action.data
+        scatterplotYYaccessor: action.data,
       };
     case "clear scatterplot":
       return {
         ...state,
         scatterplotXXaccessor: null,
-        scatterplotYYaccessor: null
+        scatterplotYYaccessor: null,
       };
 
     default:

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -198,6 +198,11 @@ class DataVarAPI(Resource):
     def put(self, data_adaptor):
         return common_rest.data_var_put(request, data_adaptor)
 
+    @cache_control(public=True, max_age=ONE_WEEK)
+    @rest_get_data_adaptor
+    def get(self, data_adaptor):
+        return common_rest.data_var_get(request, data_adaptor)
+
 
 class DiffExpObsAPI(Resource):
     @cache_control(no_store=True)

--- a/server/common/rest.py
+++ b/server/common/rest.py
@@ -49,7 +49,7 @@ def _query_parameter_to_filter(args):
         "var": {},
     }
 
-    # args has already be url-unquoted once.  We assume double escaping
+    # args has already been url-unquoted once.  We assume double escaping
     # on name and value.
     try:
         for key, value in args.items(multi=True):

--- a/server/test/test_api.py
+++ b/server/test/test_api.py
@@ -206,6 +206,13 @@ class EndPoints(object):
         result = self.session.put(url, headers=header)
         self.assertEqual(result.status_code, HTTPStatus.BAD_REQUEST)
 
+    def test_data_get_fbs(self):
+        endpoint = f"data/var"
+        url = f"{self.URL_BASE}{endpoint}"
+        header = {"Accept": "application/octet-stream"}
+        result = self.session.get(url, headers=header)
+        self.assertEqual(result.status_code, HTTPStatus.BAD_REQUEST)
+
     def test_data_put_filter_fbs(self):
         endpoint = f"data/var"
         url = f"{self.URL_BASE}{endpoint}"
@@ -221,6 +228,19 @@ class EndPoints(object):
         self.assertIsNone(df["row_idx"])
         self.assertEqual(len(df["columns"]), df["n_cols"])
         self.assertListEqual(df["col_idx"].tolist(), [0, 1, 4])
+
+    def test_data_get_filter_fbs(self):
+        index_col_name = self.schema["schema"]["annotations"]["var"]["index"]
+        query = f"var:{index_col_name}=SIK1"
+        endpoint = f"data/var"
+        url = f"{self.URL_BASE}{endpoint}?{query}"
+        header = {"Accept": "application/octet-stream"}
+        result = self.session.get(url, headers=header)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        self.assertEqual(result.headers["Content-Type"], "application/octet-stream")
+        df = decode_fbs.decode_matrix_FBS(result.content)
+        self.assertEqual(df["n_rows"], 2638)
+        self.assertEqual(df["n_cols"], 1)
 
     def test_data_put_single_var(self):
         endpoint = f"data/var"

--- a/server/test/test_filter.py
+++ b/server/test/test_filter.py
@@ -1,0 +1,83 @@
+import unittest
+from urllib.parse import parse_qs
+from werkzeug.datastructures import MultiDict
+from server.common.rest import _query_parameter_to_filter
+from server.common.errors import FilterError
+
+
+def _qsparse(qs):
+    """ emulate what Flask/Werkzeug do to our QS """
+    return MultiDict(parse_qs(qs))
+
+
+class FilterParseTests(unittest.TestCase):
+    """ Test cases for various filter parsing """
+
+    def test_queryparam_to_filter_parse(self):
+        # categories
+        self.assertEqual(_query_parameter_to_filter(_qsparse("obs:foo=bar&var:baz=133&var:baz=A&obs:baz=foo")), {
+            "obs": {
+                "annotation_value": [
+                    {"name": "foo", "values": ["bar"]},
+                    {"name": "baz", "values": ["foo"]},
+                ]
+            },
+            "var": {
+                "annotation_value": [
+                    {"name": "baz", "values": ["133", "A"]}
+                ]
+            }
+        })
+
+        # ranges
+        self.assertEqual(_query_parameter_to_filter(_qsparse("obs:A=1,99&obs:B=*,100&obs:C=0,*")), {
+            "obs": {
+                "annotation_value": [
+                    {"name": "A", "min": 1, "max": 99.},
+                    {"name": "B", "max": 100.},
+                    {"name": "C", "min": 0.},
+                ]
+            },
+        })
+
+        # combo
+        self.assertEqual(_query_parameter_to_filter(_qsparse("var:B=YES&var:A=1,99&var:B=NO")), {
+            "var": {
+                "annotation_value": [
+                    {"name": "B", "values": ["YES", "NO"]},
+                    {"name": "A", "min": 1., "max": 99.},
+                ]
+            },
+        })
+
+    def test_queryparam_to_filter_escaping(self):
+        self.assertEqual(_query_parameter_to_filter(_qsparse("obs:var=%2521%252C%253AOK%253D&obs:A%2521=YO")), {
+            "obs": {
+                "annotation_value": [
+                    {"name": "var", "values": ["!,:OK="]},
+                    {"name": "A!", "values": ["YO"]},
+                ],
+            },
+        })
+
+    def test_queryparam_to_filter_errors(self):
+
+        # should raise FilterError
+        filter_errors = [
+            "foo=bar",  # no axis
+            "X=&Y=3",  # no value
+            "X&Y=3",  # no value
+            "moo:foo=bar",  # bad axis
+            "obs:x=1,A",  # non-numeric range
+            "var:X=1,2&var:X=3,4",  # duplicate ranges
+            "var:Y=,",
+            "var:Y=2,",
+            "var:Y=,5",
+            "var:Y=*,",
+            "var:Y=,*",
+            "var:Y=*,*",
+        ]
+
+        for qs in filter_errors:
+            with self.assertRaises(FilterError):
+                _query_parameter_to_filter(_qsparse(qs))


### PR DESCRIPTION
This PR addresses the performance of expression data fetching in two ways:
* Add GET routes for the /data/ routes, which allows them to be cached
* Parallel load more than one expression column

In addition, there is some minor improvements to:
* error handling of HTTP network errors (eg fetch() throwing a TypeError)
* clean up of the action handlers used to fetch expression data
* new lint standard applied to the JS files touched
* tests for the query param filter format used in the new GET routes
* pruned some _very_ dead code from reducer/controls.js

Fixes #1382 
