### PR TITLE
force categorical treatment of user annotations

### DIFF
--- a/client/src/annoMatrix/loader.js
+++ b/client/src/annoMatrix/loader.js
@@ -90,10 +90,10 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     If an array, it must be of same size as nObs and same type as Ctor
 		*/
     colSchema.writable = true;
-    const col = colSchema.name;
+    const colName = colSchema.name;
     if (
-      _getColumnSchema(this.schema, "obs", col) ||
-      this._cache.obs.hasCol(col)
+      _getColumnSchema(this.schema, "obs", colName) ||
+      this._cache.obs.hasCol(colName)
     ) {
       throw new Error("column already exists");
     }
@@ -109,11 +109,9 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     } else {
       data = new Ctor(this.nObs).fill(value);
     }
-    o._cache.obs = this._cache.obs.withCol(col, data);
-    o.schema = addObsAnnoColumn(this.schema, col, {
-      ...colSchema,
-      writable: true,
-    });
+    o._cache.obs = this._cache.obs.withCol(colName, data);
+    _normalizeCategoricalSchema(colSchema, o._cache.obs.col(colName));
+    o.schema = addObsAnnoColumn(this.schema, colName, colSchema);
     return o;
   }
 

--- a/client/src/annoMatrix/schema.js
+++ b/client/src/annoMatrix/schema.js
@@ -66,7 +66,12 @@ export function _isContinuousType(schema) {
 
 export function _normalizeCategoricalSchema(colSchema, col) {
   const { type, writable } = colSchema;
-  if (type === "string" || type === "boolean" || type === "categorical") {
+  if (
+    type === "string" ||
+    type === "boolean" ||
+    type === "categorical" ||
+    writable
+  ) {
     const categorySet = new Set(
       col.summarizeCategorical().categories.concat(colSchema.categories ?? [])
     );
@@ -79,4 +84,5 @@ export function _normalizeCategoricalSchema(colSchema, col) {
   if (colSchema.categories) {
     colSchema.categories = catLabelSort(writable, colSchema.categories);
   }
+  return colSchema;
 }

--- a/client/src/components/continuous/continuous.js
+++ b/client/src/components/continuous/continuous.js
@@ -16,6 +16,7 @@ class Continuous extends React.PureComponent {
     const allContinuousNames = schema.annotations.obs.columns
       .filter((col) => col.type === "int32" || col.type === "float32")
       .filter((col) => col.name !== obsIndex)
+      .filter((col) => !col.writable) // skip user annotations - they will be treated as categorical
       .map((col) => col.name);
 
     return (

--- a/client/src/util/stateManager/controlsHelpers.js
+++ b/client/src/util/stateManager/controlsHelpers.js
@@ -64,7 +64,12 @@ function topNCategories(colSchema, summary, N) {
 
 export function isSelectableCategoryName(schema, name) {
   const { index } = schema.annotations.obs;
-  return name && name !== index && isCategoricalAnnotation(schema, name);
+  const colSchema = schema.annotations.obsByName[name];
+  return (
+    name &&
+    name !== index &&
+    (isCategoricalAnnotation(schema, name) || colSchema.writable)
+  );
 }
 
 export function selectableCategoryNames(schema, names) {


### PR DESCRIPTION
This PR fixes several issues introduced by the redux state refactor.  These changes revert to prior behavior:
* user annotations are forced into the categorical UI, regardless of their primtive type
* new "duplicate category" user annotations now preserve their original category's primitive type

While debugging this, I also found a bug where new user annotations would not properly sort their categories for display.  This is also fixed.

Fixes #1661