### PR TITLE
render perf refinements

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -284,4 +284,5 @@ export default {
   saveObsAnnotationsAction: annoActions.saveObsAnnotationsAction,
   needToSaveObsAnnotations: annoActions.needToSaveObsAnnotations,
   layoutChoiceAction: selnActions.layoutChoiceAction,
+  setCellSetFromSelection: selnActions.setCellSetFromSelection,
 };

--- a/client/src/actions/selection.js
+++ b/client/src/actions/selection.js
@@ -209,3 +209,16 @@ export const layoutChoiceAction = (newLayoutChoice) => async (
     obsCrossfilter,
   });
 };
+
+/*
+Differential expression set selection
+*/
+export const setCellSetFromSelection = (cellSetId) => (dispatch, getState) => {
+  const { obsCrossfilter } = getState();
+  const selected = obsCrossfilter.allSelectedLabels();
+
+  dispatch({
+    type: `store current cell selection as differential set ${cellSetId}`,
+    data: selected.length > 0 ? selected : null,
+  });
+};

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -167,6 +167,19 @@ class Graph extends React.Component {
 
   computePointFlags = memoize(
     (crossfilter, colorByData, pointDilationData, pointDilationLabel) => {
+      /*
+      We communicate with the shader using three flags:
+      - isNaN -- the value is a NaN. Only makes sense when we have a colorAccessor
+      - isSelected -- the value is selected
+      - isHightlighted -- the value is highlighted in the UI (orthogonal from selection highlighting)
+
+      Due to constraints in webgl vertex shader attributes, these are encoded in a float, "kinda"
+      like bitmasks.
+
+      We also have separate code paths for generating flags for categorical and
+      continuous metadata, as they rely on different tests, and some of the flags
+      (eg, isNaN) are meaningless in the face of categorical metadata.
+      */
       const nObs = crossfilter.size();
       const flags = new Float32Array(nObs);
 

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -167,7 +167,6 @@ class Graph extends React.Component {
 
   computePointFlags = memoize(
     (crossfilter, colorByData, pointDilationData, pointDilationLabel) => {
-
       const nObs = crossfilter.size();
       const flags = new Float32Array(nObs);
 

--- a/client/src/components/menubar/cellSetButtons.js
+++ b/client/src/components/menubar/cellSetButtons.js
@@ -3,25 +3,18 @@ import React from "react";
 import { AnchorButton, Tooltip } from "@blueprintjs/core";
 import { connect } from "react-redux";
 import { tooltipHoverOpenDelay } from "../../globals";
+import actions from "../../actions";
 
-@connect()
+@connect((state) => ({
+  differential: state.differential,
+}))
 class CellSetButton extends React.PureComponent {
   set() {
-    const {
-      differential,
-      crossfilter,
-      dispatch,
-      eitherCellSetOneOrTwo,
-    } = this.props;
+    const { differential, dispatch, eitherCellSetOneOrTwo } = this.props;
 
-    let set = crossfilter.allSelectedLabels();
-    if (set.length === 0) set = null;
     if (!differential.diffExp) {
-      /* diffexp needs to be cleared before we store a new set */
-      dispatch({
-        type: `store current cell selection as differential set ${eitherCellSetOneOrTwo}`,
-        data: set,
-      });
+      // disallow this action if the user has active differential expression results
+      dispatch(actions.setCellSetFromSelection(eitherCellSetOneOrTwo));
     }
   }
 

--- a/client/src/components/menubar/clip.js
+++ b/client/src/components/menubar/clip.js
@@ -1,4 +1,3 @@
-// jshint esversion: 6
 import React from "react";
 import {
   Position,
@@ -11,7 +10,7 @@ import {
 import { tooltipHoverOpenDelay } from "../../globals";
 import styles from "./menubar.css";
 
-function Clip(props) {
+const Clip = React.memo((props) => {
   const {
     pendingClipPercentiles,
     clipPercentileMin,
@@ -129,6 +128,6 @@ function Clip(props) {
       />
     </div>
   );
-}
+});
 
 export default Clip;

--- a/client/src/components/menubar/diffexpButtons.js
+++ b/client/src/components/menubar/diffexpButtons.js
@@ -8,8 +8,6 @@ import actions from "../../actions";
 import CellSetButton from "./cellSetButtons";
 
 @connect((state) => ({
-  config: state.config,
-  crossfilter: state.obsCrossfilter,
   differential: state.differential,
   celllist1: state.differential?.celllist1,
   celllist2: state.differential?.celllist2,
@@ -42,13 +40,7 @@ class DiffexpButtons extends React.PureComponent {
 
   render() {
     /* diffexp-related buttons may be disabled */
-    const {
-      differential,
-      diffexpMayBeSlow,
-      diffexpCellcountMax,
-      crossfilter,
-      dispatch,
-    } = this.props;
+    const { differential, diffexpMayBeSlow, diffexpCellcountMax } = this.props;
 
     const haveBothCellSets =
       !!differential.celllist1 && !!differential.celllist2;
@@ -72,17 +64,8 @@ class DiffexpButtons extends React.PureComponent {
 
     return (
       <ButtonGroup className={styles.menubarButton}>
-        {/* eslint-disable react/jsx-props-no-spreading --- disable until eslint-config-airbnb v18.1.1*/}
-        <CellSetButton
-          {...{ differential, crossfilter, dispatch }}
-          eitherCellSetOneOrTwo={1}
-        />
-        <CellSetButton
-          {...{ differential, crossfilter, dispatch }}
-          eitherCellSetOneOrTwo={2}
-        />
-        {/* eslint-enable react/jsx-props-no-spreading --- end disable*/}
-
+        <CellSetButton eitherCellSetOneOrTwo={1} />
+        <CellSetButton eitherCellSetOneOrTwo={2} />
         {!differential.diffExp ? (
           <Tooltip
             content={warnMaxSizeExceeded ? tipMessageWarn : tipMessage}

--- a/client/src/components/menubar/diffexpButtons.js
+++ b/client/src/components/menubar/diffexpButtons.js
@@ -16,7 +16,7 @@ import CellSetButton from "./cellSetButtons";
   diffexpMayBeSlow: state.config?.parameters?.["diffexp-may-be-slow"] ?? false,
   diffexpCellcountMax: state.config?.limits?.["diffexp_cellcount_max"],
 }))
-class DiffexpButtons extends React.Component {
+class DiffexpButtons extends React.PureComponent {
   computeDiffExp = () => {
     const { dispatch, differential } = this.props;
     if (differential.celllist1 && differential.celllist2) {

--- a/client/src/components/menubar/diffexpButtons.js
+++ b/client/src/components/menubar/diffexpButtons.js
@@ -1,4 +1,3 @@
-// jshint esversion: 6
 import React from "react";
 import { connect } from "react-redux";
 import { Button, ButtonGroup, AnchorButton, Tooltip } from "@blueprintjs/core";

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -12,32 +12,44 @@ import Subset from "./subset";
 import UndoRedoReset from "./undoRedo";
 import DiffexpButtons from "./diffexpButtons";
 
-@connect((state) => ({
-  annoMatrix: state.annoMatrix,
-  crossfilter: state.obsCrossfilter,
-  differential: state.differential,
-  graphInteractionMode: state.controls.graphInteractionMode,
-  clipPercentileMin: Math.round(100 * (state.annoMatrix?.clipRange?.[0] ?? 0)),
-  clipPercentileMax: Math.round(100 * (state.annoMatrix?.clipRange?.[1] ?? 1)),
-  userDefinedGenes: state.controls.userDefinedGenes,
-  diffexpGenes: state.controls.diffexpGenes,
-  colorAccessor: state.colors.colorAccessor,
-  scatterplotXXaccessor: state.controls.scatterplotXXaccessor,
-  scatterplotYYaccessor: state.controls.scatterplotYYaccessor,
-  celllist1: state.differential.celllist1,
-  celllist2: state.differential.celllist2,
-  libraryVersions: state.config?.["library_versions"],
-  undoDisabled: state["@@undoable/past"].length === 0,
-  redoDisabled: state["@@undoable/future"].length === 0,
-  aboutLink: state.config?.links?.["about-dataset"],
-  disableDiffexp: state.config?.parameters?.["disable-diffexp"] ?? false,
-  diffexpMayBeSlow: state.config?.parameters?.["diffexp-may-be-slow"] ?? false,
-  showCentroidLabels: state.centroidLabels.showLabels,
-  tosURL: state.config?.parameters?.["about_legal_tos"],
-  privacyURL: state.config?.parameters?.["about_legal_privacy"],
-  categoricalSelection: state.categoricalSelection,
-}))
-class MenuBar extends React.Component {
+@connect((state) => {
+  const { annoMatrix } = state;
+  const crossfilter = state.obsCrossfilter;
+  const selectedCount = crossfilter.countSelected();
+
+  const subsetPossible =
+    selectedCount !== 0 && selectedCount !== crossfilter.size(); // ie, not all are selected
+  const subsetResetPossible =
+    annoMatrix.nObs !== annoMatrix.schema.dataframe.nObs;
+
+  return {
+    subsetPossible,
+    subsetResetPossible,
+    differential: state.differential,
+    graphInteractionMode: state.controls.graphInteractionMode,
+    clipPercentileMin: Math.round(100 * (annoMatrix?.clipRange?.[0] ?? 0)),
+    clipPercentileMax: Math.round(100 * (annoMatrix?.clipRange?.[1] ?? 1)),
+    userDefinedGenes: state.controls.userDefinedGenes,
+    diffexpGenes: state.controls.diffexpGenes,
+    colorAccessor: state.colors.colorAccessor,
+    scatterplotXXaccessor: state.controls.scatterplotXXaccessor,
+    scatterplotYYaccessor: state.controls.scatterplotYYaccessor,
+    celllist1: state.differential.celllist1,
+    celllist2: state.differential.celllist2,
+    libraryVersions: state.config?.["library_versions"],
+    undoDisabled: state["@@undoable/past"].length === 0,
+    redoDisabled: state["@@undoable/future"].length === 0,
+    aboutLink: state.config?.links?.["about-dataset"],
+    disableDiffexp: state.config?.parameters?.["disable-diffexp"] ?? false,
+    diffexpMayBeSlow:
+      state.config?.parameters?.["diffexp-may-be-slow"] ?? false,
+    showCentroidLabels: state.centroidLabels.showLabels,
+    tosURL: state.config?.parameters?.["about_legal_tos"],
+    privacyURL: state.config?.parameters?.["about_legal_privacy"],
+    categoricalSelection: state.categoricalSelection,
+  };
+})
+class MenuBar extends React.PureComponent {
   static isValidDigitKeyEvent(e) {
     /*
     Return true if this event is necessary to enter a percent number input.
@@ -171,30 +183,18 @@ class MenuBar extends React.Component {
     });
   };
 
-  subsetPossible = () => {
-    const { crossfilter } = this.props;
-    const count = crossfilter.countSelected();
-    return (
-      count !== 0 && count !== crossfilter.size() // ie, not all are selected
-    );
-  };
-
-  subsetResetPossible = () => {
-    const { annoMatrix } = this.props;
-    return annoMatrix.nObs !== annoMatrix.schema.dataframe.nObs;
-  };
-
   handleSubset = () => {
     const { dispatch } = this.props;
     dispatch(actions.subsetAction());
-  }
+  };
 
   handleSubsetReset = () => {
     const { dispatch } = this.props;
     dispatch(actions.resetSubsetAction());
-  }
+  };
 
   render() {
+    console.log("menubar::render()");
     const {
       dispatch,
       libraryVersions,
@@ -211,6 +211,8 @@ class MenuBar extends React.Component {
       tosURL,
       categoricalSelection,
       colorAccessor,
+      subsetPossible,
+      subsetResetPossible,
     } = this.props;
     const { pendingClipPercentiles } = this.state;
 
@@ -319,8 +321,8 @@ class MenuBar extends React.Component {
           </Tooltip>
         </ButtonGroup>
         <Subset
-          subsetPossible={this.subsetPossible()}
-          subsetResetPossible={this.subsetResetPossible()}
+          subsetPossible={subsetPossible}
+          subsetResetPossible={subsetResetPossible}
           handleSubset={this.handleSubset}
           handleSubsetReset={this.handleSubsetReset}
         />

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -184,6 +184,16 @@ class MenuBar extends React.Component {
     return annoMatrix.nObs !== annoMatrix.schema.dataframe.nObs;
   };
 
+  handleSubset = () => {
+    const { dispatch } = this.props;
+    dispatch(actions.subsetAction());
+  }
+
+  handleSubsetReset = () => {
+    const { dispatch } = this.props;
+    dispatch(actions.resetSubsetAction());
+  }
+
   render() {
     const {
       dispatch,
@@ -311,12 +321,8 @@ class MenuBar extends React.Component {
         <Subset
           subsetPossible={this.subsetPossible()}
           subsetResetPossible={this.subsetResetPossible()}
-          handleSubset={() => {
-            dispatch(actions.subsetAction());
-          }}
-          handleSubsetReset={() => {
-            dispatch(actions.resetSubsetAction());
-          }}
+          handleSubset={this.handleSubset}
+          handleSubsetReset={this.handleSubsetReset}
         />
         {disableDiffexp ? null : <DiffexpButtons />}
       </div>

--- a/client/src/components/menubar/index.js
+++ b/client/src/components/menubar/index.js
@@ -194,7 +194,6 @@ class MenuBar extends React.PureComponent {
   };
 
   render() {
-    console.log("menubar::render()");
     const {
       dispatch,
       libraryVersions,

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -3,8 +3,9 @@ import React from "react";
 import { Button, Popover, Menu, MenuItem, Position } from "@blueprintjs/core";
 import styles from "./menubar.css";
 
-function InformationMenu(props) {
+const InformationMenu = React.memo((props) => {
   const { libraryVersions, aboutLink, tosURL, privacyURL } = props;
+  console.log("render InformationMenu");
   return (
     <div className={`bp3-button-group ${styles.menubarButton}`}>
       <Popover
@@ -72,6 +73,6 @@ function InformationMenu(props) {
       </Popover>
     </div>
   );
-}
+});
 
 export default InformationMenu;

--- a/client/src/components/menubar/infoMenu.js
+++ b/client/src/components/menubar/infoMenu.js
@@ -5,7 +5,6 @@ import styles from "./menubar.css";
 
 const InformationMenu = React.memo((props) => {
   const { libraryVersions, aboutLink, tosURL, privacyURL } = props;
-  console.log("render InformationMenu");
   return (
     <div className={`bp3-button-group ${styles.menubarButton}`}>
       <Popover

--- a/client/src/components/menubar/subset.js
+++ b/client/src/components/menubar/subset.js
@@ -3,7 +3,7 @@ import { AnchorButton, ButtonGroup, Tooltip } from "@blueprintjs/core";
 import styles from "./menubar.css";
 import * as globals from "../../globals";
 
-function Subset(props) {
+const Subset = React.memo((props) => {
   const {
     subsetPossible,
     subsetResetPossible,
@@ -41,6 +41,6 @@ function Subset(props) {
       </Tooltip>
     </ButtonGroup>
   );
-}
+});
 
 export default Subset;

--- a/client/src/components/menubar/undoRedo.js
+++ b/client/src/components/menubar/undoRedo.js
@@ -1,10 +1,9 @@
-// jshint esversion: 6
 import React from "react";
 import { AnchorButton, Tooltip } from "@blueprintjs/core";
 import { tooltipHoverOpenDelay } from "../../globals";
 import styles from "./menubar.css";
 
-function InformationMenu(props) {
+const UndoRedo = React.memo((props) => {
   const { undoDisabled, redoDisabled, dispatch } = props;
   return (
     <div className={`bp3-button-group ${styles.menubarButton}`}>
@@ -46,6 +45,6 @@ function InformationMenu(props) {
       </Tooltip>
     </div>
   );
-}
+});
 
-export default InformationMenu;
+export default UndoRedo;


### PR DESCRIPTION
Add optimizations and remove jank that is residual from redux refactor.  There are two primary changes:
* fixed a bunch of excessive re-rendering in the menu bar that was causing jank during histogram brush selection.  No functional changes here, just better state handling.
* improve memoization in the graph and scatterplot.

Fixes #1607 