### PR TITLE
Add default environment override back to common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7,8 +7,13 @@ ifeq ($(shell which jq),)
 $(error Please install jq using "apt-get install jq" or "brew install jq")
 endif
 
-define GetValueFromJson
-$(shell jq -r '.$(1)' "$(PROJECT_ROOT)/environment.default.json")
+define env_or_else_default
+$(if $($(1)),$($(1)),$(shell jq -r '.$(1)' "$(PROJECT_ROOT)/environment.default.json"))
+endef
+
+# if not a full path, create a full path relative to the project root
+define full_path
+$(shell [[ $(1) = /* ]] && echo $(1) || echo $(PROJECT_ROOT)/$(1))
 endef
 
 # https://stackoverflow.com/a/14777895/9587410
@@ -17,11 +22,11 @@ ifeq ($(shell uname),Darwin)     # is Windows_NT on XP, 2000, 7, Vista, 10...
 endif
 
 export CELLXGENE_COMMIT := $(shell git rev-parse --short HEAD)
-export CXG_SERVER_PORT := $(call GetValueFromJson,CXG_SERVER_PORT)
-export CXG_CLIENT_PORT := $(call GetValueFromJson,CXG_CLIENT_PORT)
-export JEST_ENV := $(call GetValueFromJson,JEST_ENV)
-export DATASET := $(call GetValueFromJson,DATASET)
-export CXG_OPTIONS := $(call GetValueFromJson,CXG_OPTIONS)
+export CXG_SERVER_PORT := $(call env_or_else_default,CXG_SERVER_PORT)
+export CXG_CLIENT_PORT := $(call env_or_else_default,CXG_CLIENT_PORT)
+export CXG_OPTIONS := $(call env_or_else_default,CXG_OPTIONS)
+export DATASET := $(call full_path,$(call env_or_else_default,DATASET))
+export JEST_ENV := $(call env_or_else_default,JEST_ENV)
 
 .PHONY: start-server
 start-server:

--- a/environment.default.json
+++ b/environment.default.json
@@ -2,7 +2,7 @@
   "CXG_CLIENT_PORT": 3000,
   "CXG_OPTIONS": "--debug",
   "CXG_SERVER_PORT": 5005,
-  "DATASET": "$(git rev-parse --show-toplevel)/example-dataset/pbmc3k.h5ad",
+  "DATASET": "example-dataset/pbmc3k.h5ad",
   "DEBUG": "debug",
   "DEV": "dev",
   "JEST_ENV": "prod",


### PR DESCRIPTION
* As part of https://github.com/chanzuckerberg/cellxgene/pull/1548 we accidentally removed the part of the "get_or_else_dev_env_default" function that allowed users to override the environment variables. This commit adds that back.
* When environment.default was changed from a shell script file to json, the shell commands used to parameterize DATASET were not evaluated. This commit fixes this issue as well.