### PR TITLE
P value and Log fold change not showing up for all DE results

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -146,7 +146,7 @@ const HistogramFooter = React.memo(
           </span>
         </div>
 
-        {logFoldChange && pvalAdj ? (
+        {logFoldChange !== undefined && pvalAdj !== undefined ? (
           <div
             style={{
               display: "flex",


### PR DESCRIPTION
The HistogramFooter needs to distinguish between an undefined
value and a value of 0.  If the pvalAdj was 0, then the logFolChange
was previously not showing up.

 #1888

#### Reviewers
**Functional:** @seve 

**Readability:** 

