### PR TITLE
[EASY] Add .gitignore file added by elastic beanstalk

### DIFF
--- a/server/eb/.gitignore
+++ b/server/eb/.gitignore
@@ -1,0 +1,5 @@
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml


### PR DESCRIPTION
## Need

This `.gitignore` file is added by elastic beanstalk during our deployment process, leaving the git tree dirty afterwards.

## Approach

To keep the git tree clean during the process, simply add the file to the repository.