### PR TITLE
Correctly check if mini histograms shouldn't be rendered

### DIFF
--- a/client/src/components/categorical/value/index.js
+++ b/client/src/components/categorical/value/index.js
@@ -439,7 +439,9 @@ class CategoryValue extends React.Component {
 
     if (
       !this.shouldRenderStackedBarOrHistogram ||
-      !AnnotationsHelpers.isContinuousAnnotation(schema, colorAccessor)
+      // This function returns true on categorical annotations(when stacked bar should not render),
+      //  in cases where the colorAccessor is a gene this function will return undefined since genes do not live on the schema
+      AnnotationsHelpers.isCategoricalAnnotation(schema, colorAccessor) === true
     ) {
       return null;
     }

--- a/client/src/components/categorical/value/index.js
+++ b/client/src/components/categorical/value/index.js
@@ -81,7 +81,7 @@ class CategoryValue extends React.Component {
   get shouldRenderStackedBarOrHistogram() {
     const { colorAccessor, isColorBy, annotations } = this.props;
 
-    return colorAccessor && !isColorBy && !annotations.isEditingLabelName;
+    return !!colorAccessor && !isColorBy && !annotations.isEditingLabelName;
   }
 
   handleDeleteValue = () => {


### PR DESCRIPTION
Previously mini histogram rendering would abort if 
```javascript
AnnotationsHelpers.isContinuousAnnotation(schema, colorAccessor)  
 ```

returned a falsey value.  Since this function parsed the schema for `colorAccessor`, it would correctly return `undefined` when `colorAccessor` was a gene name, and incorrectly abort the render since `undefined` is falsey.

This PR swaps out our call of `isContinousAnnotation` for a check if `isCategoricalAnnotation` strictly equal to `true`

---

Fixes #1808 