### PR TITLE
Fix smoke tests to work with remote deployments of cellxgene

### DIFF
--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -29,6 +29,17 @@ describe("did launch", () => {
     );
     expect(element).toBe(data.title);
   });
+
+  test("terms of service, if they are there", async () => {
+    try {
+      await utils.clickOn("tos-cookies-accept", { timeout: 500 });
+    } catch {
+      console.warn("No terms of service footer detected.")
+    }
+    page.waitFor(50);  // give the footer a chance to disappear
+    const result = await page.$("[data-testid='tos-cookies-accept']");
+    expect(result).toBeNull();
+  });
 });
 
 describe("metadata loads", () => {

--- a/client/__tests__/e2e/puppeteerUtils.js
+++ b/client/__tests__/e2e/puppeteerUtils.js
@@ -44,8 +44,8 @@ export const puppeteerUtils = (page) => ({
   },
 
   async clickOn(testid, options = {}) {
-    await this.waitByID(testid);
-    const click = await page.click(`[data-testid='${testid}']`, options);
+    await this.waitByID(testid, options);
+    const click = await page.click(`[data-testid='${testid}']`);
     await page.waitFor(50);
     return click;
   },

--- a/client/__tests__/e2e/testBrowser.js
+++ b/client/__tests__/e2e/testBrowser.js
@@ -36,6 +36,10 @@ export async function setupTestBrowser() {
     page.on("console", async (msg) => {
       // If there is a console.error but an error is not thrown, this will ensure the test fails
       if (msg.type() === "error") {
+        // TODO: chromium does not currently support the CSP directive on the
+        // line below, so we swallow this error. Remove this when the test
+        // suite uses a browser version that supports this directive.
+        if (msg.text() === "Unrecognized Content-Security-Policy directive 'require-trusted-types-for'.\n") return;
         const errorMsgText = await Promise.all(
           // TODO can we do this without internal properties?
           msg.args().map((arg) => arg._remoteObject.description)


### PR DESCRIPTION
## Needs

* The smoke test needs to accept any terms of service (ToS) shown in the browser before running the test suite.
* The version of Chromium browser used by puppeteer does not seem to support all CSP directives: `Unrecognized Content-Security-Policy directive 'require-trusted-types-for'.`

## Approach

* Add a test at the beginning of the suite that accepts the ToS.
* Ignore the `require-trusted-types-for` directive console error, for now.