### PR TITLE
re-enable front-end lint test

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Lint with flake8
         run: |
           make lint-server
-      # - name: Lint all with eslint
-      #   working-directory: ./client
-      #   if: github.event_name	!= 'pull_request'
-      #   run: |
-      #     make lint
+      - name: Lint src with eslint
+        working-directory: ./client
+        if: github.event_name	!= 'pull_request'
+        run: |
+          make lint
       # - name: Lint diff with eslint
       #   working-directory: ./client
       #   if: github.event_name	== 'pull_request'

--- a/client/Makefile
+++ b/client/Makefile
@@ -25,7 +25,7 @@ build:
 
 .PHONY: lint
 lint:
-	npx eslint .
+	npx eslint ./src/
 
 .PHONY: lint-diff
 lint-diff:


### PR DESCRIPTION
Turns master ESLint testing back on.  Also reconfigures the listing to only run on prod code (not testing lib)