### PR TITLE
Fix deprecated np.unicode type

### DIFF
--- a/server/common/utils/type_conversion_utils.py
+++ b/server/common/utils/type_conversion_utils.py
@@ -44,7 +44,7 @@ def get_dtype_from_dtype(dtype, array_values=None):
     if dtype_name == "bool":
         return np.uint8
     if dtype_name == "object" and dtype_kind == "O":
-        return np.unicode
+        return str
     if dtype_name == "category":
         return get_dtype_from_dtype(dtype.categories.dtype, array_values)
 

--- a/server/test/unit/common/utils/test_type_conversion_utils.py
+++ b/server/test/unit/common/utils/test_type_conversion_utils.py
@@ -99,7 +99,7 @@ class TestTypeConversionUtils(unittest.TestCase):
 
     def test__get_dtype_of_array__supported_dtypes_return_as_expected(self):
         types = [np.float32, np.int32, np.bool_, str]
-        expected_dtypes = [np.float32, np.int32, np.uint8, np.unicode]
+        expected_dtypes = [np.float32, np.int32, np.uint8, str]
 
         for test_type_index in range(len(types)):
             with self.subTest(
@@ -110,7 +110,7 @@ class TestTypeConversionUtils(unittest.TestCase):
 
     def test__get_dtype_of_array__categories_return_as_expected(self):
         array = Series(data=["a", "b", "c"], dtype="category")
-        expected_dtype = np.unicode
+        expected_dtype = str
 
         actual_dtype = get_dtype_of_array(array)
 
@@ -179,7 +179,7 @@ class TestTypeConversionUtils(unittest.TestCase):
         category_array = Series(data=["a", "b", "b"], dtype="category")
         dataframe = DataFrame({"float_array": float_array, "category_array": category_array})
 
-        expected_data_types_dict = {"float_array": np.float32, "category_array": np.unicode}
+        expected_data_types_dict = {"float_array": np.float32, "category_array": str}
         expected_schema_type_hints_dict = {
             "float_array": {"type": "float32"},
             "category_array": {"type": "categorical", "categories": ["a", "b"]},


### PR DESCRIPTION
Until numpy version 1.20.0, `numpy.unicode` was an alias for `str` in python3. In 1.20.0, it's fully deprecated and is an `int`. This is bad and breaks things. This commit drops the `np.unicode` alias and just uses `str`, as is advised here:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

#### Reviewers
@MDunitz 
