### PR TITLE
Change style of centroid labels of unselected values 

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: master
   pull_request:
-    branches: *
 
 env:
   JEST_ENV: prod
@@ -38,9 +37,14 @@ jobs:
           make lint-server
       - name: Lint src with eslint
         working-directory: ./client
+        if: github.event_name	!= 'pull_request'
         run: |
           make lint
-
+      # - name: Lint diff with eslint
+      #   working-directory: ./client
+      #   if: github.event_name	== 'pull_request'
+      #   run: |
+      #     make lint-diff
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: master
   pull_request:
+    branches: *
 
 env:
   JEST_ENV: prod
@@ -37,14 +38,9 @@ jobs:
           make lint-server
       - name: Lint src with eslint
         working-directory: ./client
-        if: github.event_name	!= 'pull_request'
         run: |
           make lint
-      # - name: Lint diff with eslint
-      #   working-directory: ./client
-      #   if: github.event_name	== 'pull_request'
-      #   run: |
-      #     make lint-diff
+
 
   unit-test:
     runs-on: ubuntu-latest

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -8,6 +8,7 @@ export default
   colorAccessor: state.colors.colorAccessor,
   dilatedValue: state.pointDilation.categoryField,
   labels: state.centroidLabels.labels,
+  categoricalSelection: state.categoricalSelection,
 }))
 class CentroidLabels extends PureComponent {
   // Check to see if centroids have either just been displayed or removed from the overlay
@@ -33,11 +34,20 @@ class CentroidLabels extends PureComponent {
       dilatedValue,
       dispatch,
       colorAccessor,
+      categoricalSelection,
     } = this.props;
+
+    if (!colorAccessor) return null;
+
+    const {
+      categoryValueIndices,
+      categoryValueSelected,
+    } = categoricalSelection?.[colorAccessor];
 
     const labelSVGS = [];
     let fontSize = "15px";
     let fontWeight = null;
+    const deselectOpacity = 0.5;
     labels.forEach((coords, label) => {
       fontSize = "15px";
       fontWeight = null;
@@ -45,6 +55,8 @@ class CentroidLabels extends PureComponent {
         fontSize = "18px";
         fontWeight = "800";
       }
+
+      const selected = categoryValueSelected[categoryValueIndices.get(label)];
 
       // Mirror LSB middle truncation
       let displayLabel = label;
@@ -77,6 +89,7 @@ class CentroidLabels extends PureComponent {
               fontWeight,
               fill: "black",
               userSelect: "none",
+              opacity: selected ? 1 : deselectOpacity,
             }}
             onMouseEnter={(e) =>
               dispatch({

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -47,7 +47,7 @@ class CentroidLabels extends PureComponent {
     const labelSVGS = [];
     let fontSize = "15px";
     let fontWeight = null;
-    const deselectOpacity = 0.5;
+    const deselectOpacity = 0.375;
     labels.forEach((coords, label) => {
       fontSize = "15px";
       fontWeight = null;

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -37,7 +37,8 @@ class CentroidLabels extends PureComponent {
       categoricalSelection,
     } = this.props;
 
-    if (!colorAccessor) return null;
+    if (!colorAccessor || labels.size === undefined || labels.size === 0)
+      return null;
 
     const {
       categoryValueIndices,

--- a/client/src/components/graph/overlays/graphOverlayLayer.js
+++ b/client/src/components/graph/overlays/graphOverlayLayer.js
@@ -81,7 +81,7 @@ export default class GraphOverlayLayer extends PureComponent {
           position: "absolute",
           top: 0,
           left: 0,
-          zIndex: 1,
+          zIndex: 2,
           backgroundColor: displaying ? "rgba(255, 255, 255, 0.55)" : "",
         }}
         onMouseMove={handleCanvasEvent}


### PR DESCRIPTION
This PR will add a separate styling for category values that are unselected, dropping opacity based on selection status.

This PR also includes a fix, adding back label hover/dilation functionality

![Kapture 2020-05-20 at 14 34 19](https://user-images.githubusercontent.com/8716829/82500911-33f3fd00-9aa9-11ea-9be0-2c2f731c80b8.gif)


---
Fixes #1444 