### PR TITLE
add exponential backoff to annotation put fetches

### DIFF
--- a/client/src/actions/annotation.js
+++ b/client/src/actions/annotation.js
@@ -358,6 +358,7 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
       ? `?annotation-collection-name=${encodeURIComponent(dataCollectionName)}`
       : "";
   const { response, inProgress, error } = exponentialBackoffFetch(
+    annoMatrix,
     `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
     {
       method: "PUT",

--- a/client/src/actions/annotation.js
+++ b/client/src/actions/annotation.js
@@ -325,15 +325,12 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
   const state = getState();
   const { annotations, autosave } = state;
   const { dataCollectionNameIsReadOnly, dataCollectionName } = annotations;
-  const {
-    lastSavedAnnoMatrix,
-    saveInProgress,
-    exponentialBackoffFetch,
-  } = autosave;
+  const { lastSavedAnnoMatrix, exponentialBackoffFetch } = autosave;
 
   const annoMatrix = state.annoMatrix.base();
 
-  if (saveInProgress || annoMatrix === lastSavedAnnoMatrix) return;
+  if (annoMatrix === lastSavedAnnoMatrix) return;
+
   if (!needToSaveObsAnnotations(annoMatrix, lastSavedAnnoMatrix)) {
     dispatch({
       type: "writable obs annotations - save complete",
@@ -357,6 +354,7 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
     !dataCollectionNameIsReadOnly && !!dataCollectionName
       ? `?annotation-collection-name=${encodeURIComponent(dataCollectionName)}`
       : "";
+
   try {
     const response = await exponentialBackoffFetch(
       annoMatrix,
@@ -368,8 +366,13 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
           "Content-Type": "application/octet-stream",
         }),
         credentials: "include",
-      }
+      },
+      // DEBUG
+      // DEBUG
+      // DEBUG
+      Math.floor(Math.random() * 100)
     );
+
     if (response.ok) {
       dispatch({
         type: "writable obs annotations - save complete",

--- a/client/src/actions/annotation.js
+++ b/client/src/actions/annotation.js
@@ -357,38 +357,36 @@ export const saveObsAnnotationsAction = () => async (dispatch, getState) => {
     !dataCollectionNameIsReadOnly && !!dataCollectionName
       ? `?annotation-collection-name=${encodeURIComponent(dataCollectionName)}`
       : "";
-  const { response, inProgress, error } = exponentialBackoffFetch(
-    annoMatrix,
-    `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
-    {
-      method: "PUT",
-      body: compressedMatrix,
-      headers: new Headers({
-        "Content-Type": "application/octet-stream",
-      }),
-      credentials: "include",
+  try {
+    const response = await exponentialBackoffFetch(
+      annoMatrix,
+      `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
+      {
+        method: "PUT",
+        body: compressedMatrix,
+        headers: new Headers({
+          "Content-Type": "application/octet-stream",
+        }),
+        credentials: "include",
+      }
+    );
+    if (response.ok) {
+      dispatch({
+        type: "writable obs annotations - save complete",
+        lastSavedAnnoMatrix: annoMatrix,
+      });
+    } else {
+      dispatch({
+        type: "writable obs annotations - save error",
+        message: `HTTP error ${response.status} - ${response.statusText}`,
+        response,
+      });
     }
-  );
-  if (inProgress) {
-    return;
-  }
-  if (!response && error) {
+  } catch (error) {
     dispatch({
       type: "writable obs annotations - save error",
       message: error.toString(),
       error,
-    });
-  }
-  if (response.ok) {
-    dispatch({
-      type: "writable obs annotations - save complete",
-      lastSavedAnnoMatrix: annoMatrix,
-    });
-  } else {
-    dispatch({
-      type: "writable obs annotations - save error",
-      message: `HTTP error ${response.status} - ${response.statusText}`,
-      response,
     });
   }
 };

--- a/client/src/components/autosave/index.js
+++ b/client/src/components/autosave/index.js
@@ -51,10 +51,11 @@ class Autosave extends React.Component {
   };
 
   statusMessage() {
-    const { error } = this.props;
+    const { error, saveInProgress } = this.props;
     if (error) {
       return `Autosave error: ${error}`;
     }
+    if (saveInProgress) return `Saving...`;
     return this.needToSave() ? "Unsaved" : "All saved";
   }
 

--- a/client/src/components/autosave/index.js
+++ b/client/src/components/autosave/index.js
@@ -38,8 +38,8 @@ class Autosave extends React.Component {
   }
 
   tick = () => {
-    const { dispatch, saveInProgress } = this.props;
-    if (this.needToSave() && !saveInProgress) {
+    const { dispatch } = this.props;
+    if (this.needToSave()) {
       dispatch(actions.saveObsAnnotationsAction());
     }
   };
@@ -52,10 +52,13 @@ class Autosave extends React.Component {
 
   statusMessage() {
     const { error, saveInProgress } = this.props;
+
+    if (saveInProgress) return `Saving...`;
+
     if (error) {
       return `Autosave error: ${error}`;
     }
-    if (saveInProgress) return `Saving...`;
+
     return this.needToSave() ? "Unsaved" : "All saved";
   }
 

--- a/client/src/reducers/autosave.js
+++ b/client/src/reducers/autosave.js
@@ -1,8 +1,11 @@
+import createBackoffFetch from "../util/exponentialBackoffFetch";
+
 const Autosave = (
   state = {
     saveInProgress: false,
     error: false,
     lastSavedAnnoMatrix: null,
+    exponentialBackoffFetch: null,
   },
   action
 ) => {
@@ -13,6 +16,7 @@ const Autosave = (
         error: false,
         saveInProgress: false,
         lastSavedAnnoMatrix: action.annoMatrix,
+        exponentialBackoffFetch: createBackoffFetch(3),
       };
     }
 

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -1,6 +1,5 @@
 export default function createBackoffFetch(retryTimes = 3) {
   let prevHash = null;
-  let timeoutRef = null;
   let retryCount = 0;
   let response = null;
   let error = null;
@@ -28,8 +27,7 @@ export default function createBackoffFetch(retryTimes = 3) {
           });
       } else {
         // Timeout all other requests
-        timeoutRef = setTimeout(async () => {
-          // if (done) return;
+        setTimeout(async () => {
           try {
             const resp = await fetch(...fetchArgs);
             response = resp;
@@ -58,9 +56,7 @@ export default function createBackoffFetch(retryTimes = 3) {
 
   return (hash, ...fetchArgs) => {
     if (prevHash !== hash) {
-      clearTimeout(timeoutRef);
       prevHash = hash;
-      timeoutRef = null;
       retryCount = 0;
       response = null;
       error = null;

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -1,68 +1,70 @@
 export default function createBackoffFetch(retryTimes = 3) {
   let prevHash = null;
   let retryCount = 0;
-  let response = null;
-  let error = null;
   let promise = null;
-
-  // This will only be called by itself or when we've seen a new matrix
-  const backoffFetch = (fetchArgs) => {
-    const promiseExecuter = (resolve, reject) => {
-      retryCount += 1;
-      // We don't want to timeout our first request
-      if (retryCount === 1) {
-        fetch(...fetchArgs)
-          .then((resp) => {
-            response = resp;
-            if (resp.ok) {
-              resolve(response);
-            } else {
-              promiseExecuter(resolve, reject);
-            }
-          })
-          .catch((e) => {
-            response = null;
-            error = e;
-            promiseExecuter(resolve, reject);
-          });
-      } else {
-        // Timeout all other requests
-        setTimeout(async () => {
-          try {
-            const resp = await fetch(...fetchArgs);
-            response = resp;
-            // Fetch status 2xx
-            if (resp.ok) {
-              resolve(response);
-            } else if (retryCount - 1 === retryTimes) {
-              if (error) reject(error);
-              resolve(response);
-            } else {
-              // Some non 2xx response code
-              promiseExecuter(resolve, reject);
-            }
-          } catch (e) {
-            // Fetch API error
-            error = e;
-            if (retryCount - 1 === retryTimes) reject(error);
-            promiseExecuter(resolve, reject);
-          }
-          // delay amount (3.5, 17.5, 87.5, 437.5 seconds)
-        }, 700 * 5 ** (retryCount - 1));
-      }
-    };
-    return new Promise(promiseExecuter);
-  };
+  let timeoutId = null;
 
   return (hash, ...fetchArgs) => {
     if (prevHash !== hash) {
       prevHash = hash;
       retryCount = 0;
-      response = null;
-      error = null;
+
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+
       promise = backoffFetch(fetchArgs);
     }
+
     // This isn't an initial call, return the existing promise
     return promise;
   };
+
+  function backoffFetch(fetchArgs) {
+    return new Promise(promiseExecuter);
+
+    function promiseExecuter(resolve, reject) {
+      delayFetch();
+
+      function delayFetch() {
+        if (retryCount === 0) {
+          fetchAndHandle();
+          // delay amount (3.5, 17.5, 87.5, 437.5 seconds)
+        } else timeoutId = setTimeout(fetchAndHandle, 700 * 5 ** retryCount);
+      }
+      async function fetchAndHandle() {
+        try {
+          promise.response = await mockFetch(...fetchArgs);
+
+          if (promise.response.ok || retryCount === retryTimes) {
+            resolve(promise.response);
+          }
+          console.log("success", fetchArgs[2]);
+        } catch (error) {
+          console.log("error", fetchArgs[2]);
+          if (retryCount === retryTimes) {
+            reject(error);
+          }
+        }
+        retryCount += 1;
+
+        delayFetch();
+      }
+    }
+  }
+}
+
+// DEBUG
+// DEBUG
+// DEBUG
+function mockFetch() {
+  return new Promise((resolve, reject) => {
+    const rand = Math.floor(Math.random() * 10) + 1;
+    const response = { ok: false };
+    if (rand > 5) {
+      if (rand % 1 === 1) reject(new Error("fetch error"));
+    } else response.ok = true;
+    resolve(response);
+  });
 }

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -18,7 +18,7 @@ export default function createBackoffFetch(retryTimes = 3) {
     // DEBUG
     // DEBUG
     // DEBUG
-    console.log("DELAY CALL anno", fetchArgs);
+    console.log("DELAY CALL anno", ...fetchArgs);
     console.log("DELAY CALL retryCount", retryCount);
     if (retryCount === 1) {
       returnObject.inProgress = true;
@@ -46,7 +46,7 @@ export default function createBackoffFetch(retryTimes = 3) {
     return returnObject;
   };
 
-  return (hash, fetchArgs) => {
+  return (hash, ...fetchArgs) => {
     // DEBUG
     // DEBUG
     // DEBUG

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -1,0 +1,67 @@
+const initReturnObject = {
+  response: null,
+  error: null,
+  inProgress: false,
+};
+export default function createBackoffFetch(retryTimes = 3) {
+  let prevHash = null;
+  let timeoutRef = null;
+  let retryCount = 0;
+  let returnObject = initReturnObject;
+
+  const promiseExecuter = (fetchArgs) => {
+    if (retryCount >= retryTimes) {
+      returnObject.inProgress = false;
+      return returnObject;
+    }
+    retryCount += 1;
+    // DEBUG
+    // DEBUG
+    // DEBUG
+    console.log("DELAY CALL anno", fetchArgs);
+    console.log("DELAY CALL retryCount", retryCount);
+    if (retryCount === 1) {
+      returnObject.inProgress = true;
+      fetch(...fetchArgs)
+        .then((response) => {
+          returnObject.response = response;
+          returnObject.inProgress = false;
+        })
+        .catch((e) => {
+          returnObject.error = e;
+        });
+      return returnObject;
+    }
+    timeoutRef = setTimeout(async () => {
+      try {
+        const response = await fetch(...fetchArgs);
+        returnObject.response = response;
+        returnObject.inProgress = false;
+        clearTimeout(timeoutRef);
+      } catch (e) {
+        returnObject.error = e;
+      }
+    }, 700 * 5 ** retryCount - 1);
+
+    return returnObject;
+  };
+
+  return (hash, fetchArgs) => {
+    // DEBUG
+    // DEBUG
+    // DEBUG
+    console.log("-------prevAnno", prevHash);
+    console.log("-------anno", hash);
+    if (!prevHash) {
+      prevHash = hash;
+    }
+    if (prevHash !== hash) {
+      clearTimeout(timeoutRef);
+      prevHash = hash;
+      timeoutRef = null;
+      retryCount = 0;
+      returnObject = initReturnObject;
+    }
+    return promiseExecuter(fetchArgs);
+  };
+}

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -11,6 +11,7 @@ export default function createBackoffFetch(retryTimes = 3) {
 
   // This will only be called by itself or when we've seen a new matrix
   const backoffFetch = (fetchArgs) => {
+    console.log(returnObject);
     // If we've expended all of our attempts
     if (retryCount >= retryTimes) {
       returnObject.inProgress = false;
@@ -70,9 +71,6 @@ export default function createBackoffFetch(retryTimes = 3) {
     // DEBUG
     console.log("-------prevAnno", prevHash);
     console.log("-------anno", hash);
-    if (!prevHash) {
-      prevHash = hash;
-    }
     if (prevHash !== hash) {
       clearTimeout(timeoutRef);
       prevHash = hash;

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -36,7 +36,7 @@ export default function createBackoffFetch(retryTimes = 3) {
               resolve(response);
             } else if (retryCount - 1 === retryTimes) {
               if (error) reject(error);
-              reject(response);
+              resolve(response);
             } else {
               // Some non 2xx response code
               promiseExecuter(resolve, reject);

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -48,7 +48,7 @@ export default function createBackoffFetch(retryTimes = 3) {
             promiseExecuter(resolve, reject);
           }
           // delay amount (3.5, 17.5, 87.5, 437.5 seconds)
-        }, 700 * 5 ** retryCount - 1);
+        }, 700 * 5 ** (retryCount - 1));
       }
     };
     return new Promise(promiseExecuter);

--- a/client/src/util/exponentialBackoffFetch.js
+++ b/client/src/util/exponentialBackoffFetch.js
@@ -1,85 +1,72 @@
-const initReturnObject = {
-  response: null,
-  error: null,
-  inProgress: false,
-};
 export default function createBackoffFetch(retryTimes = 3) {
   let prevHash = null;
   let timeoutRef = null;
   let retryCount = 0;
-  let returnObject = initReturnObject;
+  let response = null;
+  let error = null;
+  let promise = null;
 
   // This will only be called by itself or when we've seen a new matrix
   const backoffFetch = (fetchArgs) => {
-    console.log(returnObject);
-    // If we've expended all of our attempts
-    if (retryCount >= retryTimes) {
-      returnObject.inProgress = false;
-      return returnObject;
-    }
-    // If we've marked the fetch as complete but haven't used up all of our attempts
-    if (retryCount > 0 && !returnObject.inProgress) return returnObject;
-    retryCount += 1;
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("DELAY CALL anno", ...fetchArgs);
-    console.log("DELAY CALL retryCount", retryCount);
-    // We don't want to timeout our first request
-    if (retryCount === 1) {
-      returnObject.inProgress = true;
-      fetch(...fetchArgs)
-        .then((response) => {
-          returnObject.response = response;
-          if (response.ok) {
-            returnObject.inProgress = false;
+    const promiseExecuter = (resolve, reject) => {
+      retryCount += 1;
+      // We don't want to timeout our first request
+      if (retryCount === 1) {
+        fetch(...fetchArgs)
+          .then((resp) => {
+            response = resp;
+            if (resp.ok) {
+              resolve(response);
+            } else {
+              promiseExecuter(resolve, reject);
+            }
+          })
+          .catch((e) => {
+            response = null;
+            error = e;
+            promiseExecuter(resolve, reject);
+          });
+      } else {
+        // Timeout all other requests
+        timeoutRef = setTimeout(async () => {
+          // if (done) return;
+          try {
+            const resp = await fetch(...fetchArgs);
+            response = resp;
+            // Fetch status 2xx
+            if (resp.ok) {
+              resolve(response);
+            } else if (retryCount - 1 === retryTimes) {
+              if (error) reject(error);
+              reject(response);
+            } else {
+              // Some non 2xx response code
+              promiseExecuter(resolve, reject);
+            }
+          } catch (e) {
+            // Fetch API error
+            error = e;
+            if (retryCount - 1 === retryTimes) reject(error);
+            promiseExecuter(resolve, reject);
           }
-        })
-        .catch((e) => {
-          returnObject.error = e;
-        });
-      return backoffFetch(fetchArgs);
-    }
-    // Timeout all other requests
-    timeoutRef = setTimeout(async () => {
-      try {
-        const response = await fetch(...fetchArgs);
-        returnObject.response = response;
-        // Fetch status 2xx
-        if (response.ok) {
-          returnObject.inProgress = false;
-        } else {
-          // Some non 2xx response code
-          return backoffFetch(fetchArgs);
-        }
-      } catch (e) {
-        // Fetch API error
-        returnObject.error = e;
-        return backoffFetch(fetchArgs);
+          // delay amount (3.5, 17.5, 87.5, 437.5 seconds)
+        }, 700 * 5 ** retryCount - 1);
       }
-      // Only way we get here is if there was no error - return return obj
-      return returnObject;
-      // delay amount (3.5, 17.5, 87.5, 437.5 seconds)
-    }, 700 * 5 ** retryCount - 1);
-
-    return returnObject;
+    };
+    return new Promise(promiseExecuter);
   };
 
   return (hash, ...fetchArgs) => {
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("-------prevAnno", prevHash);
-    console.log("-------anno", hash);
     if (prevHash !== hash) {
       clearTimeout(timeoutRef);
       prevHash = hash;
       timeoutRef = null;
       retryCount = 0;
-      returnObject = initReturnObject;
-      backoffFetch(fetchArgs);
+      response = null;
+      error = null;
+      promise = backoffFetch(fetchArgs);
     }
-    // This isn't an initial call, so just give a status check in the form of our return object
-    return returnObject;
+    // This isn't an initial call, return the existing promise
+    return promise;
   };
 }


### PR DESCRIPTION
This PR creates and uses a fetch utility to help backoff repetitive fetches by collapsing fetches into a single promise which will resolve immediately on a response with an ok status or retry with exponential delay until the max retry amounts is hit, rejecting with an error or resolving non-ok response.

Also surfaced if a save is in progress

---

Hosted QA steps:

* Navigate to dataset with experimental mode enabled
* Make successful annotation change to check that there is no change in default functionality
* Make unsuccessful annotation change and watch network activity in Chrome DevTools tab
  * This can be done by intercepting response manually, with requestly, or just disconnecting from internet

CLI QA Steps:

* Same as above, but you can change the API url in `src/actions/annotation.js:363` instead of doing interception
---
#1981 