### PR TITLE
add core-js-3 and TextEncoder TextDecoder

### DIFF
--- a/client/configuration/babel/babel.dev.js
+++ b/client/configuration/babel/babel.dev.js
@@ -1,7 +1,17 @@
 module.exports = {
   babelrc: false,
   cacheDirectory: true,
-  presets: ["@babel/preset-env", "@babel/preset-react"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "entry",
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    "@babel/preset-react",
+  ],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/babel/babel.prod.js
+++ b/client/configuration/babel/babel.prod.js
@@ -1,6 +1,16 @@
 module.exports = {
   babelrc: false,
-  presets: ["@babel/preset-env", "@babel/preset-react"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "entry",
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    "@babel/preset-react",
+  ],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -24,8 +24,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: src,
+        test: /\.jsx?$/,
         loader: "babel-loader",
         options: babelOptions,
       },

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -42,8 +42,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: src,
+        test: /\.jsx?$/,
         loader: "babel-loader",
         options: babelOptions,
       },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4077,6 +4077,14 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -7735,10 +7743,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -10076,6 +10083,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "favicons": {
       "version": "5.5.0",
@@ -16521,9 +16533,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -19543,6 +19555,14 @@
         "minimist": "^1.2.0",
         "request": "^2.88.0",
         "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "wait-port": {

--- a/client/package.json
+++ b/client/package.json
@@ -40,8 +40,10 @@
     "@blueprintjs/core": "^3.30.0",
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.5",
+    "core-js": "^3.6.5",
     "d3": "^4.10.0",
     "d3-scale-chromatic": "^1.5.0",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "flatbuffers": "^1.11.0",
     "fuzzysort": "^1.1.4",
     "gl-mat4": "^1.2.0",
@@ -59,6 +61,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "regenerator-runtime": "^0.13.7",
     "regl": "^1.6.1",
     "tinyqueue": "^2.0.3"
   },

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,8 +1,13 @@
 // jshint esversion: 6
+import "core-js/stable";
+import "regenerator-runtime/runtime";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { FocusStyleManager } from "@blueprintjs/core";
+// https://github.com/anonyco/FastestSmallestTextEncoderDecoder
+// Only supports UTF-8
+import "fastestsmallesttextencoderdecoder";
 
 import "./index.css";
 

--- a/client/src/util/stateManager/matrix.js
+++ b/client/src/util/stateManager/matrix.js
@@ -170,11 +170,11 @@ export function encodeMatrixFBS(df) {
 
 function promoteTypedArray(o) {
   /*
-  Decide what internal data type to use for the data returned from 
+  Decide what internal data type to use for the data returned from
   the server.
 
   TODO - future optimization: not all int32/uint32 data series require
-  promotion to float64.  We COULD simply look at the data to decide. 
+  promotion to float64.  We COULD simply look at the data to decide.
   */
   if (isFpTypedArray(o) || Array.isArray(o)) return o;
 


### PR DESCRIPTION
I also added `core-js-3`, because I remember it’s needed for polyfilling JS features, like Array.from, Promise, Map, Set, etc., whereas `preset-env` only handles JS syntax sugars like arrow function and `[…a, …b]`

sources:
1. https://babeljs.io/docs/en/babel-preset-env#usebuiltins
2. https://www.valentinog.com/blog/preset-env/