### PR TITLE
Add server plugin system

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,6 @@
+from server.common.utils import import_plugins
+
 __version__ = "0.15.0"
+
+
+import_plugins("server.plugins")

--- a/server/eb/Makefile
+++ b/server/eb/Makefile
@@ -41,6 +41,9 @@ build: clean
 	      cp -r customize/ebextensions/* artifact.dir/.ebextensions;  \
 	  fi; \
 	fi; \
+	if [ -d plugins ] ; then \
+	  cp -r plugins artifact.dir/server/;  \
+	fi; \
 	(cd artifact.dir; \
 	  cp -r server/common/web/static static; \
 	  zip -r ../artifact.zip . --exclude server/test/\* server/eb/\* ; ); \

--- a/server/eb/Makefile
+++ b/server/eb/Makefile
@@ -41,8 +41,8 @@ build: clean
 	      cp -r customize/ebextensions/* artifact.dir/.ebextensions;  \
 	  fi; \
 	fi; \
-	if [ -d plugins ] ; then \
-	  cp -r plugins artifact.dir/server/;  \
+	if [ -d customize/plugins ] ; then \
+	  cp -r customize/plugins artifact.dir/server/;  \
 	fi; \
 	(cd artifact.dir; \
 	  cp -r server/common/web/static static; \

--- a/server/eb/README.md
+++ b/server/eb/README.md
@@ -44,14 +44,14 @@ There are many more options to these commands that may be important or necessary
    Currently cellxgene supports a flat file organization.   Each matrix file is located from
    the same s3 prefix or filesystem directory.  This location is specified in the configuration as the dataroot.
    
-2. Create an elastic beanstalk application.  For example:
+1. Create an elastic beanstalk application.  For example:
 
     ```
     EB_APP=cellxgene-app
     eb init -p python-3.6 $EB_APP
     ```
 
-3. Configuring cellxgene
+1. Configuring cellxgene
 
    All the cellxgene configuration options can be set from a configuration file.
    This file can be generated like this:
@@ -170,8 +170,8 @@ incompatibilities and raise an error.
    The application requires as secret key to be provided to flask, the web framework used by cellxgene.
    There are three ways to provide the secret key:
    
-   - In the configuration file:  update the server/flask_secret_key attribute.
-   - An environment variable:  CXG_SECRET_KEY
+   - In the configuration file: update the server/flask_secret_key attribute.
+   - An environment variable: `CXG_SECRET_KEY`
    - Managed by the AWS Secret Manager
    
    If using the AWS Secret Manager, then the secret name is passed as an environment variable:  CXG_AWS_SECRET_NAME.
@@ -180,7 +180,6 @@ incompatibilities and raise an error.
    The most straightforward way is to specified it with the CXG_AWS_SECRET_REGION_NAME environment variable.
    If this environment variable is not defined, then the app attempts to determine the region from the 
    dataroot (if in s3), or the config file location (if in s3).
-   
    
 7. Create an environment
 
@@ -205,7 +204,6 @@ incompatibilities and raise an error.
 
     If using S3, this link may provide some useful information:
     https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-s3-bucket-instance/
-    
     If using Lustre, then this link may provide a place to start:
     https://aws.amazon.com/fsx/lustre/
     

--- a/server/eb/README.md
+++ b/server/eb/README.md
@@ -1,15 +1,15 @@
-# AWS Elastic Beanstalk 
+# AWS Elastic Beanstalk
 
 This directory contains script to aid in creating and deploying cellxgene on
 an AWS Elastic Beanstalk instance.
 
-This will result in a variant of cellxgene, running on AWS EC2 instances, serving data from S3. 
-All datasets must be in the new CXG (tiledb) format - see the converter script cxgtool.py 
-in server/converters - and located in a single S3 prefix, which is accessible to the instance. 
-In the current incarnation, no access control or authentication support is available 
+This will result in a variant of cellxgene, running on AWS EC2 instances, serving data from S3.
+All datasets must be in the new CXG (tiledb) format - see the converter script cxgtool.py
+in server/converters - and located in a single S3 prefix, which is accessible to the instance.
+In the current incarnation, no access control or authentication support is available
 (outside of anything you configure yourself), so this is most appropriate for public datasets.
 
-This is early development work, and will change significantly in the near future. 
+This is early development work, and will change significantly in the near future.
 We would love feedback on it, but please assume it will change.
 
 ## Prerequisites
@@ -17,204 +17,213 @@ We would love feedback on it, but please assume it will change.
 1. Some familiarity with AWS EB, S3, and IAM are needed.
 
 2. Install the awsebcli.
-Instruction are here:  
+Instruction are here:
 https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html
 
-3. In the top level directory, run ```make build-client``` to create the client static assets. 
+3. In the top level directory, run ```make build-client``` to create the client static assets.
 
 ## Steps
 
-These steps are meant to serve as an example.  
+These steps are meant to serve as an example.
 There are many more options to these commands that may be important or necessary for your environment.
 
-1. Make your matrix files available to the EB servers.
+### 1. Make your matrix files available to the EB servers.
 
-   The following choices are known to work.
-   
-   * S3 Bucket. 
-   * POSIX filesystem (such as Lustre)
-   * Lustre filesystem backed by S3
-   
-   S3 is convenient and the relatively inexpensive option.  
-   Lustre is higher performance, but more expensive, and slightly more complex to setup and manage.
-   AWS supports a feature to back the Lustre filesystem with S3, which give an easy to manage and high
-   performance option.
-    
-   Once the storage is in place, the next step is to copy your matrix files to that location.
-   Currently cellxgene supports a flat file organization.   Each matrix file is located from
-   the same s3 prefix or filesystem directory.  This location is specified in the configuration as the dataroot.
-   
-1. Create an elastic beanstalk application.  For example:
+The following choices are known to work.
 
-    ```
-    EB_APP=cellxgene-app
-    eb init -p python-3.6 $EB_APP
-    ```
+* S3 Bucket.
+* POSIX filesystem (such as Lustre)
+* Lustre filesystem backed by S3
 
-1. Configuring cellxgene
+S3 is convenient and the relatively inexpensive option.
+Lustre is higher performance, but more expensive, and slightly more complex to setup and manage.
+AWS supports a feature to back the Lustre filesystem with S3, which give an easy to manage and high
+performance option.
 
-   All the cellxgene configuration options can be set from a configuration file.
-   This file can be generated like this:
-   
-   ```cellxgene launch --dump-default-config > myconfig.yaml```
-   
-   The config file may then be customized before the app is deployed.
-   
-   There are two ways to set the config file location, evaluated in this order:
-   
-   First, if your config file is named "config.yaml" and exists in `customize/config.yaml`, 
-   then it will be bundled with the application zip file and installed along 
-   side the app on the EB servers. 
-   
-   Second, a potentially more flexible approach is to place your config file in a location accessible to the EB 
-   servers, such as in S3.  For example:  s3://my-bucket/my-datasets/config.yaml.
-   Set the CXG_CONFIG_FILE environment variable to specify this location.  
-   
-   Another option is to set the CXG_DATAROOT environment variable.  The dataroot 
-   is the location where the matrix files are located. 
-   This environment variable will override the dataroot in the config file (if specified).
-   
-   - Note:  Certain features, such as user annotations, are automatically disabled by the EB app,
-   and cannot be enabled using configuration.  They may be enabled manually by modifying app.py, however
-   this is not supported or recommended at this time.
-   
-4. Customization
+Once the storage is in place, the next step is to copy your matrix files to that location.
+Currently cellxgene supports a flat file organization.   Each matrix file is located from
+the same s3 prefix or filesystem directory.  This location is specified in the configuration as the dataroot.
+
+### 2. Create an elastic beanstalk application.  For example:
+
+```
+EB_APP=cellxgene-app
+eb init -p python-3.6 $EB_APP
+```
+
+### 3. Configuring cellxgene
+
+All the cellxgene configuration options can be set from a configuration file.
+This file can be generated like this:
+
+```cellxgene launch --dump-default-config > myconfig.yaml```
+
+The config file may then be customized before the app is deployed.
+
+There are two ways to set the config file location, evaluated in this order:
+
+First, if your config file is named "config.yaml" and exists in `customize/config.yaml`,
+then it will be bundled with the application zip file and installed along
+side the app on the EB servers.
+
+Second, a potentially more flexible approach is to place your config file in a location accessible to the EB
+servers, such as in S3.  For example:  s3://my-bucket/my-datasets/config.yaml.
+Set the CXG_CONFIG_FILE environment variable to specify this location.
+
+Another option is to set the CXG_DATAROOT environment variable.  The dataroot
+is the location where the matrix files are located.
+This environment variable will override the dataroot in the config file (if specified).
+
+- Note:  Certain features, such as user annotations, are automatically disabled by the EB app,
+and cannot be enabled using configuration.  They may be enabled manually by modifying app.py, however
+this is not supported or recommended at this time.
+
+### 4. Customization
 
 The deployment can be customized in several ways, by adding files to a directory called
 `customize` which is placed in this directory.
- 
-config file: 
 
-This was described in the previous section.  
+#### config file
 
-static files: 
+This was described in the previous section.
+
+#### static files
 
 The cellxgene server can serve additional static webpages that will be associated with the app.
-These include the about_legal_tos (terms of service), and about_legal_privacy, for example.  
+These include the about_legal_tos (terms of service), and about_legal_privacy, for example.
 To use this feature, do the following:
 
-   * In this directory, create a sub directory called "customize/deploy/".  
-   * Copy the files you want to serve into this directory
-   * modify your configuration file to set the location to these file:  /static/deploy/<filename>
+* In this directory, create a sub directory called "customize/deploy/".
+* Copy the files you want to serve into this directory
+* modify your configuration file to set the location to these file:  /static/deploy/<filename>
 
-   Example:  you want to include an "about_legal_tos" and "about_legal_privacy" page to cellxgene.
-   Assume files called "tos.html" and "privacy.html" exist.
+Example:  you want to include an "about_legal_tos" and "about_legal_privacy" page to cellxgene.
+Assume files called "tos.html" and "privacy.html" exist.
 
-   ```
-   $ mkdir static
-   $ cp <source_dir>/tos.html customize/deploy/tos.html
-   $ cp <source_dir>/privacy.html customize/deploy/privacy.html
+```
+$ mkdir static
+$ cp <source_dir>/tos.html customize/deploy/tos.html
+$ cp <source_dir>/privacy.html customize/deploy/privacy.html
 
-   # edit config.yaml
-   $ grep "/static/deploy" config.yaml
-   about_legal_tos: /static/deploy/tos.html
-   about_legal_privacy: /static/deploy/privacy.html
-   ```
+# edit config.yaml
+$ grep "/static/deploy" config.yaml
+about_legal_tos: /static/deploy/tos.html
+about_legal_privacy: /static/deploy/privacy.html
+```
 
-Inline javascript scripts:
+#### Inline javascript scripts
 
 Additional scripts can be added using the server/inline_scripts config parameters.
 To include these scripts in the deployment, use the following steps:
 
-   * In this directory, create a sub directory called "customize/inline_scripts".  
-   * Copy the script files into this directory
-   * modify your configuration file to set the location to these file (leaving off customize/inline_scripts)
+* In this directory, create a sub directory called "customize/inline_scripts".
+* Copy the script files into this directory
+* modify your configuration file to set the location to these file (leaving off customize/inline_scripts)
 
-   For example, to add an inline script called "myscript.js":
-   
-   ```
-   $ mkdir scripts
-   $ cp <source_dir>/myscript.js customize/inline_scripts/myscript.js
-   # edit the config.yaml
-   $ grep inline_scripts config.yaml
-     inline_scripts : [ myscript.js ]
-   ```
+For example, to add an inline script called "myscript.js":
 
-ebextensions:
+```
+$ mkdir scripts
+$ cp <source_dir>/myscript.js customize/inline_scripts/myscript.js
+# edit the config.yaml
+$ grep inline_scripts config.yaml
+  inline_scripts : [ myscript.js ]
+```
+
+#### Plugins
+
+Optionally, you can add plugins to the server python code. To include a plugin in the deployment use the following steps:
+
+```
+$ mkdir plugins
+$ cp <source_dir>/<my_plugin>.py customize/plugins/<my_plugin>.py
+```
+
+#### ebextensions
 
 Any additional config files intended for the `.ebextensions` directory of the artifact can be added
 to the `customize/ebextensions` directory.  Any file found here will be copied over.
 
-requirements.txt:
+#### requirements.txt
 
-A custom requirements.txt can be supplied in customize/requirements.txt.   
+A custom requirements.txt can be supplied in customize/requirements.txt.
 This file must fully specify the versions of all the python modules used by the server in the deployment.
 This is useful to ensure that the dependencies do not change from one deployment to the next.
 Therefore the custom/requirements.txt must all have exact versions specified (e.g. anndata==0.7.1).
 
 This file can be generated the first time using a process like this:
 ```
-   #  assume you are running in this directory
-   $  virtualenv temp
-   $  source temp/bin/activate
-   $  pip install -r ../requirements.txt 
-   $  mkdir -p customize
-   $  pip freeze > customize/requirements.txt
-   $  deactivate
-   $  rm -rf temp/
+#  assume you are running in this directory
+$  virtualenv temp
+$  source temp/bin/activate
+$  pip install -r ../requirements.txt
+$  mkdir -p customize
+$  pip freeze > customize/requirements.txt
+$  deactivate
+$  rm -rf temp/
 ```
- 
-Keep the customize/requirememts.txt file, and reuse it for each deployment. 
-If a future cellxgene version updates its requirements by modifying a module version 
-or adding a new dependency, then the `make build` process will detect any 
-incompatibilities and raise an error. 
 
-5. Create the artifact.zip file for the application
+Keep the customize/requirememts.txt file, and reuse it for each deployment.
+If a future cellxgene version updates its requirements by modifying a module version
+or adding a new dependency, then the `make build` process will detect any
+incompatibilities and raise an error.
 
-   ```
-   $ make build
-   ```
-    
-6. Flask secret key
+### 5. Create the artifact.zip file for the application
 
-   The application requires as secret key to be provided to flask, the web framework used by cellxgene.
-   There are three ways to provide the secret key:
-   
-   - In the configuration file: update the server/flask_secret_key attribute.
-   - An environment variable: `CXG_SECRET_KEY`
-   - Managed by the AWS Secret Manager
-   
-   If using the AWS Secret Manager, then the secret name is passed as an environment variable:  CXG_AWS_SECRET_NAME.
-   The secret must contain a key with the name "flask_secret_key".
-   The region name for the AWS Secret Manager must be specified (e.g. us-east-1).
-   The most straightforward way is to specified it with the CXG_AWS_SECRET_REGION_NAME environment variable.
-   If this environment variable is not defined, then the app attempts to determine the region from the 
-   dataroot (if in s3), or the config file location (if in s3).
-   
-7. Create an environment
+```
+$ make build
+```
 
-    ```
-    # name of the environment
-    $ EB_ENV=cellxgene-env
-   
-    # type of ec2 instance to run the cellxgene server (for example)
-    $ EB_INSTANCE=m5.large 
-   
-    # One or both of the following environment variables needs to be set
-    $ CXG_DATAROOT=<location to your S3 bucket>
-    $ CXG_CONFIG_FILE=<location to your config file>
-  
-    # Potentially also set envvars for the sercret key.
-   
-    $ eb create $EB_ENV --instance-type $EB_INSTANCE \
-       --envvars CXG_DATAROOT=$CXG_DATAROOT,CXG_CONFIG_FILE=$CXG_CONFIG_FILE
-    ```
+### 6. Flask secret key
 
-8. Give the elastic beanstalk environment access to the dataroot. 
+The application requires as secret key to be provided to flask, the web framework used by cellxgene.
+There are three ways to provide the secret key:
 
-    If using S3, this link may provide some useful information:
-    https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-s3-bucket-instance/
-    If using Lustre, then this link may provide a place to start:
-    https://aws.amazon.com/fsx/lustre/
-    
-9. Deploy the application
+- In the configuration file: update the server/flask_secret_key attribute.
+- An environment variable: `CXG_SECRET_KEY`
+- Managed by the AWS Secret Manager
 
-    ```
-    $ eb deploy $EB_ENV 
-    ```
-   
-10. Open the application in a browser
+If using the AWS Secret Manager, then the secret name is passed as an environment variable:  CXG_AWS_SECRET_NAME.
+The secret must contain a key with the name "flask_secret_key".
+The region name for the AWS Secret Manager must be specified (e.g. us-east-1).
+The most straightforward way is to specified it with the CXG_AWS_SECRET_REGION_NAME environment variable.
+If this environment variable is not defined, then the app attempts to determine the region from the
+dataroot (if in s3), or the config file location (if in s3).
 
-   ```
-   $ eb open $EB_ENV
-   ```
+### 7. Create an environment
+
+```
+# name of the environment
+$ EB_ENV=cellxgene-env
+
+# type of ec2 instance to run the cellxgene server (for example)
+$ EB_INSTANCE=m5.large
+
+# One or both of the following environment variables needs to be set
+$ CXG_DATAROOT=<location to your S3 bucket>
+$ CXG_CONFIG_FILE=<location to your config file>
+
+# Potentially also set envvars for the sercret key.
+
+$ eb create $EB_ENV --instance-type $EB_INSTANCE \
+   --envvars CXG_DATAROOT=$CXG_DATAROOT,CXG_CONFIG_FILE=$CXG_CONFIG_FILE
+```
+
+### 8. Give the elastic beanstalk environment access to the dataroot.
+
+If using S3, this link may provide some useful information:
+https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-s3-bucket-instance/
+If using Lustre, then this link may provide a place to start:
+https://aws.amazon.com/fsx/lustre/
+
+### 9. Deploy the application
+
+```
+$ eb deploy $EB_ENV
+```
+
+### 10. Open the application in a browser
+
+```
+$ eb open $EB_ENV
+```

--- a/server/test/__init__.py
+++ b/server/test/__init__.py
@@ -1,4 +1,6 @@
+import random
 import shutil
+import string
 import tempfile
 from os import path, popen
 
@@ -74,3 +76,7 @@ def app_config(data_locator, backed=False):
     config.update(**args)
     config.complete_config()
     return config
+
+
+def random_string(n):
+    return "".join(random.choice(string.ascii_letters) for _ in range(n))

--- a/server/test/test_cxg_adaptor.py
+++ b/server/test/test_cxg_adaptor.py
@@ -7,7 +7,6 @@ from server.test.test_datasets.fixtures import pbmc3k_colors
 
 
 class TestCxgAdaptor(unittest.TestCase):
-
     def test_get_colors(self):
         data = self.get_data("pbmc3k.cxg")
         self.assertDictEqual(data.get_colors(), pbmc3k_colors)

--- a/server/test/test_cxgtool.py
+++ b/server/test/test_cxgtool.py
@@ -1,6 +1,4 @@
-import random
 import shutil
-import string
 import unittest
 
 import anndata
@@ -8,7 +6,7 @@ import anndata
 from server.common.data_locator import DataLocator
 from server.converters.cxgtool import write_cxg
 from server.data_cxg.cxg_adaptor import CxgAdaptor
-from server.test import PROJECT_ROOT, app_config
+from server.test import PROJECT_ROOT, app_config, random_string
 from server.test.test_datasets.fixtures import pbmc3k_colors
 
 
@@ -31,8 +29,8 @@ class TestCxgAdaptor(unittest.TestCase):
         self.assertEqual(data.get_colors(), {})
 
     def convert_pbmc3k(self, **kwargs):
-        random_string = "".join(random.choice(string.ascii_letters) for _ in range(8))
-        data_locator = f"/tmp/test_{random_string}.cxg"
+        rand_str = random_string(8)
+        data_locator = f"/tmp/test_{rand_str}.cxg"
         self.fixtures.append(data_locator)
         source_h5ad = anndata.read_h5ad(f"{PROJECT_ROOT}/example-dataset/pbmc3k.h5ad")
         write_cxg(adata=source_h5ad, container=data_locator, title="pbmc3k", **kwargs)

--- a/server/test/test_plugins.py
+++ b/server/test/test_plugins.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+import unittest
+
+from server.common.utils import import_plugins
+from server.test import PROJECT_ROOT, random_string
+
+
+class TestPlugins(unittest.TestCase):
+    """ Test plugin import functionality """
+
+    plugins_dir = f"{PROJECT_ROOT}/server/test/plugins"
+    test_plugin_path = f"{plugins_dir}/foo.py"
+    secret = random_string(8)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not os.path.isdir(cls.plugins_dir):
+            os.mkdir(cls.plugins_dir)
+        with open(cls.test_plugin_path, "w") as fh:
+            fh.write(f'SECRET = "{cls.secret}"\n')
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if os.path.isdir(cls.plugins_dir):
+            shutil.rmtree(cls.plugins_dir)
+        cls.modules_executed = []
+
+    def test_import_plugins(self):
+        self.assertTrue(os.path.isfile(self.test_plugin_path))
+        loaded_modules = import_plugins("server.test.plugins")
+        # test that import plugins found the file
+        self.assertEqual(["server.test.plugins.foo"], [ele.__name__ for ele in loaded_modules])
+        # test that the module was properly executed
+        self.assertEqual(self.secret, loaded_modules[0].SECRET)

--- a/server/test/test_plugins.py
+++ b/server/test/test_plugins.py
@@ -24,7 +24,6 @@ class TestPlugins(unittest.TestCase):
     def tearDownClass(cls) -> None:
         if os.path.isdir(cls.plugins_dir):
             shutil.rmtree(cls.plugins_dir)
-        cls.modules_executed = []
 
     def test_import_plugins(self):
         self.assertTrue(os.path.isfile(self.test_plugin_path))


### PR DESCRIPTION
Plugins are optional modules loaded at runtime. Specification:
* Plugins are loaded from the server.plugins module (directory
  `server/plugins`)
* The import_plugins method is run as part of the initialization of the
  server module in `__init__.py`
* Plugins are copied into the ElasticBeanstalk artifact from the `server/eb` build configuration.