### PR TITLE
Swap using href to using origin+pathname to avoid errors with including any query parameters from being passed in.

### DIFF
--- a/client/index_template.html
+++ b/client/index_template.html
@@ -39,7 +39,7 @@
     <script type="text/javascript">
       window.CELLXGENE = {};
       window.CELLXGENE.API = {
-        prefix: window.location.href + "api/",
+        prefix: `${location.origin}${location.pathname}api/`,
         version: "v0.2/",
       };
     </script>


### PR DESCRIPTION
Fixes #1699 