### PR TITLE
temporarily disable eslint in github workflow

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Lint with flake8
         run: |
           make lint-server
-      - name: Lint all with eslint
-        working-directory: ./client
-        if: github.event_name	!= 'pull_request'
-        run: |
-          make lint
-      - name: Lint diff with eslint
-        working-directory: ./client
-        if: github.event_name	== 'pull_request'
-        run: |
-          make lint-diff
+      # - name: Lint all with eslint
+      #   working-directory: ./client
+      #   if: github.event_name	!= 'pull_request'
+      #   run: |
+      #     make lint
+      # - name: Lint diff with eslint
+      #   working-directory: ./client
+      #   if: github.event_name	== 'pull_request'
+      #   run: |
+      #     make lint-diff
 
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Commented out the eslint steps until we burn down our lint debt.