### PR TITLE
fix corpora schema version check 

### DIFF
--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.js
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.js
@@ -13,7 +13,7 @@ const DATASET_TITLE_FONT_SIZE = 14;
 @connect((state) => {
   const { corpora_props: corporaProps } = state.config;
   const correctVersion =
-    corporaProps?.version?.["corpora_schema_version"] !== "1.0.0";
+    corporaProps?.version?.["corpora_schema_version"] === "1.0.0";
   return {
     datasetTitle: state.config?.displayNames?.dataset ?? "",
     libraryVersions: state.config?.["library_versions"],


### PR DESCRIPTION
Inverted the schema version check so that we check that it IS 1.0.0.

![image](https://user-images.githubusercontent.com/8716829/98184898-5c897b00-1ec0-11eb-89f7-c293dfbe8439.png)
