### PR TITLE
Handle case where new drag starts while existing lasso is not finished

### DIFF
--- a/client/src/components/graph/setupLasso.js
+++ b/client/src/components/graph/setupLasso.js
@@ -10,6 +10,7 @@ const Lasso = () => {
     let lassoPolygon;
     let lassoPath;
     let closePath;
+    let lassoCompleted;
 
     const polygonToPath = (polygon) =>
       `M${polygon.map((d) => d.join(",")).join("L")}`;
@@ -25,8 +26,18 @@ const Lasso = () => {
       lassoPolygon = [d3.mouse(svg.node())]; // current x y of mouse within element
 
       if (lassoPath) {
+        // If the existing path wasn't completed
+        if (!lassoCompleted) {
+          // cancel the existing lasso
+          handleCancel();
+          // Don't continue with current drag start
+          return;
+        }
+
         lassoPath.remove();
       }
+      // We're starting a new drag
+      lassoCompleted = false;
 
       lassoPath = g
         .append("path")
@@ -67,25 +78,33 @@ const Lasso = () => {
       }
     };
 
+    const handleCancel = () => {
+      lassoPath.remove();
+      closePath = closePath?.remove();
+      lassoPath = null;
+      lassoPolygon = null;
+      closePath = null;
+      dispatch.call("cancel");
+    };
+
     const handleDragEnd = () => {
       // remove the close path
       closePath.remove();
       closePath = null;
 
-      // succesfully closed
+      // successfully closed
       if (
         distance(lassoPolygon[0], lassoPolygon[lassoPolygon.length - 1]) <
         closeDistance
       ) {
+        lassoCompleted = true;
+
         lassoPath.attr("d", `${polygonToPath(lassoPolygon)}Z`);
         dispatch.call("end", lasso, lassoPolygon);
 
         // otherwise cancel
       } else {
-        lassoPath.remove();
-        lassoPath = null;
-        lassoPolygon = null;
-        dispatch.call("cancel");
+        handleCancel();
       }
     };
 

--- a/client/src/components/graph/setupLasso.js
+++ b/client/src/components/graph/setupLasso.js
@@ -10,7 +10,7 @@ const Lasso = () => {
     let lassoPolygon;
     let lassoPath;
     let closePath;
-    let lassoCompleted;
+    let lassoInProgress;
 
     const polygonToPath = (polygon) =>
       `M${polygon.map((d) => d.join(",")).join("L")}`;
@@ -26,8 +26,8 @@ const Lasso = () => {
       lassoPolygon = [d3.mouse(svg.node())]; // current x y of mouse within element
 
       if (lassoPath) {
-        // If the existing path wasn't completed
-        if (!lassoCompleted) {
+        // If the existing path is in progress
+        if (lassoInProgress) {
           // cancel the existing lasso
           handleCancel();
           // Don't continue with current drag start
@@ -37,7 +37,7 @@ const Lasso = () => {
         lassoPath.remove();
       }
       // We're starting a new drag
-      lassoCompleted = false;
+      lassoInProgress = true;
 
       lassoPath = g
         .append("path")
@@ -97,7 +97,7 @@ const Lasso = () => {
         distance(lassoPolygon[0], lassoPolygon[lassoPolygon.length - 1]) <
         closeDistance
       ) {
-        lassoCompleted = true;
+        lassoInProgress = false;
 
         lassoPath.attr("d", `${polygonToPath(lassoPolygon)}Z`);
         dispatch.call("end", lasso, lassoPolygon);


### PR DESCRIPTION
This PR will eliminate the errors thrown when a user attempts to use multiple fingers to lasso cells on a touch device.

This is done by checking to see if there are an in progress lasso when a new lasso is trying to spawn.  If this check is hit it will terminate the in progress lasso as well as the lasso spawning.

QA:

1. Find local IP of machine that will run server 
1. Run server using flag `--host 0.0.0.0`
1. Tweak frontend to make calls to machine on local network using IP found
   1. Change `_API.prefix` global
1. Run frontend dev server
1. Navigate to frontend on touch device using local IP and port
1. Open up browser logs on touch device
   1. Navigate to `chrome://inspect` on iOS chrome
1. Try to lasso with multiple fingers