### PR TITLE
Remove Continuous vars with 1 value from histogram, add to info drawer

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -650,7 +650,8 @@ class HistogramBrush extends React.PureComponent {
       Number.isNaN(summary.min) ||
       Number.isNaN(summary.max);
 
-    const OK2Render = !summary.categorical && !nonFiniteExtent;
+    const OK2Render =
+      !summary.categorical && !nonFiniteExtent && !isSingleValue;
 
     return {
       histogram,

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -450,6 +450,7 @@ const Histogram = ({
     isScatterplotYYaccessor: state.controls.scatterplotYYaccessor === field,
     continuousSelectionRange: state.continuousSelection[myName],
     isColorAccessor: state.colors.colorAccessor === field,
+    singleContinuousValues: state.singleContinuousValue.singleContinuousValues,
   };
 })
 class HistogramBrush extends React.PureComponent {
@@ -608,7 +609,7 @@ class HistogramBrush extends React.PureComponent {
   };
 
   fetchAsyncProps = async () => {
-    const { annoMatrix, field, dispatch } = this.props;
+    const { annoMatrix, field, dispatch, singleContinuousValues } = this.props;
     const { isClipped } = annoMatrix;
 
     const query = this.createQuery();
@@ -620,7 +621,10 @@ class HistogramBrush extends React.PureComponent {
     const summary = column.summarize();
     const range = [summary.min, summary.max];
 
-    if (summary.min === summary.max && !isClipped) {
+    if (
+      (summary.min === summary.max && !isClipped) ||
+      singleContinuousValues.has(field)
+    ) {
       dispatch({
         type: "add single continuous value",
         field,

--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -611,20 +611,24 @@ class HistogramBrush extends React.PureComponent {
   fetchAsyncProps = async () => {
     const { annoMatrix, field, dispatch, singleContinuousValues } = this.props;
     const { isClipped } = annoMatrix;
-
+    if (singleContinuousValues.has(field)) {
+      return {
+        histogram: undefined,
+        range: undefined,
+        unclippedRange: undefined,
+        unclippedRangeColor: globals.blue,
+        isSingleValue: true,
+        OK2Render: false,
+      };
+    }
     const query = this.createQuery();
     const df = await annoMatrix.fetch(...query);
     const column = df.icol(0);
 
-    // if we are clipped, fetch both our value and our unclipped value,
-    // as we need the absolute min/max range, not just the clipped min/max.
     const summary = column.summarize();
     const range = [summary.min, summary.max];
 
-    if (
-      (summary.min === summary.max && !isClipped) ||
-      singleContinuousValues.has(field)
-    ) {
+    if (summary.min === summary.max && !isClipped) {
       dispatch({
         type: "add single continuous value",
         field,
@@ -641,7 +645,8 @@ class HistogramBrush extends React.PureComponent {
     }
 
     const isSingleValue = summary.min === summary.max;
-
+    // if we are clipped, fetch both our value and our unclipped value,
+    // as we need the absolute min/max range, not just the clipped min/max.
     let unclippedRange = [...range];
     if (isClipped) {
       const parent = await annoMatrix.viewOf.fetch(...query);

--- a/client/src/components/infoDrawer/infoDrawer.js
+++ b/client/src/components/infoDrawer/infoDrawer.js
@@ -16,6 +16,67 @@ import { selectableCategoryNames } from "../../util/stateManager/controlsHelpers
   };
 })
 class InfoDrawer extends PureComponent {
+  static watchAsync(props, prevProps) {
+    return !shallowEqual(props.watchProps, prevProps.watchProps);
+  }
+
+  fetchAsyncProps = async (props) => {
+    const { schema } = props.watchProps;
+    const { annoMatrix } = this.props;
+
+    const allCategoryNames = selectableCategoryNames(schema).sort();
+    const obsIndex = schema.annotations.obs.index;
+    const allContinuousNames = schema.annotations.obs.columns
+      .filter((col) => col.type === "int32" || col.type === "float32")
+      .filter((col) => col.name !== obsIndex)
+      .filter((col) => !col.writable) // skip user annotations - they will be treated as categorical
+      .map((col) => col.name);
+    const annoContinous = allContinuousNames.map((catName) => {
+      return annoMatrix.fetch("obs", catName);
+    });
+    const singleValueContinous = (await Promise.all(annoContinous)).reduce(
+      (acc, continuousData, i) => {
+        if (!continuousData) return acc;
+        const column = continuousData.icol(0);
+        const catName = allContinuousNames[i];
+        const summary = column.summarize();
+        if (summary.min === summary.max) {
+          acc.set(catName, summary.min);
+        }
+        return acc;
+      },
+      new Map()
+    );
+    const nonUserAnnoCategories = allCategoryNames.map((catName) => {
+      const isUserAnno = schema?.annotations?.obsByName[catName]?.writable;
+      if (!isUserAnno) return annoMatrix.fetch("obs", catName);
+      return null;
+    });
+    const singleValueCategories = (
+      await Promise.all(nonUserAnnoCategories)
+    ).reduce((acc, categoryData, i) => {
+      // Actually check to see if it is null(user anno)
+      if (!categoryData) return acc;
+      const catName = allCategoryNames[i];
+
+      const column = categoryData.icol(0);
+      const colSchema = schema.annotations.obsByName[catName];
+
+      const categorySummary = createCategorySummaryFromDfCol(column, colSchema);
+
+      const { numCategoryValues } = categorySummary;
+      //  Add to the array if the category has only one value
+      if (numCategoryValues === 1) {
+        acc.set(catName, categorySummary.allCategoryValues[0]);
+      }
+      return acc;
+    }, new Map());
+    for (const [key, value] of singleValueContinous.entries()) {
+      singleValueCategories.set(key, value);
+    }
+    return { singleValueCategories };
+  };
+
   handleClose = () => {
     const { dispatch } = this.props;
 

--- a/client/src/components/infoDrawer/infoFormat.js
+++ b/client/src/components/infoDrawer/infoFormat.js
@@ -85,13 +85,13 @@ const ONTOLOGY_KEY = "ontology_term_id";
 const CAT_WIDTH = "30%";
 const VAL_WIDTH = "35%";
 // Render list of metadata attributes found in categorical field
-const renderSingleValueCategories = (singleValueCategories) => {
-  if (singleValueCategories.size === 0) return null;
+const renderSingleValues = (singleValues) => {
+  if (singleValues.size === 0) return null;
   return (
     <>
       <H3>Dataset Metadata</H3>
       <UL>
-        {Array.from(singleValueCategories).reduce((elems, pair) => {
+        {Array.from(singleValues).reduce((elems, pair) => {
           const [category, value] = pair;
           // If the value is empty skip it
           if (!value) return elems;
@@ -168,7 +168,7 @@ const renderLinks = (projectLinks, aboutURL) => {
 };
 
 const InfoFormat = React.memo(
-  ({ datasetTitle, singleValueCategories, aboutURL, dataPortalProps = {} }) => {
+  ({ datasetTitle, allSingleValues, aboutURL, dataPortalProps = {} }) => {
     if (dataPortalProps.version?.["corpora_schema_version"] !== "1.0.0") {
       dataPortalProps = {};
     }
@@ -190,7 +190,7 @@ const InfoFormat = React.memo(
         {renderDOILink("DOI", doi)}
         {renderDOILink("Preprint DOI", preprintDOI)}
         {renderOrganism(organism)}
-        {renderSingleValueCategories(singleValueCategories)}
+        {renderSingleValues(allSingleValues)}
         {renderLinks(projectLinks, aboutURL)}
       </div>
     );

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -21,7 +21,7 @@ import centroidLabels from "./centroidLabels";
 import pointDialation from "./pointDilation";
 import { reembedController } from "./reembed";
 import { gcMiddleware as annoMatrixGC } from "../annoMatrix";
-
+import singleContinuousValue from "./singleContinuousValue";
 import undoableConfig from "./undoableConfig";
 
 const Reducer = undoable(
@@ -32,6 +32,7 @@ const Reducer = undoable(
     ["ontology", ontology],
     ["annotations", annotations],
     ["layoutChoice", layoutChoice],
+    ["singleContinuousValue", singleContinuousValue],
     ["categoricalSelection", categoricalSelection],
     ["continuousSelection", continuousSelection],
     ["graphSelection", graphSelection],

--- a/client/src/reducers/singleContinuousValue.js
+++ b/client/src/reducers/singleContinuousValue.js
@@ -1,0 +1,14 @@
+const initialState = {
+  singleContinuousValues: new Map(),
+};
+const singleContinuousValue = (state = initialState, action) => {
+  switch (action.type) {
+    case "add single continuous value":
+      state.singleContinuousValues.set(action.field, action.value);
+      return state;
+    default:
+      return state;
+  }
+};
+
+export default singleContinuousValue;


### PR DESCRIPTION
## Need
- If an observation is an int type but it only has one value it shouldnt appear in a histogram

## Approach
- check if min/max match, if they match display in the infodrawer instead

Note that timepoint now appears in the info drawer rather than as a histogram

<img width="355" alt="Screen Shot 2020-10-12 at 18 41 43" src="https://user-images.githubusercontent.com/7864111/95799692-12dfb300-0cbb-11eb-8d70-5a7c3723619c.png">
<img width="849" alt="Screen Shot 2020-10-12 at 18 41 25" src="https://user-images.githubusercontent.com/7864111/95799695-1410e000-0cbb-11eb-92b9-56648c069f92.png">
