### PR TITLE
protect against non-integer array indexing

### DIFF
--- a/client/__tests__/util/dataframe/dataframe.test.js
+++ b/client/__tests__/util/dataframe/dataframe.test.js
@@ -1130,7 +1130,6 @@ describe("corner cases", () => {
     expect(df.ihas(true, true)).toBeFalsy();
     expect(df.ihas([], [])).toBeFalsy();
     expect(df.ihas({}, {})).toBeFalsy();
-
   });
 
   test("Dataframe rejects bogus labels", () => {
@@ -1212,6 +1211,5 @@ describe("corner cases", () => {
     expect(df.has(0, undefined)).toBeFalsy();
     expect(df.has(0, [])).toBeFalsy();
     expect(df.has(0, {})).toBeFalsy();
-
   });
 });

--- a/client/__tests__/util/dataframe/dataframe.test.js
+++ b/client/__tests__/util/dataframe/dataframe.test.js
@@ -1029,3 +1029,189 @@ describe("label indexing", () => {
     expect(idx.dropLabel("blue").labels()).toEqual(["red", "green"]);
   });
 });
+
+describe("corner cases", () => {
+  /* error/corner cases */
+
+  test("identity integer index rejects non-integer labels", () => {
+    const idx = new Dataframe.IdentityInt32Index(10);
+    expect(idx.getOffset(0)).toBe(0);
+    expect(idx.getOffset(9)).toBe(9);
+    expect(idx.getOffset(10)).toBeUndefined();
+    expect(idx.getOffset(-1)).toBeUndefined();
+    expect(idx.getOffset("sort")).toBeUndefined();
+    expect(idx.getOffset("length")).toBeUndefined();
+    expect(idx.getOffset(true)).toBeUndefined();
+    expect(idx.getOffset(0.001)).toBeUndefined();
+    expect(idx.getOffset({})).toBeUndefined();
+    expect(idx.getOffset([])).toBeUndefined();
+    expect(idx.getOffset(new Float32Array())).toBeUndefined();
+    expect(idx.getOffset("__proto__")).toBeUndefined();
+
+    expect(idx.getLabel(0)).toBe(0);
+    expect(idx.getLabel(9)).toBe(9);
+    expect(idx.getLabel(10)).toBeUndefined();
+    expect(idx.getLabel(-1)).toBeUndefined();
+    expect(idx.getLabel("sort")).toBeUndefined();
+    expect(idx.getLabel("length")).toBeUndefined();
+    expect(idx.getLabel(true)).toBeUndefined();
+    expect(idx.getLabel(0.001)).toBeUndefined();
+    expect(idx.getLabel({})).toBeUndefined();
+    expect(idx.getLabel([])).toBeUndefined();
+    expect(idx.getLabel(new Float32Array())).toBeUndefined();
+    expect(idx.getLabel("__proto__")).toBeUndefined();
+  });
+
+  test("dense integer index rejects non-integer labels", () => {
+    const idx = new Dataframe.DenseInt32Index([-10, 0, 3, 9, 10]);
+    expect(idx.getOffset(0)).toBe(1);
+    expect(idx.getOffset(9)).toBe(3);
+    expect(idx.getOffset(1)).toBeUndefined();
+    expect(idx.getOffset(11)).toBeUndefined();
+    expect(idx.getOffset(-1)).toBeUndefined();
+    expect(idx.getOffset("sort")).toBeUndefined();
+    expect(idx.getOffset("length")).toBeUndefined();
+    expect(idx.getOffset(true)).toBeUndefined();
+    expect(idx.getOffset(0.001)).toBeUndefined();
+    expect(idx.getOffset({})).toBeUndefined();
+    expect(idx.getOffset([])).toBeUndefined();
+    expect(idx.getOffset(new Float32Array())).toBeUndefined();
+    expect(idx.getOffset("__proto__")).toBeUndefined();
+
+    expect(idx.getLabel(0)).toBe(-10);
+    expect(idx.getLabel(4)).toBe(10);
+    expect(idx.getLabel(10)).toBeUndefined();
+    expect(idx.getLabel(-1)).toBeUndefined();
+    expect(idx.getLabel("sort")).toBeUndefined();
+    expect(idx.getLabel("length")).toBeUndefined();
+    expect(idx.getLabel(true)).toBeUndefined();
+    expect(idx.getLabel(0.001)).toBeUndefined();
+    expect(idx.getLabel({})).toBeUndefined();
+    expect(idx.getLabel([])).toBeUndefined();
+    expect(idx.getLabel(new Float32Array())).toBeUndefined();
+    expect(idx.getLabel("__proto__")).toBeUndefined();
+  });
+
+  test("Empty dataframe rejects bogus labels", () => {
+    const df = Dataframe.Dataframe.empty();
+
+    expect(df.hasCol("sort")).toBeFalsy();
+    expect(df.hasCol(0)).toBeFalsy();
+    expect(df.hasCol(true)).toBeFalsy();
+    expect(df.hasCol(false)).toBeFalsy();
+    expect(df.hasCol([])).toBeFalsy();
+    expect(df.hasCol({})).toBeFalsy();
+    expect(df.hasCol(null)).toBeFalsy();
+    expect(df.hasCol(undefined)).toBeFalsy();
+
+    expect(df.col("sort")).toBeUndefined();
+    expect(df.col(0)).toBeUndefined();
+    expect(df.col(true)).toBeUndefined();
+    expect(df.col(false)).toBeUndefined();
+    expect(df.col([])).toBeUndefined();
+    expect(df.col({})).toBeUndefined();
+    expect(df.col(null)).toBeUndefined();
+    expect(df.col(undefined)).toBeUndefined();
+
+    expect(df.icol("sort")).toBeUndefined();
+    expect(df.icol(0)).toBeUndefined();
+    expect(df.icol(true)).toBeUndefined();
+    expect(df.icol(false)).toBeUndefined();
+    expect(df.icol([])).toBeUndefined();
+    expect(df.icol({})).toBeUndefined();
+    expect(df.icol(null)).toBeUndefined();
+    expect(df.icol(undefined)).toBeUndefined();
+
+    expect(df.ihas("sort", "length")).toBeFalsy();
+    expect(df.ihas("0", "0")).toBeFalsy();
+    expect(df.ihas("", "")).toBeFalsy();
+    expect(df.ihas(null, null)).toBeFalsy();
+    expect(df.ihas(undefined, undefined)).toBeFalsy();
+    expect(df.ihas(true, true)).toBeFalsy();
+    expect(df.ihas([], [])).toBeFalsy();
+    expect(df.ihas({}, {})).toBeFalsy();
+
+  });
+
+  test("Dataframe rejects bogus labels", () => {
+    const df = new Dataframe.Dataframe(
+      [2, 2],
+      [
+        [true, false],
+        [1, 0],
+      ],
+      null,
+      new Dataframe.KeyIndex(["A", "B"])
+    );
+
+    expect(df.hasCol("sort")).toBeFalsy();
+    expect(df.hasCol("__proto__")).toBeFalsy();
+    expect(df.hasCol(0)).toBeFalsy();
+    expect(df.hasCol(true)).toBeFalsy();
+    expect(df.hasCol(false)).toBeFalsy();
+    expect(df.hasCol([])).toBeFalsy();
+    expect(df.hasCol({})).toBeFalsy();
+    expect(df.hasCol(null)).toBeFalsy();
+    expect(df.hasCol(undefined)).toBeFalsy();
+
+    expect(df.col("sort")).toBeUndefined();
+    expect(df.col("__proto__")).toBeUndefined();
+    expect(df.col(0)).toBeUndefined();
+    expect(df.col(true)).toBeUndefined();
+    expect(df.col(false)).toBeUndefined();
+    expect(df.col([])).toBeUndefined();
+    expect(df.col({})).toBeUndefined();
+    expect(df.col(null)).toBeUndefined();
+    expect(df.col(undefined)).toBeUndefined();
+
+    expect(df.icol("sort")).toBeUndefined();
+    expect(df.icol("__proto__")).toBeUndefined();
+    expect(df.icol(-1)).toBeUndefined();
+    expect(df.icol(true)).toBeUndefined();
+    expect(df.icol(false)).toBeUndefined();
+    expect(df.icol([])).toBeUndefined();
+    expect(df.icol({})).toBeUndefined();
+    expect(df.icol(null)).toBeUndefined();
+    expect(df.icol(undefined)).toBeUndefined();
+
+    expect(df.ihas("sort", "length")).toBeFalsy();
+    expect(df.ihas("__proto__", "__proto__")).toBeFalsy();
+
+    expect(df.ihas(-1, 0)).toBeFalsy();
+    expect(df.ihas("0", 0)).toBeFalsy();
+    expect(df.ihas("", 0)).toBeFalsy();
+    expect(df.ihas(null, 0)).toBeFalsy();
+    expect(df.ihas(undefined, 0)).toBeFalsy();
+    expect(df.ihas([], 0)).toBeFalsy();
+    expect(df.ihas({}, 0)).toBeFalsy();
+
+    expect(df.ihas(0, -1)).toBeFalsy();
+    expect(df.ihas(0, "0")).toBeFalsy();
+    expect(df.ihas(0, "")).toBeFalsy();
+    expect(df.ihas(0, null)).toBeFalsy();
+    expect(df.ihas(0, undefined)).toBeFalsy();
+    expect(df.ihas(0, [])).toBeFalsy();
+    expect(df.ihas(0, {})).toBeFalsy();
+
+    expect(df.has("sort", "length")).toBeFalsy();
+    expect(df.has("length", "sort")).toBeFalsy();
+    expect(df.has("__proto__", "__proto__")).toBeFalsy();
+
+    expect(df.has(-1, "A")).toBeFalsy();
+    expect(df.has("0", "A")).toBeFalsy();
+    expect(df.has("", "A")).toBeFalsy();
+    expect(df.has(null, "A")).toBeFalsy();
+    expect(df.has(undefined, "A")).toBeFalsy();
+    expect(df.has([], "A")).toBeFalsy();
+    expect(df.has({}, "A")).toBeFalsy();
+
+    expect(df.has(0, -1)).toBeFalsy();
+    expect(df.has(0, "0")).toBeFalsy();
+    expect(df.has(0, "")).toBeFalsy();
+    expect(df.has(0, null)).toBeFalsy();
+    expect(df.has(0, undefined)).toBeFalsy();
+    expect(df.has(0, [])).toBeFalsy();
+    expect(df.has(0, {})).toBeFalsy();
+
+  });
+});

