### PR TITLE
Add Deployment hook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy via single cell infra repo
 
 on:
   push:
-    branches: [master, dunitz-deploy-hook]
+    branches: master
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,13 @@
+name: Deploy via single cell infra repo
+
+on:
+  push:
+    branches: [master, dunitz-deploy-hook]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository dispatch
+        run: |
+          curl -XPOST -u mdunitz:${{secrets.SCINFRA_TOKEN}} -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/chanzuckerberg/single-cell-infra/dispatches --data '{"event_type": "cellxgene-hook"}'

--- a/app.json
+++ b/app.json
@@ -10,7 +10,11 @@
     "transcriptomics",
     "dataviz"
   ],
-  "stack": "container",
+  "buildpacks": [
+    "heroku/nodejs",
+    "heroku/python"
+  ],
+  "stack": "heroku-18",
   "env": {
     "DATASET": {
       "description": "Link to dataset",


### PR DESCRIPTION
## Need
- To automate deployment of cellxgene through the single cell infra repo master is updated
- Completes part of issue 1251 https://github.com/chanzuckerberg/cellxgene/issues/1251

## Approach
- On push to master post to the single cell repo dispatch endpoint, and run the deployment from there