### PR TITLE
Add basic authentication in the server

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -85,6 +85,7 @@ def dataset_index(url_dataroot=None, dataset=None):
     try:
         cache_manager = current_app.matrix_data_cache_manager
         with cache_manager.data_adaptor(url_dataroot, location, app_config) as data_adaptor:
+            data_adaptor.set_uri_path(f"{url_dataroot}/{dataset}")
             dataset_title = app_config.get_title(data_adaptor)
             return render_template(
                 "index.html", datasetTitle=dataset_title, SCRIPTS=scripts, INLINE_SCRIPTS=inline_scripts
@@ -143,6 +144,7 @@ def rest_get_data_adaptor(func):
     def wrapped_function(self, dataset=None):
         try:
             with get_data_adaptor(self.url_dataroot, dataset) as data_adaptor:
+                data_adaptor.set_uri_path(f"{self.url_dataroot}/{dataset}")
                 return func(self, data_adaptor)
         except DatasetAccessError as e:
             return common_rest.abort_and_log(
@@ -160,6 +162,17 @@ def dataroot_test_index():
 
     config = current_app.app_config
     server_config = config.server_config
+
+    auth = server_config.auth
+    if auth.is_valid():
+        if server_config.auth.is_authenticated():
+            data += f"<p>Logged in as {auth.get_userid()} / {auth.get_username()}</p>"
+        if auth.requires_client_login():
+            if server_config.auth.is_authenticated():
+                data += "<p><a href='/logout'>Logout</a></p>"
+            else:
+                data += "<p><a href='/login'>Login</a></p>"
+
     datasets = []
     for dataroot_dict in server_config.multi_dataset__dataroot.values():
         dataroot = dataroot_dict["dataroot"]
@@ -338,10 +351,15 @@ class Server:
                     lambda dataset, url_dataroot=url_dataroot: dataset_index(url_dataroot, dataset),
                     methods=["GET"],
                 )
+
         else:
             bp_api = Blueprint("api", __name__, url_prefix=api_version)
             resources = get_api_resources(bp_api)
             self.app.register_blueprint(resources.blueprint)
+
+        self.app.auth = server_config.auth
+        if self.app.auth.requires_client_login():
+            self.app.auth.add_url_rules(self.app)
 
         self.app.matrix_data_cache_manager = server_config.matrix_data_cache_manager
         self.app.app_config = app_config

--- a/server/auth/__init__.py
+++ b/server/auth/__init__.py
@@ -1,0 +1,6 @@
+
+# import the built in auth types so they can be registered
+
+import server.auth.auth_none  # noqa: F401
+import server.auth.auth_test  # noqa: F401
+import server.auth.auth_session  # noqa: F401

--- a/server/auth/auth.py
+++ b/server/auth/auth.py
@@ -1,0 +1,80 @@
+from abc import ABC, abstractmethod
+
+
+class AuthTypeBase(ABC):
+    """Base type for all authentication types."""
+
+    def __init__(self):
+        super().__init__()
+
+    @abstractmethod
+    def set_params(self, params):
+        """Set the parameters from app config.  raise ConfigurationError if any params are invalid"""
+        pass
+
+    @abstractmethod
+    def is_valid(self):
+        """Return True if the auth type can return user info (AuthTypeNone is the only one that cannot)"""
+        pass
+
+    def requires_client_login(self):
+        """Return True if the user needs to login from the client (e.g. Login button is shown)"""
+        return False
+
+    @abstractmethod
+    def is_authenticated(self):
+        """Return True if the user is authenticated"""
+        pass
+
+    @abstractmethod
+    def get_userid(self):
+        """Return the id for this user (string)"""
+        pass
+
+    @abstractmethod
+    def get_username(self):
+        """Return the name of the user (string)"""
+        pass
+
+
+class AuthTypeClientBase(AuthTypeBase):
+    """Base type for all authentication types that require the client to login"""
+
+    def __init__(self):
+        super().__init__()
+
+    def requires_client_login(self):
+        return True
+
+    @abstractmethod
+    def add_url_rules(self, selfapp):
+        """Add url rules to the app (like /login, /logout, etc)"""
+        pass
+
+    @abstractmethod
+    def get_login_url(self, data_adaptor):
+        """Return the url for the login route"""
+        pass
+
+    @abstractmethod
+    def get_logout_url(self, data_adaptor):
+        """Return the url for the logout route"""
+        pass
+
+
+class AuthTypeFactory:
+    """Factory class to create an authentication type"""
+
+    auth_types = {}
+
+    @staticmethod
+    def register(name, auth_type):
+        assert(issubclass(auth_type, AuthTypeBase))
+        AuthTypeFactory.auth_types[name] = auth_type
+
+    @staticmethod
+    def create(name):
+        auth_type = AuthTypeFactory.auth_types.get(name)
+        if auth_type is None:
+            return None
+        return auth_type()

--- a/server/auth/auth_none.py
+++ b/server/auth/auth_none.py
@@ -1,0 +1,27 @@
+from server.auth.auth import AuthTypeBase, AuthTypeFactory
+from server.common.errors import ConfigurationError
+
+
+class AuthTypeNone(AuthTypeBase):
+
+    def __init__(self):
+        super().__init__()
+
+    def is_valid(self):
+        return False
+
+    def set_params(self, params):
+        if params:
+            raise ConfigurationError("not expecting authentication parameters")
+
+    def is_authenticated(self):
+        return True
+
+    def get_userid(self):
+        return None
+
+    def get_username(self):
+        return None
+
+
+AuthTypeFactory.register(None, AuthTypeNone)

--- a/server/auth/auth_session.py
+++ b/server/auth/auth_session.py
@@ -1,0 +1,36 @@
+from server.auth.auth import AuthTypeBase, AuthTypeFactory
+from flask import session
+from uuid import uuid4
+
+
+class AuthTypeSession(AuthTypeBase):
+    """Session based authentication.  The user is always logged.  The user id is a random number
+    associated with the session.  This is a good choice for desktop servers."""
+
+    # key in the session token for userid
+    CXGUID = "cxguid"
+
+    def __init__(self):
+        super().__init__()
+
+    def is_valid(self):
+        return True
+
+    def set_params(self, params):
+        return
+
+    def is_authenticated(self):
+        # always authenticated
+        return True
+
+    def get_userid(self):
+        if self.CXGUID not in session:
+            session[self.CXGUID] = uuid4().hex
+            session.permanent = True
+        return session[self.CXGUID]
+
+    def get_username(self):
+        return "anonymous"
+
+
+AuthTypeFactory.register("session", AuthTypeSession)

--- a/server/auth/auth_test.py
+++ b/server/auth/auth_test.py
@@ -1,0 +1,69 @@
+from server.auth.auth import AuthTypeClientBase, AuthTypeFactory
+from flask import session, request, redirect, current_app
+
+
+class AuthTypeTest(AuthTypeClientBase):
+    """An authentication type for testing client based logins.  When the login route is accessed
+    the user is automatically logged in with a default or configured username"""
+
+    # key in session token with userid and username
+    CXGUID = "cxguid_test"
+    CXGUNAME = "cxguname_test"
+
+    def __init__(self):
+        super().__init__()
+        self.username = "test_account"
+        self.userid = "id0001"
+
+    def is_valid(self):
+        return True
+
+    def requires_client_login(self):
+        return True
+
+    def add_url_rules(self, app):
+        app.add_url_rule("/login", "login", self.login, methods=["GET"])
+        app.add_url_rule("/logout", "logout", self.logout, methods=["GET"])
+
+    def set_params(self, params):
+        if params:
+            self.username = params.get("username", self.username)
+            self.userid = params.get("userid", self.userid)
+
+    def is_authenticated(self):
+        return self.CXGUID in session
+
+    def get_userid(self):
+        return session.get(self.CXGUID)
+
+    def get_username(self):
+        return session.get(self.CXGUNAME)
+
+    def login(self):
+        args = request.args
+        return_to = args.get("dataset", "/")
+        session[self.CXGUID] = args.get("userid", self.userid)
+        session[self.CXGUNAME] = args.get("username", self.username)
+        return redirect(return_to)
+
+    def logout(self):
+        session.clear()
+        return_to = request.args.get("dataset", "/")
+        return redirect(return_to)
+
+    def get_login_url(self, data_adaptor):
+        """Return the url for the login route"""
+        if current_app.app_config.is_multi_dataset():
+            return f"/login?dataset={data_adaptor.uri_path}"
+        else:
+            return "/login"
+
+    def get_logout_url(self, data_adaptor):
+        """Return the url for the logout route"""
+        if current_app.app_config.is_multi_dataset():
+            return f"/logout?dataset={data_adaptor.uri_path}"
+        else:
+            return "/logout"
+
+
+AuthTypeFactory.register("test", AuthTypeTest)

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -14,6 +14,15 @@ server:
     server_timing_headers: false
     csp_directives: null
 
+  authentication:
+    # The authentication types may be "none" or "session"
+    # none:  No authentication support, features like user_annotations must not be enabled.
+    # session:  A session based userid is automatically generated.
+    type: session
+
+    # a dictionary of parameters that may be required for an authentication type
+    params: null
+
   multi_dataset:
     # If dataroot is set, then cellxgene may serve multiple datasets.  This parameter is not
     # compatible with single_dataset/datapath.
@@ -131,6 +140,9 @@ dataset:
 
     about_legal_tos: null
     about_legal_privacy: null
+
+    # allow authentication support
+    authentication_enable: true
 
   presentation:
     max_categories: 1000

--- a/server/data_common/data_adaptor.py
+++ b/server/data_common/data_adaptor.py
@@ -28,6 +28,11 @@ class DataAdaptor(metaclass=ABCMeta):
 
         # parameters set by this data adaptor based on the data.
         self.parameters = {}
+        self.uri_path = None
+
+    def set_uri_path(self, path):
+        # uri path to the dataset, e.g. /d/<datasetname>
+        self.uri_path = path
 
     @staticmethod
     @abstractmethod

--- a/server/test/__init__.py
+++ b/server/test/__init__.py
@@ -104,7 +104,8 @@ def test_server(command_line_args=[], app_config=None):
     yaml config file, which this server will read and parse.
     """
 
-    port = int(os.environ.get("CXG_SERVER_PORT", DEFAULT_SERVER_PORT))
+    start = random.randint(DEFAULT_SERVER_PORT, 2**16 - 1)
+    port = int(os.environ.get("CXG_SERVER_PORT", start))
     port = find_available_port("localhost", port)
     command = ["cellxgene", "--no-upgrade-check", "launch", "--verbose", "--port=%d" % port] + command_line_args
 

--- a/server/test/__init__.py
+++ b/server/test/__init__.py
@@ -86,15 +86,14 @@ def random_string(n):
     return "".join(random.choice(string.ascii_letters) for _ in range(n))
 
 
-@contextmanager
-def test_server(command_line_args=[], app_config=None):
-    """A context to run the cellxgene server.
+def start_test_server(command_line_args=[], app_config=None):
+    """
     Command line arguments can be passed in, as well as an app_config.
     This function is meant to be used like this, for example:
 
     with test_server(...) as server:
-       r = requests.get(f"{server}/...")
-       // check r
+        r = requests.get(f"{server}/...")
+        // check r
 
     where the server can be accessed within the context, and is terminated when
     the context is exited.
@@ -129,10 +128,25 @@ def test_server(command_line_args=[], app_config=None):
     if tempdir:
         tempdir.cleanup()
 
+    return ps, server
+
+
+def stop_test_server(ps):
+    try:
+        ps.terminate()
+    except ProcessLookupError:
+        pass
+
+
+@contextmanager
+def test_server(command_line_args=[], app_config=None):
+    """A context to run the cellxgene server."""
+
+    ps, server = start_test_server(command_line_args, app_config)
     try:
         yield server
     finally:
         try:
-            ps.terminate()
+            stop_test_server(ps)
         except ProcessLookupError:
             pass

--- a/server/test/test_auth.py
+++ b/server/test/test_auth.py
@@ -1,0 +1,142 @@
+import unittest
+from server.common.app_config import AppConfig
+from server.test import PROJECT_ROOT, test_server
+import requests
+
+
+class AuthTest(unittest.TestCase):
+    def test_auth_none(self):
+        c = AppConfig()
+        c.update_server_config(
+            authentication__type=None, multi_dataset__dataroot=f"{PROJECT_ROOT}/server/test/test_datasets"
+        )
+        c.update_default_dataset_config(user_annotations__enable=False)
+
+        c.complete_config()
+
+        with test_server(app_config=c) as server:
+            session = requests.Session()
+            r = session.get(f"{server}/d/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert "authentication" not in data_config["config"]
+
+    def test_auth_session(self):
+        c = AppConfig()
+        c.update_server_config(
+            authentication__type="session", multi_dataset__dataroot=f"{PROJECT_ROOT}/server/test/test_datasets"
+        )
+        c.update_default_dataset_config(user_annotations__enable=True)
+        c.complete_config()
+
+        with test_server(app_config=c) as server:
+            session = requests.Session()
+            r = session.get(f"{server}/d/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert data_config["config"]["authentication"]["is_authenticated"]
+            assert not data_config["config"]["authentication"]["requires_client_login"]
+            assert data_config["config"]["authentication"]["username"] == "anonymous"
+
+    def test_auth_test(self):
+        c = AppConfig()
+        c.update_server_config(authentication__type="test")
+        c.update_server_config(
+            multi_dataset__dataroot=dict(
+                a1=dict(dataroot=f"{PROJECT_ROOT}/server/test/test_datasets", base_url="auth"),
+                a2=dict(dataroot=f"{PROJECT_ROOT}/server/test/test_datasets", base_url="no-auth"),
+            )
+        )
+
+        # specialize the configs
+        c.add_dataroot_config("a1", app__authentication_enable=True, user_annotations__enable=True)
+        c.add_dataroot_config("a2", app__authentication_enable=False, user_annotations__enable=False)
+
+        c.complete_config()
+
+        with test_server(app_config=c) as server:
+            session = requests.Session()
+
+            # auth datasets
+            r = session.get(f"{server}/auth/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert not data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["requires_client_login"]
+            assert data_config["config"]["authentication"]["username"] is None
+            assert data_config["config"]["parameters"]["annotations"]
+
+            login_uri = data_config["config"]["authentication"]["login"]
+            logout_uri = data_config["config"]["authentication"]["logout"]
+
+            assert login_uri == "/login?dataset=auth/pbmc3k.cxg"
+            assert logout_uri == "/logout?dataset=auth/pbmc3k.cxg"
+
+            r = session.get(f"{server}/{login_uri}")
+            # check that the login redirect worked
+            assert r.history[0].status_code == 302
+            assert r.url == f"{server}/auth/pbmc3k.cxg/"
+
+            r = session.get(f"{server}/auth/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["username"] == "test_account"
+            assert data_config["config"]["parameters"]["annotations"]
+
+            r = session.get(f"{server}/{logout_uri}")
+            # check that the logout redirect worked
+            assert r.history[0].status_code == 302
+            assert r.url == f"{server}/auth/pbmc3k.cxg/"
+            r = session.get(f"{server}/auth/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert not data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["username"] is None
+            assert data_config["config"]["parameters"]["annotations"]
+
+            # no-auth datasets
+            r = session.get(f"{server}/no-auth/pbmc3k.cxg/api/v0.2/config")
+            data_config = r.json()
+            assert "authentication" not in data_config["config"]
+            assert not data_config["config"]["parameters"]["annotations"]
+
+    def test_auth_test_single(self):
+        c = AppConfig()
+        c.update_server_config(
+            authentication__type="test",
+            single_dataset__datapath=f"{PROJECT_ROOT}/server/test/test_datasets/pbmc3k.cxg")
+
+        c.complete_config()
+
+        with test_server(app_config=c) as server:
+            session = requests.Session()
+
+            r = session.get(f"{server}/api/v0.2/config")
+            data_config = r.json()
+            assert not data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["requires_client_login"]
+            assert data_config["config"]["authentication"]["username"] is None
+            assert data_config["config"]["parameters"]["annotations"]
+
+            login_uri = data_config["config"]["authentication"]["login"]
+            logout_uri = data_config["config"]["authentication"]["logout"]
+
+            assert login_uri == "/login"
+            assert logout_uri == "/logout"
+
+            r = session.get(f"{server}/{login_uri}")
+            # check that the login redirect worked
+            assert r.history[0].status_code == 302
+            assert r.url == f"{server}/"
+
+            r = session.get(f"{server}/api/v0.2/config")
+            data_config = r.json()
+            assert data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["username"] == "test_account"
+            assert data_config["config"]["parameters"]["annotations"]
+
+            r = session.get(f"{server}/{logout_uri}")
+            # check that the logout redirect worked
+            assert r.history[0].status_code == 302
+            assert r.url == f"{server}/"
+            r = session.get(f"{server}/api/v0.2/config")
+            data_config = r.json()
+            assert not data_config["config"]["authentication"]["is_authenticated"]
+            assert data_config["config"]["authentication"]["username"] is None
+            assert data_config["config"]["parameters"]["annotations"]


### PR DESCRIPTION
A pattern for creating authentication methods is introduced, with three
authentication types defined:
  none - no authentication
  session - like the current session based auth used for user annotations
  test - used to test the login/logout process end to end

The config endpoint now returns informations about the authentication, like if
the user is authenticated and their username.  The redirect uri's for login and
logout are also returned if the authentication type requires login

This is the first a several PRs for authentication.