### PR TITLE
Explicitly set Heroku button branch as main

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,8 +11,12 @@
     "dataviz"
   ],
   "buildpacks": [
-    "heroku/nodejs",
-    "heroku/python"
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/python"
+    }
   ],
   "stack": "heroku-18",
   "env": {

--- a/experiments/heroku/README.md
+++ b/experiments/heroku/README.md
@@ -4,7 +4,7 @@
 
 Clicking on the following button will forward you to Heroku to begin the deployment process:
 
-<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene">
+<a href="https://heroku.com/deploy?template=https://github.com/chanzuckerberg/cellxgene/tree/main">
  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 


### PR DESCRIPTION
Heroku was implicitly pulling the app.json from our deprecated `master` branch.