### PR TITLE
Do not cache index.html

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -56,8 +56,10 @@ def cache_control_always(**cache_kwargs):
     return _cache_control(True, **cache_kwargs)
 
 
+# tell the client not to cache the index.html page so that changes to the app work on redeployment
+# note that the bulk of the data needed by the client (datasets) will still be cached
 @webbp.route("/", methods=["GET"])
-@cache_control(public=True, max_age=ONE_WEEK)
+@cache_control_always(public=True, max_age=0, no_store=True, no_cache=True, must_revalidate=True)
 def dataset_index(url_dataroot=None, dataset=None):
     config = current_app.app_config
     if dataset is None:

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -47,7 +47,7 @@ def _cache_control(always, **cache_kwargs):
 
 
 def cache_control(**cache_kwargs):
-    """ configu driven """
+    """ config driven """
     return _cache_control(False, **cache_kwargs)
 
 

--- a/server/converters/cxgtool.py
+++ b/server/converters/cxgtool.py
@@ -493,8 +493,7 @@ def evaluate_for_sparse_column_shift_encoding(xdata, sparse_threshold):
         nnz += shape[0] * (lim - col) - np.sum(m.count)
         if nnz > maxnnz:
             return (None, nnz, shape[0] * lim)
-        log(2, "\t...cols", lim, "of", shape[1], "nnz",
-            nnz, "nnz percent %5.2f%%" % (100 * nnz / (lim * shape[0])))
+        log(2, "\t...cols", lim, "of", shape[1], "nnz", nnz, "nnz percent %5.2f%%" % (100 * nnz / (lim * shape[0])))
 
     is_sparse = (100.0 * nnz / (shape[0] * shape[1])) < sparse_threshold
     return (col_shift if is_sparse else None, nnz, shape[0] * shape[1])

--- a/server/converters/to_sparse.py
+++ b/server/converters/to_sparse.py
@@ -38,8 +38,7 @@ def main():
         print("input is not a directory", args.input)
         sys.exit(1)
 
-    shutil.copytree(args.input, args.output,
-                    ignore=shutil.ignore_patterns("X", "X_col_shift"))
+    shutil.copytree(args.input, args.output, ignore=shutil.ignore_patterns("X", "X_col_shift"))
 
     ctx = tiledb.Ctx(
         {

--- a/server/test/test_app_config.py
+++ b/server/test/test_app_config.py
@@ -50,8 +50,7 @@ class AppConfigTest(unittest.TestCase):
         # test that multi dataroots work end to end
         c.update(
             multi_dataset__dataroot=dict(
-                set1=f"{PROJECT_ROOT}/example-dataset",
-                set2=f"{PROJECT_ROOT}/server/test/test_datasets"
+                set1=f"{PROJECT_ROOT}/example-dataset", set2=f"{PROJECT_ROOT}/server/test/test_datasets"
             )
         )
         c.complete_config()


### PR DESCRIPTION
## Need/Issue

On redeployment, if the client has a cached version of the minified javascript bundle, they will not receive the updates to the frontend SPA.

## Approach

Do not cache the `index.html` that results from `GET /`.

Since most of the data we need to cache is not on the `GET /` endpoint that returns `index.html`, we can tell browsers not to cache this endpoint without incurring a bad performance penalty.


## Smoke test

```bash
❯ curl -i http://localhost:5005/
HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 1552
Cache-Control: public, max-age=0, no-store, no-cache, must-revalidate
Server: Werkzeug/1.0.1 Python/3.7.7
Date: Wed, 01 Jul 2020 20:59:35 GMT

...
```