### PR TITLE
Use sparse=True for from_pandas

### DIFF
--- a/server/common/annotations/hosted_tiledb.py
+++ b/server/common/annotations/hosted_tiledb.py
@@ -144,7 +144,7 @@ class AnnotationsHostedTileDB(Annotations):
 
             for col in df:
                 df[col] = df[col].astype(get_dtype_of_array(df[col]))
-            tiledb.from_pandas(uri, df)
+            tiledb.from_pandas(uri, df, sparse=True)
         else:
             uri = ""
 


### PR DESCRIPTION
Fixes test failures when using TileDB-Py 0.7.2, due to change in the default array type for `from_pandas`.