### PR TITLE
protect against reference detach in scatterplot

### DIFF
--- a/client/src/components/scatterplot/scatterplot.js
+++ b/client/src/components/scatterplot/scatterplot.js
@@ -59,6 +59,11 @@ class Scatterplot extends React.PureComponent {
     /*
     Must be created for each canvas
     */
+
+    // regl will create a top-level, full-screen canvas if we pass it a null.
+    // canvas should never be null, so protect against that.
+    if (!canvas) return {};
+
     // setup canvas, webgl draw function and camera
     const regl = _regl(canvas);
     const drawPoints = _drawPoints(regl);
@@ -175,9 +180,12 @@ class Scatterplot extends React.PureComponent {
 
   setReglCanvas = (canvas) => {
     this.reglCanvas = canvas;
-    this.setState({
-      ...Scatterplot.createReglState(canvas),
-    });
+    if (canvas) {
+      // no need to update this state if we are detaching.
+      this.setState({
+        ...Scatterplot.createReglState(canvas),
+      });
+    }
   };
 
   getViewportDimensions = () => {


### PR DESCRIPTION

Fixes #1633 

There was a bug introduced during the redux refactor, where a full-screen canvas would get created by regl when the scatterplot component detached its canvas ref. 