### PR TITLE
performance and correctness fixes to brushable histogram

### DIFF
--- a/client/src/components/continuous/continuous.js
+++ b/client/src/components/continuous/continuous.js
@@ -8,32 +8,20 @@ import { Button } from "@blueprintjs/core";
 import * as globals from "../../globals";
 import HistogramBrush from "../brushableHistogram";
 
-@connect(state => ({
+@connect((state) => ({
   obsAnnotations: state.world?.obsAnnotations,
   colorAccessor: state.colors.colorAccessor,
   colorScale: state.colors.scale,
-  schema: state.world?.schema
+  schema: state.world?.schema,
 }))
 class Continuous extends React.PureComponent {
-  handleColorAction = key => {
-    return () => {
-      const { dispatch, obsAnnotations } = this.props;
-      const summary = obsAnnotations.col(key).summarize();
-      dispatch({
-        type: "color by continuous metadata",
-        colorAccessor: key,
-        rangeForColorAccessor: summary
-      });
-    };
-  };
-
   static renderIsStillLoading(zebra, key) {
     return (
       <div
         key={key}
         style={{
           padding: globals.leftSidebarSectionPadding,
-          backgroundColor: zebra % 2 === 0 ? globals.lightestGrey : "white"
+          backgroundColor: zebra % 2 === 0 ? globals.lightestGrey : "white",
         }}
       >
         <div
@@ -41,7 +29,7 @@ class Continuous extends React.PureComponent {
             display: "flex",
             justifyContent: "space-between",
             justifyItems: "center",
-            alignItems: "center"
+            alignItems: "center",
           }}
         >
           <div style={{ minWidth: 30 }} />
@@ -51,7 +39,7 @@ class Continuous extends React.PureComponent {
           <div
             style={{
               display: "flex",
-              justifyContent: "flex-end"
+              justifyContent: "flex-end",
             }}
           >
             <Button minimal loading intent="primary" />
@@ -66,16 +54,16 @@ class Continuous extends React.PureComponent {
 
     const obsIndex = schema.annotations.obs.index;
     const allContinuousNames = schema.annotations.obs.columns
-      .filter(col => col.type === "int32" || col.type === "float32")
-      .filter(col => col.name !== obsIndex)
-      .map(col => col.name);
+      .filter((col) => col.type === "int32" || col.type === "float32")
+      .filter((col) => col.name !== obsIndex)
+      .map((col) => col.name);
 
     /* initial value for iterator to simulate index, ranges is an object */
     let zebra = 0;
 
     return (
       <div>
-        {allContinuousNames.map(key => {
+        {allContinuousNames.map((key) => {
           if (!obsAnnotations.hasCol(key)) {
             // still loading!
             zebra += 1;
@@ -98,7 +86,6 @@ class Continuous extends React.PureComponent {
                 isObs
                 zebra={zebra % 2 === 0}
                 ranges={summary}
-                handleColorAction={this.handleColorAction(key)}
               />
             );
           }

--- a/client/src/reducers/continuousSelection.js
+++ b/client/src/reducers/continuousSelection.js
@@ -15,7 +15,7 @@ const ContinuousSelection = (state = {}, action) => {
       );
       return {
         ...state,
-        [name]: action.range
+        [name]: action.range,
       };
     }
     case "continuous metadata histogram cancel": {

--- a/client/src/reducers/crossfilter.js
+++ b/client/src/reducers/crossfilter.js
@@ -4,14 +4,14 @@ import Crossfilter from "../util/typedCrossfilter";
 import {
   World,
   ControlsHelpers,
-  AnnotationsHelpers
+  AnnotationsHelpers,
 } from "../util/stateManager";
 import {
   layoutDimensionName,
   obsAnnoDimensionName,
   userDefinedDimensionName,
   diffexpDimensionName,
-  makeContinuousDimensionName
+  makeContinuousDimensionName,
 } from "../util/nameCreators";
 
 const XYDimName = layoutDimensionName("XY");
@@ -124,7 +124,7 @@ const CrossfilterReducerBase = (
     case "request differential expression success": {
       const { world } = prevSharedState;
       const varIndexName = world.schema.annotations.var.index;
-      const genes = _.map(action.data, d =>
+      const genes = _.map(action.data, (d) =>
         world.varAnnotations.at(d[0], varIndexName)
       );
       const crossfilter = _.reduce(
@@ -216,7 +216,7 @@ const CrossfilterReducerBase = (
         minX,
         minY,
         maxX,
-        maxY
+        maxY,
       });
     }
 
@@ -224,7 +224,7 @@ const CrossfilterReducerBase = (
       const { polygon } = action;
       return state.select(XYDimName, {
         mode: "within-polygon",
-        polygon
+        polygon,
       });
     }
 
@@ -249,7 +249,12 @@ const CrossfilterReducerBase = (
         return state.select(name, { mode: "all" });
       }
       const [lo, hi] = action.range;
-      const newState = state.select(name, { mode: "range", lo, hi });
+      const newState = state.select(name, {
+        mode: "range",
+        lo,
+        hi,
+        inclusive: true, // [lo, hi] incluisve selection
+      });
       return newState;
     }
 
@@ -261,19 +266,19 @@ const CrossfilterReducerBase = (
       const values = categoryValues.filter((v, i) => categoryValueSelected[i]);
       return state.select(obsAnnoDimensionName(action.metadataField), {
         mode: "exact",
-        values
+        values,
       });
     }
 
     case "categorical metadata filter none of these": {
       return state.select(obsAnnoDimensionName(action.metadataField), {
-        mode: "none"
+        mode: "none",
       });
     }
 
     case "categorical metadata filter all of these": {
       return state.select(obsAnnoDimensionName(action.metadataField), {
-        mode: "all"
+        mode: "all",
       });
     }
 


### PR DESCRIPTION
This PR fixes two issues:
* rendering performance of continuous histograms was very slow due to poor state management in the component.  This caused excessive re-rendering of every histogram when _any_ histogram state changed.
* there was a edge case where the highest value in a continuous range was not selectable

Fixes #1326
Fixes #1389 
