### PR TITLE
disable-puppeteer-dumpio

### DIFF
--- a/client/jest-puppeteer.config.js
+++ b/client/jest-puppeteer.config.js
@@ -13,7 +13,6 @@ const isHeadful =
 const DEFAULT_LAUNCH_CONFIG = {
   headless: !isHeadful,
   args: ["--ignore-certificate-errors", "--ignore-ssl-errors"],
-  dumpio: true,
   ignoreHTTPSErrors: true,
   defaultViewport: {
     width: 1280,


### PR DESCRIPTION
Disable `Puppeteer`'s `dumpio`, so we don't have as much noise in the terminal. Such as 

```
[0625/135335.909526:ERROR:vertex_attrib_manager.cc(293)] [.WebGL-0x1d376b305e00]GL ERROR :GL_INVALID_OPERATION : glDrawArrays: attempt to access out of range vertices in attribute 0

2020-06-25 13:43:51.307 Chromium Helper (Renderer)[11156:8257719] CoreText note: Client requested name “.AppleSymbolsFB”, it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].

2020-06-25 13:43:51.307 Chromium Helper (Renderer)[11156:8257719] CoreText note: Set a breakpoint on CTFontLogSystemFontNameRequest to debug.
```