### PR TITLE
Cache crossfilter when embedding type is changed

### DIFF
--- a/client/src/reducers/resetCache.js
+++ b/client/src/reducers/resetCache.js
@@ -14,7 +14,8 @@ const ResetCacheReducer = (
   nextSharedState
 ) => {
   switch (action.type) {
-    case "initial data load complete (universe exists)": {
+    case "initial data load complete (universe exists)":
+    case "set layout choice": {
       const { crossfilter } = nextSharedState;
       return {
         ...state,


### PR DESCRIPTION
Fixes https://github.com/chanzuckerberg/cellxgene/issues/1433

When selection is deselected the world is reset to the universe the crossfilter is reset to that in the resetCache, including the embeddings in the layout_XY dim.  However, the embedding selection stays the same.

If the embedding selected is not the default when a reset is performed, the embedding shown to the user will be different than the embedding layout_XY in the crossfilter, causing lasso selections to be made against the wrong embedding coordinates.