### PR TITLE
app config bug fix:

### DIFF
--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -103,7 +103,7 @@ class AppConfig(object):
             # first create and initialize the dataroot with the default config
             self.add_dataroot_config(key, **config["dataset"])
             # then apply the per dataset configuration
-            self.dataroot_config[key].update_from_config(dataroot_config, "per_dataset_config")
+            self.dataroot_config[key].update_from_config(dataroot_config, f"per_dataset_config__{key}")
 
         self.is_complete = False
 

--- a/server/common/app_config.py
+++ b/server/common/app_config.py
@@ -100,7 +100,10 @@ class AppConfig(object):
 
         per_dataset_config = config.get("per_dataset_config", {})
         for key, dataroot_config in per_dataset_config.items():
-            self.add_dataroot_config(key, **dataroot_config)
+            # first create and initialize the dataroot with the default config
+            self.add_dataroot_config(key, **config["dataset"])
+            # then apply the per dataset configuration
+            self.dataroot_config[key].update_from_config(dataroot_config, "per_dataset_config")
 
         self.is_complete = False
 


### PR DESCRIPTION
When reading a config file that included per_dataset_config,
the dataroot specializations were applied, but not the default config.
This PR fixes that and also includes a test for this case.