### PR TITLE
refactor categorical controls state

### DIFF
--- a/client/__tests__/util/centroid.test.js
+++ b/client/__tests__/util/centroid.test.js
@@ -35,19 +35,15 @@ describe("centroid", () => {
 
     // Create categorical selection from world
     categoricalSelection = CH.createCategoricalSelection(
-      world,
-      CH.selectableCategoryNames(world.schema, CH.maxCategoryItems(REST.config))
+      CH.selectableCategoryNames(world.schema)
     );
   });
 
   test("field4 (categorical obsAnnotation)", () => {
     const centroidResult = calcCentroid(
-      world.obsAnnotations,
-      world.obsLayout,
+      world,
       "field4",
-      ["umap_0", "umap_1"],
-      categoricalSelection,
-      world.schema.annotations.obsByName
+      ["umap_0", "umap_1"]
     );
 
     // Check to see that a centroid has been calculated for every categorical value
@@ -69,12 +65,9 @@ describe("centroid", () => {
 
   test("field3 (boolean obsAnnotation)", () => {
     const centroidResult = calcCentroid(
-      world.obsAnnotations,
-      world.obsLayout,
+      world,
       "field3",
-      ["umap_0", "umap_1"],
-      categoricalSelection,
-      world.schema.annotations.obsByName
+      ["umap_0", "umap_1"]
     );
 
     // Check to see that a centroid has been calculated for every categorical value

--- a/client/src/components/categorical/annoDialog.js
+++ b/client/src/components/categorical/annoDialog.js
@@ -2,12 +2,6 @@ import React from "react";
 import { connect } from "react-redux";
 import { Button, Tooltip, Dialog, Classes, Colors } from "@blueprintjs/core";
 
-@connect((state) => ({
-  colorAccessor: state.colors.colorAccessor,
-  categoricalSelection: state.categoricalSelection,
-  annotations: state.annotations,
-  universe: state.universe,
-}))
 class AnnoDialog extends React.PureComponent {
   constructor(props) {
     super(props);

--- a/client/src/components/categorical/annoSelect.js
+++ b/client/src/components/categorical/annoSelect.js
@@ -3,12 +3,6 @@ import { connect } from "react-redux";
 import { Button, MenuItem } from "@blueprintjs/core";
 import { Select } from "@blueprintjs/select";
 
-@connect((state) => ({
-  colorAccessor: state.colors.colorAccessor,
-  categoricalSelection: state.categoricalSelection,
-  annotations: state.annotations,
-  universe: state.universe,
-}))
 class DuplicateCategorySelect extends React.PureComponent {
   constructor(props) {
     super(props);

--- a/client/src/components/categorical/category/annoDialogAddLabel.js
+++ b/client/src/components/categorical/category/annoDialogAddLabel.js
@@ -5,8 +5,6 @@ import LabelInput from "../labelInput";
 import { labelPrompt, isLabelErroneous } from "../labelUtil";
 
 @connect((state) => ({
-  colorAccessor: state.colors.colorAccessor,
-  categoricalSelection: state.categoricalSelection,
   annotations: state.annotations,
   universe: state.universe,
   ontology: state.ontology,

--- a/client/src/components/categorical/category/annoDialogEditCategoryName.js
+++ b/client/src/components/categorical/category/annoDialogEditCategoryName.js
@@ -8,9 +8,9 @@ import { labelPrompt } from "../labelUtil";
 import { AnnotationsHelpers } from "../../../util/stateManager";
 
 @connect((state) => ({
-  categoricalSelection: state.categoricalSelection,
   annotations: state.annotations,
   universe: state.universe,
+  schema: state.world?.schema,
   ontology: state.ontology,
 }))
 class AnnoDialogEditCategoryName extends React.PureComponent {
@@ -36,10 +36,15 @@ class AnnoDialogEditCategoryName extends React.PureComponent {
   };
 
   handleEditCategory = (e) => {
-    const { dispatch, metadataField, categoricalSelection } = this.props;
+    const { dispatch, metadataField } = this.props;
     const { newCategoryText } = this.state;
 
-    const allCategoryNames = _.keys(categoricalSelection);
+    /*
+    test for uniqueness against *all* annotation names, not just the subset
+    we render as categorical.
+    */
+    const { schema } = this.props;
+    const allCategoryNames = schema.annotations.obs.columns.map((c) => c.name);
 
     if (
       (allCategoryNames.indexOf(newCategoryText) > -1 &&
@@ -60,7 +65,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent {
   };
 
   editedCategoryNameError = (name) => {
-    const { metadataField, categoricalSelection } = this.props;
+    const { metadataField } = this.props;
 
     /* check for syntax errors in category name */
     const error = AnnotationsHelpers.annotationNameIsErroneous(name);
@@ -69,7 +74,14 @@ class AnnoDialogEditCategoryName extends React.PureComponent {
     }
 
     /* check for duplicative categories */
-    const allCategoryNames = _.keys(categoricalSelection);
+
+    /*
+    test for uniqueness against *all* annotation names, not just the subset
+    we render as categorical.
+    */
+    const { schema } = this.props;
+    const allCategoryNames = schema.annotations.obs.columns.map((c) => c.name);
+
     const categoryNameAlreadyExists = allCategoryNames.indexOf(name) > -1;
     const sameName = name === metadataField;
     if (categoryNameAlreadyExists && !sameName) {

--- a/client/src/components/categorical/category/categoryFlipperLayout.js
+++ b/client/src/components/categorical/category/categoryFlipperLayout.js
@@ -6,9 +6,6 @@ import { Flipper, Flipped } from "react-flip-toolkit";
 import * as globals from "../../../globals";
 import Value from "../value";
 
-@connect((state) => ({
-  categoricalSelection: state.categoricalSelection,
-}))
 class Category extends React.Component {
   constructor(props) {
     super(props);
@@ -16,7 +13,7 @@ class Category extends React.Component {
   }
 
   renderCategoryItems(optTuples) {
-    const { metadataField, isUserAnno } = this.props;
+    const { metadataField, isUserAnno, categorySummary } = this.props;
 
     return _.map(optTuples, (tuple, i) => {
       return (
@@ -30,6 +27,7 @@ class Category extends React.Component {
               categoryIndex={tuple[1]}
               i={i}
               flippedProps={flippedProps}
+              categorySummary={categorySummary}
             />
           )}
         </Flipped>
@@ -38,15 +36,9 @@ class Category extends React.Component {
   }
 
   render() {
-    const {
-      metadataField,
-      categoricalSelection,
-      children,
-      isExpanded,
-    } = this.props;
-    const { isTruncated } = categoricalSelection[metadataField];
-    const cat = categoricalSelection[metadataField];
-    const optTuples = [...cat.categoryValueIndices];
+    const { metadataField, categorySummary, children, isExpanded } = this.props;
+    const { isTruncated } = categorySummary;
+    const optTuples = [...categorySummary.categoryValueIndices];
     const optTuplesAsKey = _.map(optTuples, (t) => t[0]).join(""); // animation
 
     return (

--- a/client/src/components/categorical/index.js
+++ b/client/src/components/categorical/index.js
@@ -130,8 +130,7 @@ class Categories extends React.Component {
     const ontologyEnabled = ontology?.enabled ?? false;
     /* all names, sorted in display order.  Will be rendered in this order */
     const allCategoryNames = ControlsHelpers.selectableCategoryNames(
-      schema,
-      ControlsHelpers.maxCategoryItems(config)
+      schema
     ).sort();
 
     return (

--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -40,10 +40,7 @@ class CentroidLabels extends PureComponent {
     if (!colorAccessor || labels.size === undefined || labels.size === 0)
       return null;
 
-    const {
-      categoryValueIndices,
-      categoryValueSelected,
-    } = categoricalSelection?.[colorAccessor];
+    const category = categoricalSelection[colorAccessor];
 
     const labelSVGS = [];
     let fontSize = "15px";
@@ -57,7 +54,7 @@ class CentroidLabels extends PureComponent {
         fontWeight = "800";
       }
 
-      const selected = categoryValueSelected[categoryValueIndices.get(label)];
+      const selected = category.get(label) ?? true;
 
       // Mirror LSB middle truncation
       let displayLabel = label;

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -15,7 +15,6 @@ export const configDefaults = {
   features: {},
   displayNames: {},
   parameters: {
-    "max-category-items": 1000,
     "disable-diffexp": false,
     "diffexp-may-be-slow": false,
   },

--- a/client/src/reducers/centroidLabels.js
+++ b/client/src/reducers/centroidLabels.js
@@ -26,14 +26,7 @@ const centroidLabels = (state = initialState, action, sharedNextState) => {
         ...state,
         labels:
           !!colorAccessor && showLabels && !!categoricalSelection[colorAccessor]
-            ? calcCentroid(
-                world.obsAnnotations,
-                world.obsLayout,
-                colorAccessor,
-                layoutChoice.currentDimNames,
-                categoricalSelection,
-                world.schema.annotations.obsByName
-              )
+            ? calcCentroid(world, colorAccessor, layoutChoice.currentDimNames)
             : [],
       };
 
@@ -52,12 +45,9 @@ const centroidLabels = (state = initialState, action, sharedNextState) => {
       return {
         ...state,
         labels: calcCentroid(
-          world.obsAnnotations,
-          world.obsLayout,
+          world,
           colorAccessor,
-          layoutChoice.currentDimNames,
-          categoricalSelection,
-          world.schema.annotations.obsByName
+          layoutChoice.currentDimNames
         ),
         showLabels,
       };

--- a/client/src/reducers/crossfilter.js
+++ b/client/src/reducers/crossfilter.js
@@ -260,10 +260,9 @@ const CrossfilterReducerBase = (
 
     case "categorical metadata filter select":
     case "categorical metadata filter deselect": {
-      const { categoricalSelection } = nextSharedState;
-      const cat = categoricalSelection[action.metadataField];
-      const { categoryValues, categoryValueSelected } = cat;
-      const values = categoryValues.filter((v, i) => categoryValueSelected[i]);
+      const { labels, metadataField } = action;
+      const selected = nextSharedState.categoricalSelection[metadataField];
+      const values = labels.filter((label) => selected.get(label) ?? true);
       return state.select(obsAnnoDimensionName(action.metadataField), {
         mode: "exact",
         values,

--- a/client/src/reducers/pointDilation.js
+++ b/client/src/reducers/pointDilation.js
@@ -5,10 +5,7 @@ const initialState = {
 
 const pointDialation = (state = initialState, action, sharedNextState) => {
   const { categoricalSelection } = sharedNextState;
-  const { metadataField, categoryIndex } = action;
-  const categoryField =
-    action.categoryField ||
-    categoricalSelection?.[metadataField]?.categoryValues[categoryIndex];
+  const { metadataField, categoryIndex, label: categoryField } = action;
 
   switch (action.type) {
     case "category value mouse hover start":


### PR DESCRIPTION
This PR refactors the reducer store `categoricalSelection` state, which had become a mashup of:
* categorical selection state
* summary information about the categorical annotations

The `categoricalSelection` reducer is now solely selection state, and the data summary is computed on demand by the <Category> component.   

This refactoring is a step toward the upcoming annotated matrix refactor.