### PR TITLE
Upgrade python requirements to click>=7.1.2

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 anndata>=0.6.20
 boto3>=1.12.18
-click>=6.7
+click>=7.1.2
 fastobo>=0.6.1
 Flask>=1.0.2
 Flask-Compress>=1.4.0


### PR DESCRIPTION
6.7 does not have the `hidden` flag used in the code. Users building the app with an older version of click within the current range specified by requirements.txt will fail.