### PR TITLE
oauth support, add the token in a configuration specified cookie

### DIFF
--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -393,6 +393,7 @@ class ServerConfig(BaseConfig):
     def __init__(self, app_config, default_config):
         dictval_cases = [
             ("app", "csp_directives"),
+            ("authentication", "params_oauth", "cookie"),
             ("adaptor", "cxg_adaptor", "tiledb_ctx"),
             ("multi_dataset", "dataroot"),
         ]
@@ -417,6 +418,8 @@ class ServerConfig(BaseConfig):
             self.authentication__params_oauth__client_secret = dc["authentication"]["params_oauth"]["client_secret"]
             self.authentication__params_oauth__callback_base_url = \
                 dc["authentication"]["params_oauth"]["callback_base_url"]
+            self.authentication__params_oauth__session_cookie = dc["authentication"]["params_oauth"]["session_cookie"]
+            self.authentication__params_oauth__cookie = dc["authentication"]["params_oauth"]["cookie"]
 
             self.multi_dataset__dataroot = dc["multi_dataset"]["dataroot"]
             self.multi_dataset__index = dc["multi_dataset"]["index"]
@@ -531,6 +534,12 @@ class ServerConfig(BaseConfig):
         self.check_attr("authentication__params_oauth__client_id", ptypes)
         self.check_attr("authentication__params_oauth__client_secret", ptypes)
         self.check_attr("authentication__params_oauth__callback_base_url", (type(None), str))
+        self.check_attr("authentication__params_oauth__session_cookie", bool)
+
+        if self.authentication__params_oauth__session_cookie:
+            self.check_attr("authentication__params_oauth__cookie", (type(None), dict))
+        else:
+            self.check_attr("authentication__params_oauth__cookie", dict)
         #   secret key: first, from CXG_OAUTH_CLIENT_SECRET environment variable
         #   second, from config file
         self.authentication__params__oauth__client_secret = os.environ.get(

--- a/server/common/default_config.py
+++ b/server/common/default_config.py
@@ -33,6 +33,15 @@ server:
        # A value of None, indicates the client and server are on the localhost.  http://localhost:<port> will be used.
        callback_base_url: null
 
+       # if true, the jwt containing the id_token is stored in a session cookie
+       session_cookie:  true
+
+       # if session_cookie is false, then a regular cookie will be used.  In that case
+       # the cookie will be defined by a dictionary of parameters.
+       # The keys of the dictionary match the parameters of the flask set_cookie api
+       # (https://flask.palletsprojects.com/en/1.1.x/api/), and with the same meaning.
+       # legal keys:  key, max_age, expires, path, domain, secure, httponly, and samesite.
+       cookie:  null
 
   multi_dataset:
     # If dataroot is set, then cellxgene may serve multiple datasets.  This parameter is not


### PR DESCRIPTION
Previously, the id token was stored in the session token.
Now, it can be placed in a different cookie with different properties.