### PR TITLE
Explicit Browser Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ To explore more datasets already formatted for cellxgene, check out the [Demo da
 see [Preparing your data](https://chanzuckerberg.github.io/cellxgene/posts/prepare) to learn more about formatting your own
 data for cellxgene.
 
+### Supported browsers
+
+cellxgene currently supports the following browsers:
+
+- Google Chrome 61+
+- Edge 15+
+- Firefox 60+
+- Safari 10.1+
+
+Please [file an issue](https://github.com/chanzuckerberg/cellxgene/issues/new/choose) if you find that your browser is not supported or if would like us to expand our support to other browsers.
+
 ### Finding help
 
 We'd love to hear from you!

--- a/README.md
+++ b/README.md
@@ -14,26 +14,30 @@ Whether you need to visualize one thousand cells or one million, cellxgene helps
 <img src="https://github.com/chanzuckerberg/cellxgene/raw/main/docs/images/crossfilter.gif" width="350" height="200" hspace="30"><img src="https://github.com/chanzuckerberg/cellxgene/raw/main/docs/images/category-breakdown.gif" width="350" height="200" hspace="30">
 
 # Getting started
+
 ### The comprehensive guide to cellxgene
+
 [The cellxgene documentation is your one-stop-shop for information about cellxgene](https://chanzuckerberg.github.io/cellxgene/)! You may be particularly interested in:
-* Seeing [what cellxgene can do](https://chanzuckerberg.github.io/cellxgene/posts/gallery)  
-* Learning more about cellxgene [installation](https://chanzuckerberg.github.io/cellxgene/posts/install) and [usage](https://chanzuckerberg.github.io/cellxgene/posts/launch)
-* [Preparing your own data](https://chanzuckerberg.github.io/cellxgene/posts/prepare) for use in cellxgene
-* Checking out [our roadmap](https://chanzuckerberg.github.io/cellxgene/posts/roadmap) for future development
-* [Contributing](https://chanzuckerberg.github.io/cellxgene/posts/contribute) to cellxgene
+
+- Seeing [what cellxgene can do](https://chanzuckerberg.github.io/cellxgene/posts/gallery)
+- Learning more about cellxgene [installation](https://chanzuckerberg.github.io/cellxgene/posts/install) and [usage](https://chanzuckerberg.github.io/cellxgene/posts/launch)
+- [Preparing your own data](https://chanzuckerberg.github.io/cellxgene/posts/prepare) for use in cellxgene
+- Checking out [our roadmap](https://chanzuckerberg.github.io/cellxgene/posts/roadmap) for future development
+- [Contributing](https://chanzuckerberg.github.io/cellxgene/posts/contribute) to cellxgene
 
 ### Quick start
 
 To install cellxgene you need Python 3.6+. We recommend [installing cellxgene into a conda or virtual environment.](https://chanzuckerberg.github.io/cellxgene/posts/install)
 
 Install the package.
-``` bash
+
+```bash
 pip install cellxgene
 ```
 
 Launch cellxgene with an example [anndata](https://anndata.readthedocs.io/en/latest/) file
 
-``` bash
+```bash
 cellxgene launch https://cellxgene-example-data.czi.technology/pbmc3k.h5ad
 ```
 
@@ -51,6 +55,7 @@ For any errors, [report bugs on Github](https://github.com/chanzuckerberg/cellxg
 # Developing with cellxgene
 
 ### Contributing
+
 We warmly welcome contributions from the community! Please see our [contributing guide](https://chanzuckerberg.github.io/cellxgene/posts/contribute) and don't hesitate to open an issue or send a pull request to improve cellxgene.
 
 This project adheres to the Contributor Covenant [code of conduct](https://github.com/chanzuckerberg/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to opensource@chanzuckerberg.com.
@@ -64,6 +69,7 @@ This project was started with the sole goal of empowering the scientific communi
 If you believe you have found a security issue, we would appreciate notification. Please send email to <security@chanzuckerberg.com>.
 
 # About
+
 ### Core team
 
 The current core team:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cellxgene currently supports the following browsers:
 - Firefox 60+
 - Safari 10.1+
 
-Please [file an issue](https://github.com/chanzuckerberg/cellxgene/issues/new/choose) if you find that your browser is not supported or if would like us to expand our support to other browsers.
+Please [file an issue](https://github.com/chanzuckerberg/cellxgene/issues/new/choose) if you would like us to add support for an unsupported browser.
 
 ### Finding help
 

--- a/client/configuration/babel/babel.dev.js
+++ b/client/configuration/babel/babel.dev.js
@@ -1,7 +1,17 @@
 module.exports = {
   babelrc: false,
   cacheDirectory: true,
-  presets: ["@babel/preset-env", "@babel/preset-react"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "entry",
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    "@babel/preset-react",
+  ],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/babel/babel.dev.js
+++ b/client/configuration/babel/babel.dev.js
@@ -1,10 +1,7 @@
 module.exports = {
   babelrc: false,
   cacheDirectory: true,
-  presets: [
-    ["modern-browsers", { loose: true, modules: false }],
-    "@babel/preset-react",
-  ],
+  presets: ["@babel/preset-env", "@babel/preset-react"],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/babel/babel.prod.js
+++ b/client/configuration/babel/babel.prod.js
@@ -1,6 +1,16 @@
 module.exports = {
   babelrc: false,
-  presets: ["@babel/preset-env", "@babel/preset-react"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "entry",
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    "@babel/preset-react",
+  ],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/babel/babel.prod.js
+++ b/client/configuration/babel/babel.prod.js
@@ -1,9 +1,6 @@
 module.exports = {
   babelrc: false,
-  presets: [
-    ["modern-browsers", { loose: true, modules: false }],
-    "@babel/preset-react",
-  ],
+  presets: ["@babel/preset-env", "@babel/preset-react"],
   plugins: [
     "@babel/plugin-proposal-function-bind",
     ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -4,6 +4,7 @@ module.exports = {
   extends: [
     "airbnb",
     "plugin:eslint-comments/recommended",
+    "plugin:compat/recommended",
     "plugin:prettier/recommended",
     "prettier/react",
   ],

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -16,6 +16,7 @@ module.exports = {
       "Request",
       "Response",
       "Headers",
+      "AbortController",
     ],
   },
   env: { browser: true, commonjs: true, es6: true },

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -8,6 +8,9 @@ module.exports = {
     "plugin:prettier/recommended",
     "prettier/react",
   ],
+  settings: {
+    polyfills: ["TextDecoder", "TextEncoder"],
+  },
   env: { browser: true, commonjs: true, es6: true },
   globals: {
     expect: true,

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -9,7 +9,14 @@ module.exports = {
     "prettier/react",
   ],
   settings: {
-    polyfills: ["TextDecoder", "TextEncoder"],
+    polyfills: [
+      "TextDecoder",
+      "TextEncoder",
+      "fetch",
+      "Request",
+      "Response",
+      "Headers",
+    ],
   },
   env: { browser: true, commonjs: true, es6: true },
   globals: {

--- a/client/configuration/webpack/obsoleteHTMLTemplate.html
+++ b/client/configuration/webpack/obsoleteHTMLTemplate.html
@@ -1,0 +1,81 @@
+<script>
+  var root = document.getElementById("root");
+  root.remove();
+  var portals = document.getElementsByClassName("bp3-portal");
+  for (var i = 0; i < portals.length; i += 1) {
+    portals[i].remove();
+  }
+</script>
+<div
+  style="
+    display: flex;
+    flex-direction: column;
+    width: 100vw;
+    height: 100vh;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+    background: #8080801a;
+    font-family: 'Roboto Condensed, sans serif';
+  "
+>
+  <img
+    src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png"
+    style="width: 320px;"
+  />
+  <div
+    style="
+      margin-top: 16px;
+      background: white;
+      width: 40vw;
+      border-radius: 4px;
+      padding: 24px 64px;
+      -webkit-box-shadow: 0px 0px 3px 2px rgba(0, 0, 0, 0.38);
+      -moz-box-shadow: 0px 0px 3px 2px rgba(0, 0, 0, 0.38);
+      box-shadow: 0px 0px 3px 2px rgba(0, 0, 0, 0.38);
+      max-width: 550px;
+    "
+  >
+    <div style="margin-bottom: 0; font-weight: bolder; font-size: 1.2em;">
+      Unsupported Browser
+    </div>
+    <div style="margin-top: 0;">
+      cellxgene is currently supported on the following browsers
+    </div>
+    <div
+      style="display: flex; justify-content: space-around; margin-top: 16px;"
+    >
+      <a
+        href="https://www.google.com/chrome/?hl=en%22"
+        aria-label="Download Google Chrome"
+      >
+        <img
+          src="https://assets.beta.meta.org/images/browsers/chrome.png"
+          style="width: 80px; height: 80px;"
+        />
+        <div>Chrome &gt; 60</div>
+      </a>
+      <a href="https://www.apple.com/safari/" aria-label="Download Safari">
+        <img
+          src="https://assets.beta.meta.org/images/browsers/safari.png"
+          style="width: 80px; height: 80px;"
+        />
+        <div>Safari ≥ 10.1</div>
+      </a>
+      <a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">
+        <img
+          src="https://assets.beta.meta.org/images/browsers/firefox.png"
+          style="width: 80px; height: 80px;"
+        />
+        <div>Firefox ≥ 60</div>
+      </a>
+      <a href="//www.microsoft.com/edge" aria-label="Download Edge">
+        <img
+          src="https://assets.beta.meta.org/images/browsers/edge.png"
+          style="width: 80px; height: 80px;"
+        />
+        <div>Edge ≥ 15</div>
+      </a>
+    </div>
+  </div>
+</div>

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -90,22 +90,22 @@ module.exports = {
         '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
         '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
         '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
-        "<div>" +
+        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
         '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
         "<div>Chrome &gt; 60</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
         '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
         "<div>Safari ≥ 10.1</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
         '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
         "<div>Firefox ≥ 60</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
         '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
         "<div>Edge ≥ 15</div>" +
-        "</div>" +
+        "</a>" +
         "</div>" +
         "</div>" +
         "</div>",

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -4,6 +4,7 @@ const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
+const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 const src = path.resolve("src");
 const fonts = path.resolve("src/fonts");
@@ -74,6 +75,7 @@ module.exports = {
       template: path.resolve("index.html"),
     }),
     new ObsoleteWebpackPlugin({
+      name: "obsolete",
       template:
         "<script>" +
         'var root = document.getElementById("root");' +
@@ -119,6 +121,9 @@ module.exports = {
       "process.env.CXG_SERVER_PORT": JSON.stringify(
         process.env.CXG_SERVER_PORT
       ),
+    }),
+    new ScriptExtHtmlWebpackPlugin({
+      async: "obsolete",
     }),
   ],
 };

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -24,8 +24,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: src,
+        test: /\.jsx?$/,
         loader: "babel-loader",
         options: babelOptions,
       },

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -1,4 +1,3 @@
-// jshint esversion: 6
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -85,17 +85,31 @@ module.exports = {
         "portals[i].remove();" +
         "}" +
         "</script>" +
+        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
+        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
+        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
+        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
+        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
+        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
         "<div>" +
-        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;">' +
-        "<h1> cellxgene </h1>" +
-        "<div> Unsupported Browser </div>" +
-        '<div style="margin-top: 16px;"> cellxgene is currently supported on the following browsers' +
-        '<div style="display: flex;justify-content: space-around;margin: auto 40vw;margin-top: 16px">' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"><div>Chrome &gt; 60</div></div>' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"><div>Safari &gt;= 10.1</div> </div>' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"><div>Firefox &gt;= 60</div> </div>' +
-        '<div><img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"><div>Edge &gt;= 15</div> </div>' +
-        "</div></div><div></div></div>",
+        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Chrome &gt; 60</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Safari ≥ 10.1</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Firefox ≥ 60</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Edge ≥ 15</div>" +
+        "</div>" +
+        "</div>" +
+        "</div>" +
+        "</div>",
       promptOnNonTargetBrowser: true,
     }),
     new FaviconsWebpackPlugin({

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -15,7 +15,7 @@ const babelOptions = require("../babel/babel.dev");
 module.exports = {
   mode: "development",
   devtool: "eval",
-  entry: ["./src/index"],
+  entry: ["whatwg-fetch", "./src/index"],
   output: {
     path: path.resolve("build"),
     pathinfo: true,

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -110,7 +110,7 @@ module.exports = {
         "</div>" +
         "</div>" +
         "</div>",
-      promptOnNonTargetBrowser: true,
+      promptOnNonTargetBrowser: false,
     }),
     new FaviconsWebpackPlugin({
       logo: "./favicon.png",

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -2,31 +2,23 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
-const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
-const src = path.resolve("src");
+const { merge } = require("webpack-merge");
+
+const sharedConfig = require("./webpack.config.shared");
+const babelOptions = require("../babel/babel.dev");
+
 const fonts = path.resolve("src/fonts");
 const nodeModules = path.resolve("node_modules");
 
-const babelOptions = require("../babel/babel.dev");
-
-module.exports = {
+const devConfig = {
   mode: "development",
   devtool: "eval",
-  entry: [
-    "core-js",
-    "regenerator-runtime/runtime",
-    "fastestsmallesttextencoderdecoder",
-    "whatwg-fetch",
-    "abort-controller/polyfill",
-    "./src/index",
-  ],
   output: {
-    path: path.resolve("build"),
     pathinfo: true,
     filename: "static/js/bundle.js",
-    publicPath: "/",
   },
   module: {
     rules: [
@@ -35,38 +27,6 @@ module.exports = {
         loader: "babel-loader",
         options: babelOptions,
       },
-      {
-        test: /\.css$/,
-        include: src,
-        exclude: [path.resolve(src, "index.css")],
-        loader: [
-          {
-            loader: "style-loader",
-          },
-          {
-            loader: "css-loader",
-            options: {
-              modules: {
-                localIdentName: "[name]__[local]___[hash:base64:5]",
-              },
-            },
-          },
-        ],
-      },
-      {
-        test: /index\.css$/,
-        include: [path.resolve(src, "index.css")],
-        loader: [
-          {
-            loader: "style-loader",
-          },
-          {
-            loader: "css-loader",
-          },
-        ],
-      },
-
-      { test: /\.json$/, include: [src, nodeModules], loader: "json-loader" },
       {
         test: /\.(jpg|png|gif|eot|svg|ttf|woff|woff2|otf)$/i,
         loader: "file-loader",
@@ -79,44 +39,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: path.resolve("index.html"),
-    }),
-    new ObsoleteWebpackPlugin({
-      name: "obsolete",
-      template:
-        "<script>" +
-        'var root = document.getElementById("root");' +
-        "root.remove();" +
-        'var portals = document.getElementsByClassName("bp3-portal");' +
-        "for(var i = 0; i < portals.length; i += 1) {" +
-        "portals[i].remove();" +
-        "}" +
-        "</script>" +
-        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
-        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
-        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
-        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
-        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
-        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
-        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Chrome &gt; 60</div>" +
-        "</a>" +
-        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Safari ≥ 10.1</div>" +
-        "</a>" +
-        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Firefox ≥ 60</div>" +
-        "</a>" +
-        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Edge ≥ 15</div>" +
-        "</a>" +
-        "</div>" +
-        "</div>" +
-        "</div>",
-      promptOnNonTargetBrowser: false,
     }),
     new FaviconsWebpackPlugin({
       logo: "./favicon.png",
@@ -133,6 +55,9 @@ module.exports = {
         },
       },
     }),
+    new MiniCssExtractPlugin({
+      filename: "static/[name].css",
+    }),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({
       __REACT_DEVTOOLS_GLOBAL_HOOK__: "({ isDisabled: true })",
@@ -147,3 +72,5 @@ module.exports = {
     }),
   ],
 };
+
+module.exports = merge(sharedConfig, devConfig);

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -3,6 +3,7 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
 
 const src = path.resolve("src");
 const fonts = path.resolve("src/fonts");
@@ -72,6 +73,25 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: path.resolve("index.html"),
+    }),
+    new ObsoleteWebpackPlugin({
+      template:
+        '<div class="outerContainer">' +
+        '<h1 class="purple"> Meta </h1>' +
+        '<div class="innerContainer">' +
+        '<div class="header"> Unsupported Browser </div>' +
+        '<div class="content"> Meta is currently supported on the following browsers' +
+        '<div class="supported-browsers purple">' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/chrome.png"/>' +
+        '<div class="version">Chrome > 60</div> </div>' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/safari.png"/>' +
+        '<div class="version">Safari >= 10.1</div> </div>' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/firefox.png"/>' +
+        '<div class="version">Firefox >= 60</div> </div>' +
+        '<div class="browser-type"><img src="https://assets.beta.meta.org/images/browsers/edge.png"/>' +
+        '<div class="version">Edge >= 15</div> </div>' +
+        "</div>",
+      promptOnNonTargetBrowser: true,
     }),
     new FaviconsWebpackPlugin({
       logo: "./favicon.png",

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -75,21 +75,25 @@ module.exports = {
     }),
     new ObsoleteWebpackPlugin({
       template:
-        '<div class="outerContainer">' +
-        '<h1 class="purple"> Meta </h1>' +
-        '<div class="innerContainer">' +
-        '<div class="header"> Unsupported Browser </div>' +
-        '<div class="content"> Meta is currently supported on the following browsers' +
-        '<div class="supported-browsers purple">' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/chrome.png"/>' +
-        '<div class="version">Chrome > 60</div> </div>' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/safari.png"/>' +
-        '<div class="version">Safari >= 10.1</div> </div>' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/firefox.png"/>' +
-        '<div class="version">Firefox >= 60</div> </div>' +
-        '<div class="browser-type"><img src="https://assets.beta.meta.org/images/browsers/edge.png"/>' +
-        '<div class="version">Edge >= 15</div> </div>' +
-        "</div>",
+        "<script>" +
+        'var root = document.getElementById("root");' +
+        "root.remove();" +
+        'var portals = document.getElementsByClassName("bp3-portal");' +
+        "for(var i = 0; i < portals.length; i += 1) {" +
+        "portals[i].remove();" +
+        "}" +
+        "</script>" +
+        "<div>" +
+        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;">' +
+        "<h1> cellxgene </h1>" +
+        "<div> Unsupported Browser </div>" +
+        '<div style="margin-top: 16px;"> cellxgene is currently supported on the following browsers' +
+        '<div style="display: flex;justify-content: space-around;margin: auto 40vw;margin-top: 16px">' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"><div>Chrome &gt; 60</div></div>' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"><div>Safari &gt;= 10.1</div> </div>' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"><div>Firefox &gt;= 60</div> </div>' +
+        '<div><img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"><div>Edge &gt;= 15</div> </div>' +
+        "</div></div><div></div></div>",
       promptOnNonTargetBrowser: true,
     }),
     new FaviconsWebpackPlugin({

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -15,7 +15,7 @@ const babelOptions = require("../babel/babel.dev");
 module.exports = {
   mode: "development",
   devtool: "eval",
-  entry: ["whatwg-fetch", "./src/index"],
+  entry: ["whatwg-fetch", "abort-controller/polyfill", "./src/index"],
   output: {
     path: path.resolve("build"),
     pathinfo: true,

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -15,7 +15,7 @@ module.exports = {
   mode: "development",
   devtool: "eval",
   entry: [
-    "core-js-stable",
+    "core-js",
     "regenerator-runtime/runtime",
     "fastestsmallesttextencoderdecoder",
     "whatwg-fetch",

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -14,7 +14,14 @@ const babelOptions = require("../babel/babel.dev");
 module.exports = {
   mode: "development",
   devtool: "eval",
-  entry: ["whatwg-fetch", "abort-controller/polyfill", "./src/index"],
+  entry: [
+    "core-js-stable",
+    "regenerator-runtime/runtime",
+    "fastestsmallesttextencoderdecoder",
+    "whatwg-fetch",
+    "abort-controller/polyfill",
+    "./src/index",
+  ],
   output: {
     path: path.resolve("build"),
     pathinfo: true,

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -107,6 +107,7 @@ module.exports = {
         '<div class="browser-type"><img src="https://assets.beta.meta.org/images/browsers/edge.png"/>' +
         '<div class="version">Edge >= 15</div> </div>' +
         "</div>",
+      promptOnNonTargetBrowser: true,
     }),
     new CleanWebpackPlugin({
       verbose: true,

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -1,40 +1,28 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
 const CleanCss = require("clean-css");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
-const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
-const CspHashPlugin = require("./cspHashPlugin");
-
-const src = path.resolve("src");
-const fonts = path.resolve("src/fonts");
-const nodeModules = path.resolve("node_modules");
+const { merge } = require("webpack-merge");
 
 const babelOptions = require("../babel/babel.prod");
 
-const publicPath = "/";
+const CspHashPlugin = require("./cspHashPlugin");
+const sharedConfig = require("./webpack.config.shared");
 
-module.exports = {
+const fonts = path.resolve("src/fonts");
+const nodeModules = path.resolve("node_modules");
+
+const prodConfig = {
   mode: "production",
   bail: true,
   cache: false,
-  entry: [
-    "core-js",
-    "regenerator-runtime/runtime",
-    "fastestsmallesttextencoderdecoder",
-    "whatwg-fetch",
-    "abort-controller/polyfill",
-    "./src/index",
-  ],
   output: {
     filename: "static/[name]-[contenthash].js",
-    path: path.resolve("build"),
-    publicPath,
   },
   optimization: {
     minimize: true,
@@ -54,34 +42,6 @@ module.exports = {
         options: babelOptions,
       },
       {
-        test: /\.css$/,
-        include: src,
-        exclude: [path.resolve(src, "index.css")],
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: "css-loader",
-            options: {
-              modules: {
-                localIdentName: "[name]__[local]___[hash:base64:5]",
-              },
-              importLoaders: 1,
-            },
-          },
-        ],
-      },
-      {
-        test: /index\.css$/,
-        include: [path.resolve(src, "index.css")],
-        use: [MiniCssExtractPlugin.loader, "css-loader"],
-      },
-      {
-        test: /\.json$/,
-        include: [src, nodeModules],
-        loader: "json-loader",
-        exclude: /manifest.json$/,
-      },
-      {
         test: /\.(jpg|png|gif|eot|svg|ttf|woff|woff2|otf)$/i,
         loader: "file-loader",
         include: [nodeModules, fonts],
@@ -95,44 +55,6 @@ module.exports = {
       template: path.resolve("index_template.html"),
       decodeEntities: false,
       minify: false,
-    }),
-    new ObsoleteWebpackPlugin({
-      name: "obsolete",
-      template:
-        "<script>" +
-        'var root = document.getElementById("root");' +
-        "root.remove();" +
-        'var portals = document.getElementsByClassName("bp3-portal");' +
-        "for(var i = 0; i < portals.length; i += 1) {" +
-        "portals[i].remove();" +
-        "}" +
-        "</script>" +
-        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
-        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
-        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
-        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
-        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
-        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
-        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Chrome &gt; 60</div>" +
-        "</a>" +
-        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Safari ≥ 10.1</div>" +
-        "</a>" +
-        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Firefox ≥ 60</div>" +
-        "</a>" +
-        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Edge ≥ 15</div>" +
-        "</a>" +
-        "</div>" +
-        "</div>" +
-        "</div>",
-      promptOnNonTargetBrowser: false,
     }),
     new CleanWebpackPlugin({
       verbose: true,
@@ -160,12 +82,11 @@ module.exports = {
     new CspHashPlugin({
       filename: "csp-hashes.json",
     }),
-    new ScriptExtHtmlWebpackPlugin({
-      async: "obsolete",
-    }),
   ],
   performance: {
     maxEntrypointSize: 2000000,
     maxAssetSize: 2000000,
   },
 };
+
+module.exports = merge(sharedConfig, prodConfig);

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -24,7 +24,7 @@ module.exports = {
   bail: true,
   cache: false,
   entry: [
-    "core-js-stable",
+    "core-js",
     "regenerator-runtime/runtime",
     "fastestsmallesttextencoderdecoder",
     "whatwg-fetch",

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -23,7 +23,14 @@ module.exports = {
   mode: "production",
   bail: true,
   cache: false,
-  entry: ["whatwg-fetch", "abort-controller/polyfill", "./src/index"],
+  entry: [
+    "core-js-stable",
+    "regenerator-runtime/runtime",
+    "fastestsmallesttextencoderdecoder",
+    "whatwg-fetch",
+    "abort-controller/polyfill",
+    "./src/index",
+  ],
   output: {
     filename: "static/[name]-[contenthash].js",
     path: path.resolve("build"),

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -101,17 +101,31 @@ module.exports = {
         "portals[i].remove();" +
         "}" +
         "</script>" +
+        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
+        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
+        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
+        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
+        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
+        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
         "<div>" +
-        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;">' +
-        "<h1> cellxgene </h1>" +
-        "<div> Unsupported Browser </div>" +
-        '<div style="margin-top: 16px;"> cellxgene is currently supported on the following browsers' +
-        '<div style="display: flex;justify-content: space-around;margin: auto 40vw;margin-top: 16px">' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"><div>Chrome &gt; 60</div></div>' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"><div>Safari &gt;= 10.1</div> </div>' +
-        '<div> <img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"><div>Firefox &gt;= 60</div> </div>' +
-        '<div><img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"><div>Edge &gt;= 15</div> </div>' +
-        "</div></div><div></div></div>",
+        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Chrome &gt; 60</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Safari ≥ 10.1</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Firefox ≥ 60</div>" +
+        "</div>" +
+        "<div>" +
+        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Edge ≥ 15</div>" +
+        "</div>" +
+        "</div>" +
+        "</div>" +
+        "</div>",
       promptOnNonTargetBrowser: true,
     }),
     new CleanWebpackPlugin({

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -91,21 +91,25 @@ module.exports = {
     }),
     new ObsoleteWebpackPlugin({
       template:
-        '<div class="outerContainer">' +
-        '<h1 class="purple"> Meta </h1>' +
-        '<div class="innerContainer">' +
-        '<div class="header"> Unsupported Browser </div>' +
-        '<div class="content"> Meta is currently supported on the following browsers' +
-        '<div class="supported-browsers purple">' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/chrome.png"/>' +
-        '<div class="version">Chrome > 60</div> </div>' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/safari.png"/>' +
-        '<div class="version">Safari >= 10.1</div> </div>' +
-        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/firefox.png"/>' +
-        '<div class="version">Firefox >= 60</div> </div>' +
-        '<div class="browser-type"><img src="https://assets.beta.meta.org/images/browsers/edge.png"/>' +
-        '<div class="version">Edge >= 15</div> </div>' +
-        "</div>",
+        "<script>" +
+        'var root = document.getElementById("root");' +
+        "root.remove();" +
+        'var portals = document.getElementsByClassName("bp3-portal");' +
+        "for(var i = 0; i < portals.length; i += 1) {" +
+        "portals[i].remove();" +
+        "}" +
+        "</script>" +
+        "<div>" +
+        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;">' +
+        "<h1> cellxgene </h1>" +
+        "<div> Unsupported Browser </div>" +
+        '<div style="margin-top: 16px;"> cellxgene is currently supported on the following browsers' +
+        '<div style="display: flex;justify-content: space-around;margin: auto 40vw;margin-top: 16px">' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"><div>Chrome &gt; 60</div></div>' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"><div>Safari &gt;= 10.1</div> </div>' +
+        '<div> <img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"><div>Firefox &gt;= 60</div> </div>' +
+        '<div><img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"><div>Edge &gt;= 15</div> </div>' +
+        "</div></div><div></div></div>",
       promptOnNonTargetBrowser: true,
     }),
     new CleanWebpackPlugin({

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -8,6 +8,7 @@ const TerserJSPlugin = require("terser-webpack-plugin");
 const CleanCss = require("clean-css");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
+const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 const CspHashPlugin = require("./cspHashPlugin");
 
@@ -90,6 +91,7 @@ module.exports = {
       minify: false,
     }),
     new ObsoleteWebpackPlugin({
+      name: "obsolete",
       template:
         "<script>" +
         'var root = document.getElementById("root");' +
@@ -137,6 +139,9 @@ module.exports = {
     }),
     new CspHashPlugin({
       filename: "csp-hashes.json",
+    }),
+    new ScriptExtHtmlWebpackPlugin({
+      async: "obsolete",
     }),
   ],
   performance: {

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -106,26 +106,26 @@ module.exports = {
         '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
         '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
         '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
-        "<div>" +
+        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
         '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
         "<div>Chrome &gt; 60</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
         '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
         "<div>Safari ≥ 10.1</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
         '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
         "<div>Firefox ≥ 60</div>" +
-        "</div>" +
-        "<div>" +
+        "</a>" +
+        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
         '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
         "<div>Edge ≥ 15</div>" +
-        "</div>" +
+        "</a>" +
         "</div>" +
         "</div>" +
         "</div>",
-      promptOnNonTargetBrowser: true,
+      promptOnNonTargetBrowser: false,
     }),
     new CleanWebpackPlugin({
       verbose: true,

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -1,4 +1,3 @@
-// jshint esversion: 6
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -24,7 +23,7 @@ module.exports = {
   mode: "production",
   bail: true,
   cache: false,
-  entry: ["./src/index.js"],
+  entry: ["whatwg-fetch", "abort-controller/polyfill", "./src/index"],
   output: {
     filename: "static/[name]-[contenthash].js",
     path: path.resolve("build"),

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -7,6 +7,7 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
 const CleanCss = require("clean-css");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
 
 const CspHashPlugin = require("./cspHashPlugin");
 
@@ -88,6 +89,24 @@ module.exports = {
       template: path.resolve("index_template.html"),
       decodeEntities: false,
       minify: false,
+    }),
+    new ObsoleteWebpackPlugin({
+      template:
+        '<div class="outerContainer">' +
+        '<h1 class="purple"> Meta </h1>' +
+        '<div class="innerContainer">' +
+        '<div class="header"> Unsupported Browser </div>' +
+        '<div class="content"> Meta is currently supported on the following browsers' +
+        '<div class="supported-browsers purple">' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/chrome.png"/>' +
+        '<div class="version">Chrome > 60</div> </div>' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/safari.png"/>' +
+        '<div class="version">Safari >= 10.1</div> </div>' +
+        '<div class="browser-type"> <img src="https://assets.beta.meta.org/images/browsers/firefox.png"/>' +
+        '<div class="version">Firefox >= 60</div> </div>' +
+        '<div class="browser-type"><img src="https://assets.beta.meta.org/images/browsers/edge.png"/>' +
+        '<div class="version">Edge >= 15</div> </div>' +
+        "</div>",
     }),
     new CleanWebpackPlugin({
       verbose: true,

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -42,8 +42,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: src,
+        test: /\.jsx?$/,
         loader: "babel-loader",
         options: babelOptions,
       },

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,0 +1,99 @@
+const path = require("path");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
+const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+
+const src = path.resolve("src");
+const nodeModules = path.resolve("node_modules");
+
+const publicPath = "/";
+
+module.exports = {
+  entry: [
+    "core-js",
+    "regenerator-runtime/runtime",
+    "fastestsmallesttextencoderdecoder",
+    "whatwg-fetch",
+    "abort-controller/polyfill",
+    "./src/index",
+  ],
+  output: {
+    path: path.resolve("build"),
+    publicPath,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        include: src,
+        exclude: [path.resolve(src, "index.css")],
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: "css-loader",
+            options: {
+              modules: {
+                localIdentName: "[name]__[local]___[hash:base64:5]",
+              },
+              importLoaders: 1,
+            },
+          },
+        ],
+      },
+      {
+        test: /index\.css$/,
+        include: [path.resolve(src, "index.css")],
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+      {
+        test: /\.json$/,
+        include: [src, nodeModules],
+        loader: "json-loader",
+        exclude: /manifest.json$/,
+      },
+    ],
+  },
+  plugins: [
+    new ObsoleteWebpackPlugin({
+      name: "obsolete",
+      template:
+        "<script>" +
+        'var root = document.getElementById("root");' +
+        "root.remove();" +
+        'var portals = document.getElementsByClassName("bp3-portal");' +
+        "for(var i = 0; i < portals.length; i += 1) {" +
+        "portals[i].remove();" +
+        "}" +
+        "</script>" +
+        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
+        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
+        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
+        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
+        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
+        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
+        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
+        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Chrome &gt; 60</div>" +
+        "</a>" +
+        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
+        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Safari ≥ 10.1</div>" +
+        "</a>" +
+        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
+        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Firefox ≥ 60</div>" +
+        "</a>" +
+        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
+        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
+        "<div>Edge ≥ 15</div>" +
+        "</a>" +
+        "</div>" +
+        "</div>" +
+        "</div>",
+      promptOnNonTargetBrowser: false,
+    }),
+    new ScriptExtHtmlWebpackPlugin({
+      async: "obsolete",
+    }),
+  ],
+};

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -9,10 +9,12 @@ const nodeModules = path.resolve("node_modules");
 
 const publicPath = "/";
 
-const obsoleteHTMLTemplate = fs.readFileSync(
+const rawObsoleteHTMLTemplate = fs.readFileSync(
   `${__dirname}/obsoleteHTMLTemplate.html`,
   "utf8"
 );
+
+const obsoleteHTMLTemplate = rawObsoleteHTMLTemplate.replace(/'/g, '"');
 
 module.exports = {
   entry: [

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require("fs");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
@@ -7,6 +8,11 @@ const src = path.resolve("src");
 const nodeModules = path.resolve("node_modules");
 
 const publicPath = "/";
+
+const obsoleteHTMLTemplate = fs.readFileSync(
+  `${__dirname}/obsoleteHTMLTemplate.html`,
+  "utf8"
+);
 
 module.exports = {
   entry: [
@@ -56,40 +62,7 @@ module.exports = {
   plugins: [
     new ObsoleteWebpackPlugin({
       name: "obsolete",
-      template:
-        "<script>" +
-        'var root = document.getElementById("root");' +
-        "root.remove();" +
-        'var portals = document.getElementsByClassName("bp3-portal");' +
-        "for(var i = 0; i < portals.length; i += 1) {" +
-        "portals[i].remove();" +
-        "}" +
-        "</script>" +
-        '<div style="display: flex;flex-direction: column;width: 100vw;height: 100vh;text-align: center;justify-content: center;align-items: center;background: #8080801a;font-family: &quot;Roboto Condensed, sans serif&quot;;">' +
-        '<img src="https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/docs/cellxgene-logo.png" style="width: 320px;"/>' +
-        '<div style="margin-top: 16px;background: white;width: 40vw;border-radius: 4px;padding: 24px 64px;-webkit-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);-moz-box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);box-shadow: 0px 0px 3px 2px rgba(0,0,0,0.38);max-width: 550px;">' +
-        '<div style="margin-bottom: 0;font-weight: bolder;font-size: 1.2em;"> Unsupported Browser </div>' +
-        '<div style="margin-top: 0;">cellxgene is currently supported on the following browsers</div>' +
-        '<div style="display: flex;justify-content: space-around;margin-top: 16px">' +
-        '<a href="https://www.google.com/chrome/?hl=en%22" aria-label="Download Google Chrome">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/chrome.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Chrome &gt; 60</div>" +
-        "</a>" +
-        '<a href="https://www.apple.com/safari/" aria-label="Download Safari">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/safari.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Safari ≥ 10.1</div>" +
-        "</a>" +
-        '<a href="https://www.mozilla.com/firefox/" aria-label="Download Firefox">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/firefox.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Firefox ≥ 60</div>" +
-        "</a>" +
-        '<a href="//www.microsoft.com/edge" aria-label="Download Edge">' +
-        '<img src="https://assets.beta.meta.org/images/browsers/edge.png" style="width: 80px;height: 80px;"/>' +
-        "<div>Edge ≥ 15</div>" +
-        "</a>" +
-        "</div>" +
-        "</div>" +
-        "</div>",
+      template: obsoleteHTMLTemplate,
       promptOnNonTargetBrowser: false,
     }),
     new ScriptExtHtmlWebpackPlugin({

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -34,7 +34,8 @@
         box-sizing: border-box;
       }
     </style>
-    <script src="https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0" nomodule="" type="text/javascript"></script>
+    <!-- We know some versions of edge will bypass nomodule but still don't have TextEncoder, not ideal since this means ALL browser will have to load the script -->
+    <script src="https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0" type="text/javascript"></script>
 
   </head>
   <body>

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -34,9 +34,6 @@
         box-sizing: border-box;
       }
     </style>
-    <!-- We know some versions of edge will bypass nomodule but still don't have TextEncoder, not ideal since this means ALL browser will have to load the script -->
-    <script src="https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0" type="text/javascript"></script>
-
   </head>
   <body>
     <script type="text/javascript">

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -34,6 +34,8 @@
         box-sizing: border-box;
       }
     </style>
+    <script src="https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0" nomodule="" type="text/javascript"></script>
+
   </head>
   <body>
     <script type="text/javascript">

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17298,6 +17298,14 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "script-ext-html-webpack-plugin": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.4.tgz",
+      "integrity": "sha512-7MAv3paAMfh9y2Rg+yQKp9jEGC5cEcmdge4EomRqri10qoczmliYEVPVNz0/5e9QQ202e05qDll9B8zZlY9N1g==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -20352,6 +20360,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11404,93 +11404,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
-    "html-loader": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz",
-      "integrity": "sha512-zwLbEgy+i7sgIYTlxI9M7jwkn29IvdsV6f1y7a2aLv/w8l1RigVk0PFijBZLLFsdi2gvL8sf2VJhTjLlfnK8sA==",
-      "dev": true,
-      "requires": {
-        "html-minifier-terser": "^5.0.5",
-        "htmlparser2": "^4.1.0",
-        "loader-utils": "^2.0.0",
-        "parse-srcset": "^1.0.2",
-        "schema-utils": "^2.6.5"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
-        },
-        "domhandler": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-          "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1"
-          }
-        },
-        "domutils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
-          "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "^0.2.1",
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0"
-          }
-        },
-        "htmlparser2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0",
-            "domutils": "^2.0.0",
-            "entities": "^2.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        }
-      }
-    },
     "html-minifier-terser": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.5.tgz",
@@ -15243,12 +15156,6 @@
       "requires": {
         "pngjs": "^3.2.0"
       }
-    },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-      "dev": true
     },
     "parse5": {
       "version": "5.1.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11404,6 +11404,93 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
+    "html-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz",
+      "integrity": "sha512-zwLbEgy+i7sgIYTlxI9M7jwkn29IvdsV6f1y7a2aLv/w8l1RigVk0PFijBZLLFsdi2gvL8sf2VJhTjLlfnK8sA==",
+      "dev": true,
+      "requires": {
+        "html-minifier-terser": "^5.0.5",
+        "htmlparser2": "^4.1.0",
+        "loader-utils": "^2.0.0",
+        "parse-srcset": "^1.0.2",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+          "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
+          "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^0.2.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "html-minifier-terser": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.5.tgz",
@@ -15156,6 +15243,12 @@
       "requires": {
         "pngjs": "^3.2.0"
       }
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
+      "dev": true
     },
     "parse5": {
       "version": "5.1.0",
@@ -20348,6 +20441,35 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.0.9.tgz",
+      "integrity": "sha512-P4teh6O26xIDPugOGX61wPxaeP918QOMjmzhu54zTVcLtOS28ffPWtnv+ilt3wscwBUCL2WNMnh97XkrKqt9Fw==",
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "dependencies": {
+        "clone-deep": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+          "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+          "requires": {
+            "is-plain-object": "^2.0.4",
+            "kind-of": "^6.0.2",
+            "shallow-clone": "^3.0.0"
+          }
+        },
+        "shallow-clone": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+          "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+          "requires": {
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -20503,6 +20625,11 @@
           }
         }
       }
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4077,6 +4077,14 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -7735,10 +7743,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -10076,6 +10083,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "favicons": {
       "version": "5.5.0",
@@ -16521,9 +16533,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -19543,6 +19555,14 @@
         "minimist": "^1.2.0",
         "request": "^2.88.0",
         "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "wait-port": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17189,6 +17189,14 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "script-ext-html-webpack-plugin": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.4.tgz",
+      "integrity": "sha512-7MAv3paAMfh9y2Rg+yQKp9jEGC5cEcmdge4EomRqri10qoczmliYEVPVNz0/5e9QQ202e05qDll9B8zZlY9N1g==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4069,6 +4069,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+      "integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/runtime-corejs3": {
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz",
@@ -14767,6 +14777,26 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      }
+    },
+    "obsolete-web": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/obsolete-web/-/obsolete-web-0.5.6.tgz",
+      "integrity": "sha512-rrs7kSJxOVFvvY7wuCfjg/ngXbO6q1m7Llq30RaN9WYIDH1zAoA1xWLIY39D3e5967g/NeCasI/o8ojhMMkaaA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs2": "^7.0.0"
+      }
+    },
+    "obsolete-webpack-plugin": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/obsolete-webpack-plugin/-/obsolete-webpack-plugin-0.5.6.tgz",
+      "integrity": "sha512-oKlRW4ycxJfF/mojtpGuQwaP+J4JwIgjFuFnMgURB6AaKxAVaRwiO0oWhqYjwwJ5LxhVybOl+CnGAlhHBHBdEQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "obsolete-web": "^0.5.6",
+        "webpack-sources": "^1.0.0"
       }
     },
     "omggif": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6075,6 +6075,12 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "ast-metadata-inferer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
+      "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -6961,6 +6967,12 @@
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
       }
+    },
+    "caniuse-db": {
+      "version": "1.0.30001107",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001107.tgz",
+      "integrity": "sha512-ffbV17yvEamsNm4N4dDDHdj147tWwdKw+mGyeOmvQcnu+gu455xUg8degvUOCB+fIAm7Rv3gXVn7XlTiYKymMQ==",
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001039",
@@ -9462,6 +9474,94 @@
           "requires": {
             "find-up": "^2.1.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-compat": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.8.0.tgz",
+      "integrity": "sha512-5CuWUSZXZkXLCQJBriEpndn/YWrvggDSHTpRJq++kR8GVcsWbTdp8Eh+nBA7JlrNi7ZJ/+kniOVXmn3bpnxuRA==",
+      "dev": true,
+      "requires": {
+        "ast-metadata-inferer": "^0.4.0",
+        "browserslist": "^4.12.2",
+        "caniuse-db": "^1.0.30001090",
+        "core-js": "^3.6.5",
+        "find-up": "^4.1.0",
+        "lodash.memoize": "4.1.2",
+        "mdn-browser-compat-data": "^1.0.28",
+        "semver": "7.3.2"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+          "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001093",
+            "electron-to-chromium": "^1.3.488",
+            "escalade": "^3.0.1",
+            "node-releases": "^1.1.58"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001107",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz",
+          "integrity": "sha512-86rCH+G8onCmdN4VZzJet5uPELII59cUzDphko3thQFgAQG1RNa+sVLDoALIhRYmflo5iSIzWY3vu1XTWtNMQQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.510",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.510.tgz",
+          "integrity": "sha512-sLtGB0znXdmo6lM8hy5wTVo+fLqvIuO8hEpgc0DvPmFZqvBu/WB7AarEwhxVKjf3rVbws/rC8Xf+AlsOb36lJQ==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "node-releases": {
+          "version": "1.1.60",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+          "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+          "dev": true
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
         }
       }
     },
@@ -13908,6 +14008,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdn-browser-compat-data": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.32.tgz",
+      "integrity": "sha512-dqIstpk2ysqa6XcI8/fz1yB6bOKrIs61RIEE00Dj7+WHReXlGrCIiol1NBPsLUNE+HC/4y2f8va8vy1WsiCkAQ==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -17187,14 +17296,6 @@
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
-      }
-    },
-    "script-ext-html-webpack-plugin": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.4.tgz",
-      "integrity": "sha512-7MAv3paAMfh9y2Rg+yQKp9jEGC5cEcmdge4EomRqri10qoczmliYEVPVNz0/5e9QQ202e05qDll9B8zZlY9N1g==",
-      "requires": {
-        "debug": "^4.1.1"
       }
     },
     "semver": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5704,6 +5704,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -9832,6 +9840,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.7",
     "regl": "^1.6.1",
+    "script-ext-html-webpack-plugin": "^2.1.4",
     "tinyqueue": "^2.0.3"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -96,6 +96,7 @@
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-loader": "^3.0.4",
+    "eslint-plugin-compat": "^3.8.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.22.0",

--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,8 @@
     "regenerator-runtime": "^0.13.7",
     "regl": "^1.6.1",
     "script-ext-html-webpack-plugin": "^2.1.4",
-    "tinyqueue": "^2.0.3"
+    "tinyqueue": "^2.0.3",
+    "whatwg-fetch": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",

--- a/client/package.json
+++ b/client/package.json
@@ -67,6 +67,7 @@
     "regl": "^1.6.1",
     "script-ext-html-webpack-plugin": "^2.1.4",
     "tinyqueue": "^2.0.3",
+    "webpack-merge": "^5.0.9",
     "whatwg-fetch": "^3.2.0"
   },
   "devDependencies": {
@@ -112,6 +113,7 @@
     "express": "^4.17.1",
     "favicons-webpack-plugin": "^3.0.1",
     "file-loader": "^6.0.0",
+    "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
     "husky": "^4.2.5",
     "jest": "^26.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,13 @@
   "resolutions": {
     "eslint-scope": "3.7.1"
   },
+  "browserslist": [
+    "Chrome > 60",
+    "Safari >= 10.1",
+    "iOS >= 10.3",
+    "Firefox >= 60",
+    "Edge >= 15"
+  ],
   "dependencies": {
     "@blueprintjs/core": "^3.30.0",
     "@blueprintjs/icons": "^3.19.0",
@@ -107,6 +114,7 @@
     "json-loader": "^0.5.7",
     "lint-staged": "^10.2.11",
     "mini-css-extract-plugin": "^0.9.0",
+    "obsolete-webpack-plugin": "^0.5.6",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "prettier": "^2.0.5",
     "puppeteer": "^3.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "@blueprintjs/core": "^3.30.0",
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.5",
+    "abort-controller": "^3.0.0",
     "core-js": "^3.6.5",
     "d3": "^4.10.0",
     "d3-scale-chromatic": "^1.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -113,7 +113,6 @@
     "express": "^4.17.1",
     "favicons-webpack-plugin": "^3.0.1",
     "file-loader": "^6.0.0",
-    "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
     "husky": "^4.2.5",
     "jest": "^26.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -40,8 +40,10 @@
     "@blueprintjs/core": "^3.30.0",
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.5",
+    "core-js": "^3.6.5",
     "d3": "^4.10.0",
     "d3-scale-chromatic": "^1.5.0",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "flatbuffers": "^1.11.0",
     "fuzzysort": "^1.1.4",
     "gl-mat4": "^1.2.0",
@@ -59,6 +61,7 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "regenerator-runtime": "^0.13.7",
     "regl": "^1.6.1",
     "tinyqueue": "^2.0.3"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,8 @@
     "Safari >= 10.1",
     "iOS >= 10.3",
     "Firefox >= 60",
-    "Edge >= 15"
+    "Edge >= 15",
+    "not Explorer > 0"
   ],
   "dependencies": {
     "@blueprintjs/core": "^3.30.0",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,8 +1,13 @@
 // jshint esversion: 6
+import "core-js/stable";
+import "regenerator-runtime/runtime";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { FocusStyleManager } from "@blueprintjs/core";
+// https://github.com/anonyco/FastestSmallestTextEncoderDecoder
+// Only supports UTF-8
+import "fastestsmallesttextencoderdecoder";
 
 import "./index.css";
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,13 +1,7 @@
-// jshint esversion: 6
-import "core-js/stable";
-import "regenerator-runtime/runtime";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { FocusStyleManager } from "@blueprintjs/core";
-// https://github.com/anonyco/FastestSmallestTextEncoderDecoder
-// Only supports UTF-8
-import "fastestsmallesttextencoderdecoder";
 
 import "./index.css";
 

--- a/client/src/util/stateManager/matrix.js
+++ b/client/src/util/stateManager/matrix.js
@@ -170,11 +170,11 @@ export function encodeMatrixFBS(df) {
 
 function promoteTypedArray(o) {
   /*
-  Decide what internal data type to use for the data returned from 
+  Decide what internal data type to use for the data returned from
   the server.
 
   TODO - future optimization: not all int32/uint32 data series require
-  promotion to float64.  We COULD simply look at the data to decide. 
+  promotion to float64.  We COULD simply look at the data to decide.
   */
   if (isFpTypedArray(o) || Array.isArray(o)) return o;
 


### PR DESCRIPTION
This PR adds transparency and explicit support for our supported browsers.

This PR includes the following changes:
* `README.md`
  * Add section on supported browsers
* `client/package.json`
  * addition of `browserslist` attribute
  * dependencies and dev-dependencies additons
* `client/configuration/babel/babel.dev.js` + `client/configuration/babel/babel.prod.js`
  * switch from `modern-browsers` to `@babel/preset-env` for browerslists support on polyfill
* EDIT(8/3): `client/configuration/webpack/webpack.config.dev.js` + `client/configuration/webpack/webpack.config.prod.js` + `client/configuration/webpack/webpack.config.shared.js`
  * Add`script-ext-html-webpack-plugin` for async bundle loading support
  * Add polyfills to entry
  * Expand babel transpiling to node_modules and `.jsx` files to guarantee browser support
  * Add `obsolete-webpack-plugin` to display message on supported browsers
  * EDIT(8/3): Created shared config to consolidate shared aspects of webpack config in a single config
* EDIT(8/3): `client/configuration/webpack/obsoleteHTMLTemplate.html`
  *  Created HTML file to hold obsolete html template
* `client/configuration/eslint/eslint.js`
  * Extend compat plugin to ensure no unsupported API usage
  * List included polyfills

 
--- 
Closes #1477, Closes #1479

