### PR TITLE
fix accidental state error

### DIFF
--- a/client/src/components/infoDrawer/infoDrawer.js
+++ b/client/src/components/infoDrawer/infoDrawer.js
@@ -7,12 +7,11 @@ import { selectableCategoryNames } from "../../util/stateManager/controlsHelpers
 
 @connect((state) => {
   return {
-    annoMatrix: state.annoMatrix,
     schema: state.annoMatrix.schema,
     datasetTitle: state.config?.displayNames?.dataset ?? "",
     aboutURL: state.config?.links?.["about-dataset"],
     isOpen: state.controls.datasetDrawer,
-    dataPortalProps: state.config?.["corpora_props"] ?? {},
+    dataPortalProps: state.config?.["corpora_props"],
   };
 })
 class InfoDrawer extends PureComponent {
@@ -54,7 +53,7 @@ class InfoDrawer extends PureComponent {
             datasetTitle,
             aboutURL,
             singleValueCategories,
-            dataPortalProps,
+            dataPortalProps: dataPortalProps ?? {},
           }}
         />
       </Drawer>


### PR DESCRIPTION
The InfoDrawer was unnecessarily rendering on any prop change scan due to a misuse of the nullish coalescing operator.  This change causes the drawer to only re-render when its props have actually changed.