### PR TITLE
skip user annos when building dataset metadata

### DIFF
--- a/client/src/components/infoDrawer/infoDrawer.js
+++ b/client/src/components/infoDrawer/infoDrawer.js
@@ -38,6 +38,8 @@ class InfoDrawer extends PureComponent {
     const singleValueCategories = (
       await Promise.all(nonUserAnnoCategories)
     ).reduce((acc, categoryData, i) => {
+      // Actually check to see if it is null(user anno)
+      if (!categoryData) return acc;
       const catName = allCategoryNames[i];
 
       const column = categoryData.icol(0);


### PR DESCRIPTION
User annos were marked but not skipped when building the dataset metadata mapping.

QA:
1. Create a user anno
1. Open dataset info drawer

---

Closes #1870 