### PR TITLE
Create new label button overflow

### DIFF
--- a/client/src/components/categorical/category/annoDialogAddLabel.js
+++ b/client/src/components/categorical/category/annoDialogAddLabel.js
@@ -92,7 +92,7 @@ class Category extends React.PureComponent {
           instruction={this.instruction(newLabelText)}
           cancelTooltipContent="Close this dialog without adding a label."
           primaryButtonText="Add label"
-          secondaryButtonText={`Add label and assign ${crossfilter.countSelected()} currently selected cells`}
+          secondaryButtonText={`Add label, assign ${crossfilter.countSelected()} selected cells`}
           handleSecondaryButtonSubmit={this.addLabelAndAssignCells}
           text={newLabelText}
           validationError={this.labelNameError(newLabelText)}

--- a/client/src/components/categorical/category/annoDialogAddLabel.js
+++ b/client/src/components/categorical/category/annoDialogAddLabel.js
@@ -92,7 +92,7 @@ class Category extends React.PureComponent {
           instruction={this.instruction(newLabelText)}
           cancelTooltipContent="Close this dialog without adding a label."
           primaryButtonText="Add label"
-          secondaryButtonText={`Add label, assign ${crossfilter.countSelected()} selected cells`}
+          secondaryButtonText={`Add label & assign ${crossfilter.countSelected()} selected cells`}
           handleSecondaryButtonSubmit={this.addLabelAndAssignCells}
           text={newLabelText}
           validationError={this.labelNameError(newLabelText)}


### PR DESCRIPTION
Fixes #1131

By removing `and`, and `currently`, we get the characters we need without losing meaning. If we don't like the comma, removing `currently` is enough.

![image](https://user-images.githubusercontent.com/1770265/81108414-a7f9a700-8ee6-11ea-94e2-757ac6124114.png)