### PR TITLE
Fix demo data an prepare links on docs index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ Launch cellxgene with an example [anndata](https://anndata.readthedocs.io/en/lat
 cellxgene launch https://cellxgene-example-data.czi.technology/pbmc3k.h5ad
 ```
 
-To explore more datasets already formatted for cellxgene, check out the [Demo data](demo-data) or
-see [Preparing your data](prepare) to learn more about formatting your own
+To explore more datasets already formatted for cellxgene, check out the [Demo data](posts/demo-data) or
+see [Preparing your data](posts/prepare) to learn more about formatting your own
 data for cellxgene.
 
 # Getting help


### PR DESCRIPTION
On the [landing page](https://chanzuckerberg.github.io/cellxgene/) the last paragraph of QuickStart has two broken links:  "Demo data" and "Preparing your data". Links were missing `posts/` in their path.