### PR TITLE
Fix centroid label + continuous color-by interactions

### DIFF
--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -334,7 +334,8 @@ describe("centroid labels", () => {
     // Toggle colorby for each category and check to see if labels are generated
     for (let i = 0, { length } = labels; i < length; i += 1) {
       const label = labels[i];
-      await utils.clickOn(`colorby-${label}`);
+      // first label is already enabled
+      if (i !== 0) await utils.clickOn(`colorby-${label}`);
       const generatedLabels = await utils.getAllByClass("centroid-label");
       // Number of labels generated should be equal to size of the object
       expect(generatedLabels).toHaveLength(

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -326,8 +326,10 @@ describe("ui elements don't error", () => {
 
 describe("centroid labels", () => {
   test("labels are created", async () => {
-    await utils.clickOn("centroid-label-toggle");
     const labels = Object.keys(data.categorical);
+
+    await utils.clickOn(`colorby-${labels[0]}`);
+    await utils.clickOn("centroid-label-toggle");
     /* eslint-disable no-await-in-loop */
     // Toggle colorby for each category and check to see if labels are generated
     for (let i = 0, { length } = labels; i < length; i += 1) {
@@ -346,8 +348,8 @@ describe("centroid labels", () => {
 describe("graph overlay", () => {
   test("transform centroids correctly", async () => {
     const category = Object.keys(data.categorical)[0];
-    await utils.clickOn("centroid-label-toggle");
     await utils.clickOn(`colorby-${category}`);
+    await utils.clickOn("centroid-label-toggle");
     await utils.clickOn("mode-pan-zoom");
     const panCoords = await cxgActions.calcDragCoordinates(
       "layout-graph",

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -37,6 +37,7 @@ import DiffexpButtons from "./diffexpButtons";
   showCentroidLabels: state.centroidLabels.showLabels,
   tosURL: state.config?.parameters?.["about_legal_tos"],
   privacyURL: state.config?.parameters?.["about_legal_privacy"],
+  categoricalSelection: state.categoricalSelection,
 }))
 class MenuBar extends React.Component {
   static isValidDigitKeyEvent(e) {
@@ -203,8 +204,12 @@ class MenuBar extends React.Component {
       showCentroidLabels,
       privacyURL,
       tosURL,
+      categoricalSelection,
+      colorAccessor,
     } = this.props;
     const { pendingClipPercentiles } = this.state;
+
+    const isColoredByCategorical = !!categoricalSelection?.[colorAccessor];
 
     // constants used to create selection tool button
     const [selectionTooltip, selectionButtonIcon] =
@@ -267,6 +272,7 @@ class MenuBar extends React.Component {
             onClick={this.handleCentroidChange}
             active={showCentroidLabels}
             intent={showCentroidLabels ? "primary" : "none"}
+            disabled={!isColoredByCategorical}
           />
         </Tooltip>
         <ButtonGroup className={styles.menubarButton}>

--- a/client/src/reducers/centroidLabels.js
+++ b/client/src/reducers/centroidLabels.js
@@ -63,6 +63,7 @@ const centroidLabels = (state = initialState, action, sharedNextState) => {
       };
 
     case "color by continuous metadata":
+    case "color by expression":
       return { ...state, labels: [] };
 
     case "reset centroid labels":


### PR DESCRIPTION
This PR fixes a few edge cases regarding the centroid button in conjunction with continuous metadata and expression data.  

The label button will now disable when no categorical metadata is colored by while still maintaining the toggled state. This will remove the ability to toggle centroids on while continuous data is colored-by.  

This PR also catches a case where centroids were still present if `colorBy` switches from a categorical to a continuous piece of metadata.


![Kapture 2020-05-19 at 16 52 37](https://user-images.githubusercontent.com/8716829/82389559-5d515200-99f1-11ea-9c4e-68de26da5f61.gif)


---
Closes #1397
Fixes #1476

