### PR TITLE
Fix frontend mishandling of null userinfo

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -43,7 +43,7 @@ async function configFetch(dispatch) {
 
 async function userInfoFetch(dispatch) {
   return fetchJson("userinfo").then((response) => {
-    const userinfo = { ...response.userinfo };
+    const userinfo = { ...(response ? response.userinfo : null) };
     dispatch({
       type: "userinfo load complete",
       userinfo,

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -43,7 +43,7 @@ async function configFetch(dispatch) {
 
 async function userInfoFetch(dispatch) {
   return fetchJson("userinfo").then((response) => {
-    const userinfo = { ...(response ? response.userinfo : null) };
+    const { userinfo } = response || {};
     dispatch({
       type: "userinfo load complete",
       userinfo,

--- a/server/auth/auth_oauth.py
+++ b/server/auth/auth_oauth.py
@@ -29,7 +29,9 @@ class Tokens:
         self.id_token = id_token
         self.refresh_token = refresh_token
         self.expires_at = expires_at
-        if not (access_token and id_token and refresh_token and expires_at):
+
+        # expires_at may be None after a token refresh, and so it is not checked here
+        if not (access_token and id_token and refresh_token):
             raise KeyError(str(self.__dict__))
 
 


### PR DESCRIPTION
If the authentication is disabled, the userinfo endpoint returns null.
This case needs to be handled.

 #1780