### PR TITLE
Remove the trusted types requirement

### DIFF
--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -67,7 +67,6 @@ class WSGIServer(Server):
             "object-src": ["'none'"],
             "base-uri": ["'none'"],
             "frame-ancestors": ["'none'"],
-            "require-trusted-types-for": ["'script'"],
         }
 
         if not app.debug:


### PR DESCRIPTION
There seem to be breaking changes in Chrome that are causing our EB deployments to fail in the client. We've weighed the risk of disabling the feature with the issues we've encountered using it and decided to disable it for now.