### PR TITLE
Pass in the previous crossfilter when creating a new annomatrix for a switched embedding in order to retain the previous selection of cells.

### DIFF
--- a/client/src/actions/embedding.js
+++ b/client/src/actions/embedding.js
@@ -30,8 +30,7 @@ export const layoutChoiceAction = (newLayoutChoice) => async (
   On layout choice, make sure we have selected all on the previous layout, AND the new
   layout.
   */
-  const { annoMatrix: prevAnnoMatrix } = getState();
-  const { obsCrossfilter: prevCrossfilter } = getState();
+  const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevCrossfilter } = getState();
   const [annoMatrix, obsCrossfilter] = await _switchEmbedding(
     prevAnnoMatrix,
     prevCrossfilter,

--- a/client/src/actions/embedding.js
+++ b/client/src/actions/embedding.js
@@ -5,14 +5,14 @@ action creators related to embeddings choice
 import { AnnoMatrixObsCrossfilter } from "../annoMatrix";
 import { _setEmbeddingSubset } from "../util/stateManager/viewStackHelpers";
 
-export async function _switchEmbedding(prevAnnoMatrix, newEmbeddingName) {
+export async function _switchEmbedding(prevAnnoMatrix, prevCrossfilter, newEmbeddingName) {
   /*
   DRY helper used by this and reembedding action creators
   */
   const base = prevAnnoMatrix.base();
   const embeddingDf = await base.fetch("emb", newEmbeddingName);
   const annoMatrix = _setEmbeddingSubset(prevAnnoMatrix, embeddingDf);
-  const obsCrossfilter = await new AnnoMatrixObsCrossfilter(annoMatrix).select(
+  const obsCrossfilter = await new AnnoMatrixObsCrossfilter(annoMatrix, prevCrossfilter.obsCrossfilter).select(
     "emb",
     newEmbeddingName,
     {
@@ -31,8 +31,10 @@ export const layoutChoiceAction = (newLayoutChoice) => async (
   layout.
   */
   const { annoMatrix: prevAnnoMatrix } = getState();
+  const { obsCrossfilter: prevCrossfilter } = getState();
   const [annoMatrix, obsCrossfilter] = await _switchEmbedding(
     prevAnnoMatrix,
+    prevCrossfilter,
     newLayoutChoice
   );
   dispatch({


### PR DESCRIPTION
![Screen Shot 2020-09-11 at 6 31 38 PM](https://user-images.githubusercontent.com/4887796/92984158-0fa79c00-f45d-11ea-9f88-3179f076ef91.png)
![Screen Shot 2020-09-11 at 6 31 17 PM](https://user-images.githubusercontent.com/4887796/92984159-1209f600-f45d-11ea-8e17-c77d27710bdd.png)
