### PR TITLE
Break out anno plus button

### DIFF
--- a/client/src/components/categorical/category/annoMenuCategory.js
+++ b/client/src/components/categorical/category/annoMenuCategory.js
@@ -6,8 +6,12 @@ import {
   MenuItem,
   Popover,
   Position,
+  Tooltip,
+  Icon,
   PopoverInteractionKind,
 } from "@blueprintjs/core";
+
+import * as globals from "../../../globals";
 
 @connect((state) => ({
   annotations: state.annotations,
@@ -56,46 +60,64 @@ class AnnoMenuCategory extends React.PureComponent {
     return (
       <>
         {isUserAnno ? (
-          <Popover
-            interactionKind={PopoverInteractionKind.HOVER}
-            boundary="window"
-            position={Position.RIGHT_TOP}
-            content={
-              <Menu>
-                <MenuItem
-                  icon="tag"
-                  data-testclass="handleAddNewLabelToCategory"
-                  data-testid={`${metadataField}:add-new-label-to-category`}
-                  onClick={this.activateAddNewLabelMode}
-                  text={createText}
-                />
-                <MenuItem
-                  icon="edit"
-                  disabled={annotations.isEditingCategoryName}
-                  data-testclass="activateEditCategoryMode"
-                  data-testid={`${metadataField}:edit-category-mode`}
-                  onClick={this.activateEditCategoryMode}
-                  text={editText}
-                />
-                <MenuItem
-                  icon="delete"
-                  intent="danger"
-                  data-testclass="handleDeleteCategory"
-                  data-testid={`${metadataField}:delete-category`}
-                  onClick={this.handleDeleteCategory}
-                  text={deleteText}
-                />
-              </Menu>
-            }
-          >
-            <Button
-              style={{ marginLeft: 0 }}
-              data-testclass="seeActions"
-              data-testid={`${metadataField}:see-actions`}
-              icon="more"
-              minimal
-            />
-          </Popover>
+          <>
+            <Tooltip
+              content={createText}
+              position="bottom"
+              hoverOpenDelay={globals.tooltipHoverOpenDelay}
+            >
+              <Button
+                style={{ marginLeft: 0 }}
+                data-testclass="handleAddNewLabelToCategory"
+                data-testid={`${metadataField}:add-new-label-to-category`}
+                icon={<Icon icon="plus" iconSize={10} />}
+                onClick={this.activateAddNewLabelMode}
+                small
+                minimal
+              />
+            </Tooltip>
+            <Popover
+              interactionKind={PopoverInteractionKind.HOVER}
+              boundary="window"
+              position={Position.RIGHT_TOP}
+              content={
+                <Menu>
+                  {/* <MenuItem
+                    icon="tag"
+                    data-testclass="handleAddNewLabelToCategory"
+                    data-testid={`${metadataField}:add-new-label-to-category`}
+                    onClick={this.activateAddNewLabelMode}
+                    text={createText}
+                  /> */}
+                  <MenuItem
+                    icon="edit"
+                    disabled={annotations.isEditingCategoryName}
+                    data-testclass="activateEditCategoryMode"
+                    data-testid={`${metadataField}:edit-category-mode`}
+                    onClick={this.activateEditCategoryMode}
+                    text={editText}
+                  />
+                  <MenuItem
+                    icon="delete"
+                    intent="danger"
+                    data-testclass="handleDeleteCategory"
+                    data-testid={`${metadataField}:delete-category`}
+                    onClick={this.handleDeleteCategory}
+                    text={deleteText}
+                  />
+                </Menu>
+              }
+            >
+              <Button
+                style={{ marginLeft: 0 }}
+                data-testclass="seeActions"
+                data-testid={`${metadataField}:see-actions`}
+                icon={<Icon icon="more" iconSize={10} />}
+                small
+                minimal
+              />
+            </Popover>
+          </>
         ) : null}
       </>
     );

--- a/client/src/components/categorical/category/annoMenuCategory.js
+++ b/client/src/components/categorical/category/annoMenuCategory.js
@@ -82,13 +82,6 @@ class AnnoMenuCategory extends React.PureComponent {
               position={Position.RIGHT_TOP}
               content={
                 <Menu>
-                  {/* <MenuItem
-                    icon="tag"
-                    data-testclass="handleAddNewLabelToCategory"
-                    data-testid={`${metadataField}:add-new-label-to-category`}
-                    onClick={this.activateAddNewLabelMode}
-                    text={createText}
-                  /> */}
                   <MenuItem
                     icon="edit"
                     disabled={annotations.isEditingCategoryName}

--- a/client/src/components/categorical/category/annoMenuCategory.js
+++ b/client/src/components/categorical/category/annoMenuCategory.js
@@ -67,7 +67,7 @@ class AnnoMenuCategory extends React.PureComponent {
               hoverOpenDelay={globals.tooltipHoverOpenDelay}
             >
               <Button
-                style={{ marginLeft: 0 }}
+                style={{ marginLeft: 0, marginRight: 2 }}
                 data-testclass="handleAddNewLabelToCategory"
                 data-testid={`${metadataField}:add-new-label-to-category`}
                 icon={<Icon icon="plus" iconSize={10} />}
@@ -102,7 +102,7 @@ class AnnoMenuCategory extends React.PureComponent {
               }
             >
               <Button
-                style={{ marginLeft: 0 }}
+                style={{ marginLeft: 0, marginRight: 2 }}
                 data-testclass="seeActions"
                 data-testid={`${metadataField}:see-actions`}
                 icon={<Icon icon="more" iconSize={10} />}

--- a/client/src/components/categorical/category/annoMenuCategory.js
+++ b/client/src/components/categorical/category/annoMenuCategory.js
@@ -102,7 +102,7 @@ class AnnoMenuCategory extends React.PureComponent {
               }
             >
               <Button
-                style={{ marginLeft: 0, marginRight: 2 }}
+                style={{ marginLeft: 0, marginRight: 5 }}
                 data-testclass="seeActions"
                 data-testid={`${metadataField}:see-actions`}
                 icon={<Icon icon="more" iconSize={10} />}

--- a/client/src/components/categorical/category/index.js
+++ b/client/src/components/categorical/category/index.js
@@ -265,9 +265,6 @@ class Category extends React.Component {
                 }
               }}
             >
-              {isUserAnno ? (
-                <Icon style={{ marginRight: 5 }} icon="tag" iconSize={16} />
-              ) : null}
               {truncatedString || metadataField}
               {isExpanded ? (
                 <FaChevronDown

--- a/client/src/components/categorical/value/index.js
+++ b/client/src/components/categorical/value/index.js
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Popover,
   Position,
+  Icon,
   PopoverInteractionKind,
   Tooltip,
 } from "@blueprintjs/core";
@@ -339,7 +340,7 @@ class CategoryValue extends React.Component {
         }
         data-testclass="categorical-row"
         style={{
-          padding: "4px 7px",
+          padding: "4px 0px 4px 7px",
           display: "flex",
           alignItems: "baseline",
           justifyContent: "space-between",
@@ -552,14 +553,14 @@ class CategoryValue extends React.Component {
                 >
                   <Button
                     style={{
-                      marginLeft: 0,
+                      marginLeft: 2,
                       position: "relative",
                       top: -1,
                       minHeight: 16,
                     }}
                     data-testclass="seeActions"
                     data-testid={`${metadataField}:${displayString}:see-actions`}
-                    icon="more"
+                    icon={<Icon icon="more" iconSize={10} />}
                     small
                     minimal
                   />


### PR DESCRIPTION
Anno plus button broken out to reduce 4 actions (hover, wait, hover, click) to 1 action to speed create new label interaction. Sets up similar pattern for gene sets.

## No hover

![image](https://user-images.githubusercontent.com/1770265/81760318-e79b3280-9494-11ea-8560-d87856f52e73.png)

## Hover on menu

![image](https://user-images.githubusercontent.com/1770265/81760283-d2260880-9494-11ea-8b1c-cbadf6a708d5.png)

## Hover on plus

![image](https://user-images.githubusercontent.com/1770265/81760303-d9e5ad00-9494-11ea-9d27-c6e1e98c3e1c.png)
