### PR TITLE
FIX-test-target-closed: remove jestPuppeteer.resetBrowser()

### DIFF
--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -149,7 +149,7 @@ describe("cell selection", () => {
 describe("gene entry", () => {
   test("search for single gene", async () => {
     await goToPage(appUrlBase);
-    addGeneToSearch(data.genes.search);
+    await addGeneToSearch(data.genes.search);
   });
 
   test("bulk add genes", async () => {

--- a/client/__tests__/e2e/puppeteer.setup.js
+++ b/client/__tests__/e2e/puppeteer.setup.js
@@ -17,25 +17,21 @@ setDefaultOptions({ timeout: 20 * 1000 });
 
 jest.retryTimes(ENV_DEFAULT.RETRY_ATTEMPTS);
 
-beforeEach(async () => {
-  await jestPuppeteer.resetBrowser();
-
+(async () => {
   const userAgent = await browser.userAgent();
   await page.setUserAgent(`${userAgent}bot`);
 
   await page._client.send("Animation.setPlaybackRate", { playbackRate: 12 });
 
+  page.on("pageerror", (err) => {
+    throw new Error(`Console error: ${err}`);
+  });
+
+  page.on("error", (err) => {
+    throw new Error(`Console error: ${err}`);
+  });
+
   page.on("console", async (msg) => {
-    page.on("pageerror", (err) => {
-      console.log(`PAGE LOG: ${msg.text()}`);
-      throw new Error(`Console error: ${err}`);
-    });
-
-    page.on("error", (err) => {
-      console.log(`PAGE LOG: ${msg.text()}`);
-      throw new Error(`Console error: ${err}`);
-    });
-
     if (isDev || isDebug) {
       // If there is a console.error but an error is not thrown, this will ensure the test fails
       console.log(`PAGE LOG: ${msg.text()}`);
@@ -57,4 +53,4 @@ beforeEach(async () => {
       }
     }
   });
-});
+})();


### PR DESCRIPTION
This PR fixes some unknown `target closed` errors, likely due to `jestPuppeteer.resetBrowser()` is run before the previous test is done.

`jestPuppeteer.resetBrowser()` was introduced to make sure each test has its own isolated state, so no browser state such as cookies are shared. This was helpful at Meta because we have AuthN, so some tests need to run in logged in mode and some logged out. But setting `browserContext: "incognito"` seems to be enough for cellxgene right now, since at least it will start a new tab for each test, and we don't have AuthN cookies yet.

We can take a look at using `jestPuppeteer.resetBrowser()` in a reliable way once cellxgene has AuthN. But for now I think it's less noise to not reset browser 😄 

Thank you!