### PR TITLE
dont cache schema

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -233,7 +233,8 @@ class DatasetResource(Resource):
 
 
 class SchemaAPI(DatasetResource):
-    @cache_control(public=True, max_age=ONE_WEEK)
+    # TODO @mdunitz separate dataset schema and user schema
+    @cache_control(no_store=True)
     @rest_get_data_adaptor
     def get(self, data_adaptor):
         return common_rest.schema_get(data_adaptor)


### PR DESCRIPTION
## Need
- to return a schema containing recently created user annotations when a user logs out and then logs back in (without requiring a hard refresh)

## Approach
- dont cache the schema route

## Future Todos
- separate the user schema and the dataset schema so we can cache the dataset schema