### PR TITLE
update graph GPU buffers only when necessary

### DIFF
--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -730,14 +730,25 @@ class Graph extends React.Component {
     );
   });
 
-  updateReglAndRender(asyncProps) {
+  updateReglAndRender(asyncProps, prevAsyncProps) {
     const { positions, colors, flags } = asyncProps;
     this.cachedAsyncProps = asyncProps;
     const { pointBuffer, colorBuffer, flagBuffer } = this.state;
-    pointBuffer({ data: positions, dimension: 2 });
-    colorBuffer({ data: colors, dimension: 3 });
-    flagBuffer({ data: flags, dimension: 1 });
-    this.renderCanvas();
+    let needToRenderCanvas = false;
+
+    if (positions !== prevAsyncProps?.positions) {
+      pointBuffer({ data: positions, dimension: 2 });
+      needToRenderCanvas = true;
+    }
+    if (colors !== prevAsyncProps?.colors) {
+      colorBuffer({ data: colors, dimension: 3 });
+      needToRenderCanvas = true;
+    }
+    if (flags !== prevAsyncProps?.flags) {
+      flagBuffer({ data: flags, dimension: 1 });
+      needToRenderCanvas = true;
+    }
+    if (needToRenderCanvas) this.renderCanvas();
   }
 
   updateColorTable(colors, colorDf) {
@@ -906,7 +917,7 @@ class Graph extends React.Component {
           <Async.Fulfilled>
             {(asyncProps) => {
               if (regl && !shallowEqual(asyncProps, this.cachedAsyncProps)) {
-                this.updateReglAndRender(asyncProps);
+                this.updateReglAndRender(asyncProps, this.cachedAsyncProps);
               }
               return null;
             }}


### PR DESCRIPTION
The main graph component updates all three GPU buffers (position, colors, flags) when any one of these buffers changes. Most commonly, the app interaction model changes only one at a time (eg, selection changes only flags, color-by changes only color, etc).  For large datasets, this unnecessary data copying can cause a very significant performance hit.

This change simply adds guards to only perform the buffer update when the data has changed.