--- a/client/src/util/dataframe/dataframe.js
+++ b/client/src/util/dataframe/dataframe.js
@@ -721,7 +721,6 @@ class Dataframe {
     */
     const coff = this.colIndex.getOffset(c);
     const roff = this.rowIndex.getOffset(r);
-    if (coff === undefined || roff === undefined) return undefined;
     return this.__columns[coff][roff];
   }
 

--- a/client/src/util/dataframe/dataframe.js
+++ b/client/src/util/dataframe/dataframe.js
@@ -290,10 +290,8 @@ class Dataframe {
 
     Use an existing accessor if provided, else compile a new one.
     */
-    const {
-      getOffset: getRowByOffset,
-      getLabel: getRowByLabel,
-    } = this.rowIndex;
+    const getRowByOffset = this.rowIndex.getOffset.bind(this.rowIndex);
+    const getRowByLabel = this.rowIndex.getLabel.bind(this.rowIndex);
     this.__columnsAccessor = this.__columns.map((column, idx) => {
       if (accessors[idx]) {
         return accessors[idx];
@@ -704,7 +702,9 @@ class Dataframe {
     /*
     Return column accessor by offset.
     */
-    return this.__columnsAccessor[columnOffset];
+    return Number.isInteger(columnOffset)
+      ? this.__columnsAccessor[columnOffset]
+      : undefined;
   }
 
   at(r, c) {
@@ -721,6 +721,7 @@ class Dataframe {
     */
     const coff = this.colIndex.getOffset(c);
     const roff = this.rowIndex.getOffset(r);
+    if (coff === undefined || roff === undefined) return undefined;
     return this.__columns[coff][roff];
   }
 
@@ -753,7 +754,14 @@ class Dataframe {
     dataframe - returns true/false
     */
     const [nRows, nCols] = this.dims;
-    return c >= 0 && c < nCols && r >= 0 && r < nRows;
+    return (
+      Number.isInteger(r) &&
+      Number.isInteger(c) &&
+      c >= 0 &&
+      c < nCols &&
+      r >= 0 &&
+      r < nRows
+    );
   }
 
   hasCol(c) {


### PR DESCRIPTION
There were several critical modules in Dataframe that assumed that Array bracket access with a non-integer number would return undefined.  This failed when a dataset contained a category named "sort".

TL;DR:  `[]["sort"] === Array.prototype.sort`.

Which leads to all kinds of potential for mischief and mayhem.

Fixes #1594 