### PR TITLE
Properly generate hash and provide how-to

### DIFF
--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -101,7 +101,7 @@ class WSGIServer(Server):
 
         # It is _very_ difficult to generate the correct hash manually,
         # consider forcing CSP to fail on the local server by intercepting the response via Requestly
-        # this should print the failing script's hash to console
+        # this should print the failing script's hash to console. See more here: https://github.com/chanzuckerberg/cellxgene/pull/1745
         obsolete_browser_script_hash = ["'sha256-/rmgOi/skq9MpiZxPv6lPb1PNSN+Uf4NaUHO/IjyfwM='"]
         csp = {
             "default-src": ["'self'"],

--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -106,7 +106,7 @@ class WSGIServer(Server):
         csp = {
             "default-src": ["'self'"],
             "connect-src": ["'self'"],
-            "script-src": ["'self'", "'unsafe-eval'", "'unsafe-inline'"]
+            "script-src": ["'self'", "'unsafe-eval'"]
             + obsolete_browser_script_hash + script_hashes,
             "style-src": ["'self'", "'unsafe-inline'"],
             "img-src": ["'self'", "https://cellxgene.cziscience.com", "data:"],

--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -98,7 +98,11 @@ class WSGIServer(Server):
         server_config = app_config.server_config
         # This hash should be in sync with the script within
         # `client/configuration/webpack/obsoleteHTMLTemplate.html`
-        obsolete_browser_script_hash = ["'sha256-wl4OlniJEAFM1/VNFG/LBDQyPRkO7P/5kfQWf3+fPWE='"]
+
+        # It is _very_ difficult to generate the correct hash manually,
+        # consider forcing CSP to fail on the local server by intercepting the response via Requestly
+        # this should print the failing script's hash to console
+        obsolete_browser_script_hash = ["'sha256-/rmgOi/skq9MpiZxPv6lPb1PNSN+Uf4NaUHO/IjyfwM='"]
         csp = {
             "default-src": ["'self'"],
             "connect-src": ["'self'"],


### PR DESCRIPTION
We did it! @tihuan and I were finally able to correctly generate the CSP hash after _a lot_ of tinkering.  I've provided a short how to above the hash, but I'll also write it here for posterity.

Here's how to generate and test a CSP hash without the need to make test deployments:
* Start up local cellxgene
* Install (requestly)[https://app.requestly.io/rules]
* Generate a new rule that modifies the header
* Set it to `Add` `Response` Header: `Content-Security-Policy` `Url` `Contains` `localhost`
* Go to prod and copy the CSP header value
 ```
default-src 'self'; connect-src 'self' sentry.prod.si.czi.technology; script-src 'self' 'unsafe-eval' 'sha256-/rmgOi/skq9MpiZxPv6lPb1PNSN+Uf4NaUHO/IjyfwM=' 'sha256-aFVmiBiEgb+j7fokN003RXrmU/RNz49S53HhxV5fz5k=' 'sha256-VaCbcpE7DqBJBipfdVmR6ctn0HR5HE1em2j+7NuCu2U=' 'sha256-w4uT8Jm+8zCdP4dnxhaN3LSKvtIq4ASVrheKTlJ0UMs=' www.google-analytics.com browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://cellxgene.cziscience.com data: www.google-analytics.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; upgrade-insecure-requests
```
* Paste that into the header value, save and reload the client
* You should see the missing hash in the console
![image](https://user-images.githubusercontent.com/8716829/90196529-e540c100-dd80-11ea-89f3-5de327177cb0.png)
* Viola!

Huge h/t to Timmy for helping me along the way and giving me some awesome resources :)