### PR TITLE
app_config, fix bug with list/tuple command line arguments.

### DIFF
--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -167,6 +167,9 @@ class AppConfig(object):
             if not hasattr(self, key):
                 raise ConfigurationError(f"unknown config parameter {key}.")
             try:
+                if type(value) == tuple:
+                    # convert tuple values to list values
+                    value = list(value)
                 setattr(self, key, value)
             except KeyError:
                 raise ConfigurationError(f"Unable to set config parameter {key}.")

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -241,8 +241,8 @@ class AppConfig(object):
         self.__check_attr("server__debug", bool)
         self.__check_attr("server__host", str)
         self.__check_attr("server__port", (type(None), int))
-        self.__check_attr("server__scripts", (list, tuple))
-        self.__check_attr("server__inline_scripts", (list, tuple))
+        self.__check_attr("server__scripts", list)
+        self.__check_attr("server__inline_scripts", list)
         self.__check_attr("server__open_browser", bool)
         self.__check_attr("server__force_https", bool)
         self.__check_attr("server__flask_secret_key", (type(None), str))
@@ -357,7 +357,7 @@ class AppConfig(object):
     def handle_multi_dataset(self, context):
         self.__check_attr("multi_dataset__dataroot", (type(None), str))
         self.__check_attr("multi_dataset__index", (type(None), bool, str))
-        self.__check_attr("multi_dataset__allowed_matrix_types", (tuple, list))
+        self.__check_attr("multi_dataset__allowed_matrix_types", list)
         self.__check_attr("multi_dataset__matrix_cache__max_datasets", int)
         self.__check_attr("multi_dataset__matrix_cache__timelimit_s", (type(None), int, float))
 
@@ -442,7 +442,7 @@ class AppConfig(object):
                 )
 
     def handle_embeddings(self, context):
-        self.__check_attr("embeddings__names", (list, tuple))
+        self.__check_attr("embeddings__names", list)
         self.__check_attr("embeddings__enable_reembedding", bool)
 
         if self.single_dataset__datapath:

--- a/server/test/test_app_config.py
+++ b/server/test/test_app_config.py
@@ -23,9 +23,6 @@ class AppConfigTest(unittest.TestCase):
         self.assertCountEqual(v, [])
 
         c = AppConfig()
-        c.update(server__scripts=("a","b"), server__inline_scripts=["c","d"])
+        c.update(server__scripts=("a", "b"), server__inline_scripts=["c", "d"])
         v = c.changes_from_default()
-        self.assertCountEqual(v, [("server__scripts", ["a","b"], []), ("server__inline_scripts", ["c","d"], [])])
-
-
-
+        self.assertCountEqual(v, [("server__scripts", ["a", "b"], []), ("server__inline_scripts", ["c", "d"], [])])

--- a/server/test/test_app_config.py
+++ b/server/test/test_app_config.py
@@ -9,6 +9,23 @@ class AppConfigTest(unittest.TestCase):
     def test_update(self):
         c = AppConfig()
         c.update(server__verbose=True, multi_dataset__dataroot="datadir")
-
         v = c.changes_from_default()
-        self.assertCountEqual(v, [("server__verbose", True, False), ("multi_dataset__dataroot", "datadir", None)]),
+        self.assertCountEqual(v, [("server__verbose", True, False), ("multi_dataset__dataroot", "datadir", None)])
+
+        c = AppConfig()
+        c.update(server__scripts=(), server__inline_scripts=())
+        v = c.changes_from_default()
+        self.assertCountEqual(v, [])
+
+        c = AppConfig()
+        c.update(server__scripts=[], server__inline_scripts=[])
+        v = c.changes_from_default()
+        self.assertCountEqual(v, [])
+
+        c = AppConfig()
+        c.update(server__scripts=("a","b"), server__inline_scripts=["c","d"])
+        v = c.changes_from_default()
+        self.assertCountEqual(v, [("server__scripts", ["a","b"], []), ("server__inline_scripts", ["c","d"], [])])
+
+
+


### PR DESCRIPTION
There was a error caused by pyyaml using lists, and click using tuples.
Now tuples are automatically converted to lists when the config is
updated.