### PR TITLE
[EASY] Fix heroku buildpack syntax

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,8 +11,12 @@
     "dataviz"
   ],
   "buildpacks": [
-    "heroku/nodejs",
-    "heroku/python"
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/python"
+    }
   ],
   "stack": "heroku-18",
   "env": {


### PR DESCRIPTION
There was a syntax error in our app.json that was leading to the inability to use the "deploy-to-heroku" button.