### PR TITLE
use czi-sci-single-cell-eng github user/access token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - name: repository dispatch
         run: |
-          curl -XPOST -u mdunitz:${{secrets.SCINFRA_TOKEN}} -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/chanzuckerberg/single-cell-infra/dispatches --data '{"event_type": "cellxgene-hook"}'
+          curl -XPOST -u czi-sci-single-cell-eng:${{secrets.SCI_GITHUB_TOKEN}} -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/chanzuckerberg/single-cell-infra/dispatches --data '{"event_type": "cellxgene-hook"}'


### PR DESCRIPTION
## Need
- Create a single cell github user so access token isnt linked to a particular employee 

## Approach
- infra created czi-sci-single-cell-eng github user account, password and login info is in 1Pass vault controlled by @mweiden 
- Access token saved as secret for github actions under SCI_GITHUB_TOKEN

Fulfills https://app.zenhub.com/workspaces/corpora-5e2a191dad828d52cc78b028/issues/chanzuckerberg/cellxgene/1431