### PR TITLE
add and check system arg to state auth type

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -35,7 +35,7 @@ smoke-test:
 	start_server_and_test \
 		'CXG_OPTIONS="--config-file $(CXG_CONFIG)" $(MAKE) start-server' \
 		$(CXG_SERVER_PORT) \
-		'CXG_URL_BASE="http://localhost:$(CXG_SERVER_PORT)" npm run e2e -- --verbose false'
+		'CXG_URL_BASE="http://localhost:$(CXG_SERVER_PORT)" CXG_AUTH_TYPE="test" npm run e2e -- --verbose false'
 
 # start an instance of cellxgene and run the end-to-end annotations tests
 .PHONY: smoke-test-annotations

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -523,7 +523,9 @@ test("lasso moves after pan", async () => {
 });
 
 const describeIfCalledByMakeFileTarget =
-  process.env.CXG_AUTH_TYPE === "test" ? describe : describe.skip;
+  process.env.CXG_AUTH_TYPE?.toLowerCase() === "test"
+    ? describe
+    : describe.skip;
 
 describeIfCalledByMakeFileTarget("auth buttons", () => {
   test("login then logout", async () => {

--- a/client/__tests__/e2e/e2e.test.js
+++ b/client/__tests__/e2e/e2e.test.js
@@ -522,7 +522,10 @@ test("lasso moves after pan", async () => {
   expect(panCount).toBe(initialCount);
 });
 
-describe("auth buttons", () => {
+const describeIfCalledByMakeFileTarget =
+  process.env.CXG_AUTH_TYPE === "test" ? describe : describe.skip;
+
+describeIfCalledByMakeFileTarget("auth buttons", () => {
   test("login then logout", async () => {
     await goToPage(appUrlBase);
     await clickOnUntil("log-in", async () => {


### PR DESCRIPTION
Turns out that our e2e tests are called in more places than just our GitHub actions. 

PR checks if `CXG_AUTH_TYPE ` is test (case-insensitive) to conditionally smoke test the auth buttons.