### PR TITLE
Convert HGNC ids to their symbol

### DIFF
--- a/server/converters/schema/gene_symbol.py
+++ b/server/converters/schema/gene_symbol.py
@@ -109,6 +109,9 @@ class HGNCSymbolChecker:
                 if record[field] is not np.nan:
                     for symbol in record[field].split("|"):
                         yield format_symbol(symbol)[0]
+            # Sometimes something like HGNC:1234 appears in datasets, which we
+            # want to fix as well.
+            yield record["hgnc_id"]
 
         hgnc_records = pd.read_csv(hgnc_dataset_path, sep="\t", header=0, low_memory=False).to_dict("records")
 

--- a/server/test/unit/converters/schema/test_gene_symbol.py
+++ b/server/test/unit/converters/schema/test_gene_symbol.py
@@ -41,6 +41,11 @@ class TestHGNCSymbolChecker(unittest.TestCase):
         self.assertEqual(self.hgnc_checker.upgrade_symbol("NOTASYMBOL"), "NOTASYMBOL")
         self.assertEqual(self.hgnc_checker.upgrade_symbol("notasymbol"), "notasymbol")
 
+        # Upgrade HGNC ids unless you can't find it
+        self.assertEqual(self.hgnc_checker.upgrade_symbol("HGNC:286"), "ADRB2")
+        self.assertEqual(self.hgnc_checker.upgrade_symbol("HGNC:4812"), "HAP1")
+        self.assertEqual(self.hgnc_checker.upgrade_symbol("HGNC:123456"), "HGNC:123456")
+
     def test_check_symbol(self):
         self.assertEqual(self.hgnc_checker.check_symbol("SEPT1"), gene_symbol.SymbolStatus.UPGRADABLE)
         self.assertEqual(self.hgnc_checker.check_symbol("DIFF6"), gene_symbol.SymbolStatus.AMBIGUOUS)


### PR DESCRIPTION
There are entries in some var indexes like HGNC:18790. We'd like to convert that to its symbol, NSG1.