### PR TITLE
correctly handle non-string categoricals

### DIFF
--- a/client/src/annoMatrix/schema.js
+++ b/client/src/annoMatrix/schema.js
@@ -68,7 +68,7 @@ export function _normalizeCategoricalSchema(colSchema, col) {
   const { type, writable } = colSchema;
   if (type === "string" || type === "boolean" || type === "categorical") {
     const categorySet = new Set(
-      col.summarize().categories.concat(colSchema.categories ?? [])
+      col.summarizeCategorical().categories.concat(colSchema.categories ?? [])
     );
     if (writable && !categorySet.has(unassignedCategoryLabel)) {
       categorySet.add(unassignedCategoryLabel);


### PR DESCRIPTION
Categoricals which are not a string primitive may not rely on Dataframe's weak attempt to guess which type of summarization is required.  Change `summarize()` to `summarizeCategorical()` to request an explicitly categorical summarization.