### PR TITLE
Provide ToS button identifiers for smoke test to use

### DIFF
--- a/client/src/components/termsPrompt/index.js
+++ b/client/src/components/termsPrompt/index.js
@@ -145,10 +145,19 @@ class TermsPrompt extends React.PureComponent {
             </div>
           </div>
           <div className={Classes.DIALOG_FOOTER} style={{ textAlign: "left" }}>
-            <Button intent="primary" onClick={this.handleOK}>
+            <Button
+              intent="primary"
+              onClick={this.handleOK}
+              data-testid="tos-cookies-accept"
+            >
               I'm OK with cookies!
             </Button>{" "}
-            <Button onClick={this.handleNo}>No thanks</Button>
+            <Button
+              onClick={this.handleNo}
+              data-testid="tos-cookies-reject"
+            >
+              No thanks
+            </Button>
           </div>
         </div>
       </Drawer>


### PR DESCRIPTION
Currently, smoke tests fail when run against a deployment of cellxgene with the ToS message displayed. This PR inserts `data-testid`s in the ToS "Accept" and "Reject" buttons so that:

1. the smoke test can detect and act on them
2. we can change the smoke tests to accept the ToS before running the standard test suite