### PR TITLE
Small fix for handling display versions

### DIFF
--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -41,11 +41,11 @@ function InformationMenu(props) {
             />
             <MenuItem
               target="_blank"
-              text={`cellxgene v${
+              text={
                 libraryVersions && libraryVersions.cellxgene
                   ? libraryVersions.cellxgene
                   : null
-              }`}
+              }
             />
             <MenuItem text="MIT License" />
             {tosURL ? (

--- a/common.mk
+++ b/common.mk
@@ -16,12 +16,6 @@ define full_path
 $(shell [[ $(1) = /* ]] && echo $(1) || echo $(PROJECT_ROOT)/$(1))
 endef
 
-# https://stackoverflow.com/a/14777895/9587410
-ifeq ($(shell uname),Darwin)     # is Windows_NT on XP, 2000, 7, Vista, 10...
-    IS_DARWIN := "true"
-endif
-
-export CELLXGENE_COMMIT := $(shell git rev-parse --short HEAD)
 export CXG_SERVER_PORT := $(call env_or_else_default,CXG_SERVER_PORT)
 export CXG_CLIENT_PORT := $(call env_or_else_default,CXG_CLIENT_PORT)
 export CXG_OPTIONS := $(call env_or_else_default,CXG_OPTIONS)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,6 +1,6 @@
 from server.common.utils import import_plugins
 
 __version__ = "0.15.0"
-
+display_version = "cellxgene v" + __version__
 
 import_plugins("server.plugins")

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -1,4 +1,4 @@
-from server import __version__ as cellxgene_version
+from server import display_version as cellxgene_display_version
 from flatten_dict import flatten, unflatten
 import os
 from os.path import splitext, basename, isdir
@@ -213,7 +213,7 @@ class AppConfig(object):
         # library_versions
         library_versions = {}
         library_versions.update(data_adaptor.get_library_versions())
-        library_versions["cellxgene"] = cellxgene_version
+        library_versions["cellxgene"] = cellxgene_display_version
 
         # links
         links = {"about-dataset": about}

--- a/server/common/utils.py
+++ b/server/common/utils.py
@@ -164,6 +164,7 @@ def import_plugins(plugin_module):
             module = importlib.import_module(full_name)
             logging.info(f"Imported plugin {full_name}")
             loaded_modules.append(module)
-    except ModuleNotFoundError:
-        logging.debug(f"No plugins found in module: {plugin_module}")
+    except ModuleNotFoundError as e:
+        logging.error(f"No plugins found in module: {plugin_module}: {str(e)}")
+
     return loaded_modules

--- a/server/eb/Makefile
+++ b/server/eb/Makefile
@@ -38,7 +38,6 @@ build: clean
 	  fi; \
 	  if [ -d customize/inline_scripts ] ; then \
 	      cp -r customize/inline_scripts/* artifact.dir/server/common/web/templates;  \
-	      find artifact.dir/server/common/web/templates/ -type f -exec sed -i$(if $(IS_DARWIN), '',) 's/__CELLXGENE_COMMIT__/$(CELLXGENE_COMMIT)/g' {} \;; \
 	  fi; \
 	  if [ -d customize/ebextensions ] ; then \
 	      cp -r customize/ebextensions/* artifact.dir/.ebextensions;  \
@@ -46,7 +45,6 @@ build: clean
 	fi; \
 	if [ -d customize/plugins ] ; then \
 	  cp -r customize/plugins artifact.dir/server/;  \
-	  find artifact.dir/server/plugins/ -type f -exec sed -i$(if $(IS_DARWIN), '',) 's/__CELLXGENE_COMMIT__/$(CELLXGENE_COMMIT)/g' {} \;; \
 	fi; \
 	(cd artifact.dir; \
 	  cp -r server/common/web/static static; \


### PR DESCRIPTION
Making a distinction between __version__ and the version we display in the info panel (display_version).
The hosted cellxgene can overwrite the display_version using a plugin.