### PR TITLE
e2e-add-more-logs

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -72,7 +72,7 @@ jobs:
           cd client && ./node_modules/codecov/bin/codecov --yml=../.codecov.yml --root=../ --gcov-root=../ -C -F frontend,javascript,unitTest
 
   smoke-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/client/__tests__/e2e/puppeteer.setup.js
+++ b/client/__tests__/e2e/puppeteer.setup.js
@@ -53,4 +53,6 @@ jest.retryTimes(ENV_DEFAULT.RETRY_ATTEMPTS);
       }
     }
   });
-})();
+})().catch((error) => {
+  console.error("puppeteer.setup.js error", error);
+});

--- a/client/__tests__/e2e/screenshot_env.js
+++ b/client/__tests__/e2e/screenshot_env.js
@@ -6,19 +6,27 @@ const takeScreenshot = require("./takeScreenshot");
 
 class ScreenshotEnvironment extends PuppeteerEnvironment {
   async handleTestEvent(event, state) {
+    if (["test_start", "test_done"].includes(event.name)) {
+      console.log("------------------event name:\n", event.name);
+      console.log("~~~~ Current test errors\n", new Date(), event.test.errors);
+      console.log("~~~~ Current test\n", new Date(), event.test);
+    }
+
     if (event.name === "error") {
-      console.log("error", JSON.stringify(event));
+      console.log("error event:", JSON.stringify(event));
     }
 
     if (event.name === "test_fn_failure" || event.name === "hook_failure") {
+      console.log("------------------event name:\n", event.name);
+      console.log(">>>> Current state\n", new Date(), state);
+      console.log("===> Failure event\n", new Date(), event);
+
       // (thuang): We only want to take screenshot on the last try
       if (
         state.currentlyRunningTest.invocations <= ENV_DEFAULT.RETRY_ATTEMPTS
       ) {
         return;
       }
-
-      console.log("===> Failure event\n", new Date(), event);
 
       await takeScreenshot(state.currentlyRunningTest.name, this.global.page);
     }


### PR DESCRIPTION
Adding more logs in GH Actions to gather more data

Update: Also it seems like using `macos-latest` doesn't get `Error: Execution context was destroyed, most likely because of a navigation`. So maybe we can try if that resolves the flakiness issue?

Thank you!