### PR TITLE
thuang-compress-annotation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15483,8 +15483,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -54,6 +54,7 @@
     "is-number": "^7.0.0",
     "lodash": "^4.17.20",
     "memoize-one": "^5.1.1",
+    "pako": "^1.0.11",
     "react": "^16.13.1",
     "react-async": "^10.0.1",
     "react-dom": "^16.13.1",

--- a/client/src/actions/annotation.js
+++ b/client/src/actions/annotation.js
@@ -2,6 +2,7 @@
 Action creators for user annotation
 */
 import _ from "lodash";
+import pako from "pako";
 import * as globals from "../globals";
 import { MatrixFBS, AnnotationsHelpers } from "../util/stateManager";
 
@@ -153,7 +154,7 @@ export const annotationCreateLabelInCategory = (
   assignSelected
 ) => async (dispatch, getState) => {
   /*
-  Add a new label to a user-defined category.  If assignSelected is true, assign 
+  Add a new label to a user-defined category.  If assignSelected is true, assign
   the label to all currently selected cells.
   */
   const {
@@ -347,6 +348,7 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
 
   const df = await annoMatrix.fetch("obs", writableAnnotations(annoMatrix));
   const matrix = MatrixFBS.encodeMatrixFBS(df);
+  const compressedMatrix = pako.deflate(matrix);
   try {
     const queryString =
       !dataCollectionNameIsReadOnly && !!dataCollectionName
@@ -358,7 +360,7 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
       `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
       {
         method: "PUT",
-        body: matrix,
+        body: compressedMatrix,
         headers: new Headers({
           "Content-Type": "application/octet-stream",
         }),

--- a/server/common/rest.py
+++ b/server/common/rest.py
@@ -161,11 +161,7 @@ def annotations_put_fbs_helper(data_adaptor, fbs):
 
 
 def inflate(data):
-    # https://docs.python.org/3/library/zlib.html#zlib.decompressobj
-    decompress = zlib.decompressobj()
-    decompressed_data = decompress.decompress(data)
-    decompressed_data += decompress.flush()
-    return decompressed_data
+    return zlib.decompress(data)
 
 
 def annotations_obs_put(request, data_adaptor):

--- a/server/test/unit/common/test_api.py
+++ b/server/test/unit/common/test_api.py
@@ -1,6 +1,7 @@
 import shutil
 import time
 import unittest
+import zlib
 from http import HTTPStatus
 
 import pandas as pd
@@ -343,7 +344,7 @@ class EndPointsAnnotations(EndPoints):
         url = f"{self.URL_BASE}{endpoint}?{query}"
         n_rows = self.data.get_shape()[0]
         fbs = make_fbs({"cat_A": pd.Series(["label_A"] * n_rows, dtype="category")})
-        result = self.session.put(url, data=fbs)
+        result = self.session.put(url, data=zlib.compress(fbs))
         self.assertEqual(result.status_code, HTTPStatus.OK)
         self.assertEqual(result.headers["Content-Type"], "application/json")
         self.assertEqual(result.json(), {"status": "OK"})


### PR DESCRIPTION
This PR aims to compress FE's annotation request before sending it over the wire to BE

Through an informal experiment, the compression is able to reduce the request's content length by 98% (51x compression)

FE uses [pako](https://github.com/nodeca/pako) to compress the matrix, which is a high speed zlib port to Javascript. And BE already has `zlib` in Python, so no extra package imported there

PTAL and see if this compression causes any weird regression 🙏 Thanks all!

![demo2](https://user-images.githubusercontent.com/6309723/99326760-5cc53700-282d-11eb-8d2a-1a64156204d2.gif)
