### PR TITLE
improve error message for OBO parse failure

### DIFF
--- a/server/common/annotations/annotations.py
+++ b/server/common/annotations/annotations.py
@@ -33,10 +33,10 @@ class Annotations(metaclass=ABCMeta):
             raise OntologyLoadFailure("Unable to find OBO ontology path") from e
 
         except SyntaxError as e:
-            raise OntologyLoadFailure("Syntax error loading OBO ontology") from e
+            raise OntologyLoadFailure(f"{path}:{e.lineno}:{e.offset} OBO syntax error, unable to read ontology") from e
 
         except Exception as e:
-            raise OntologyLoadFailure("Error loading OBO file") from e
+            raise OntologyLoadFailure(f"{path}:Error loading OBO file") from e
 
     def get_schema(self, data_adaptor):
         schema = []


### PR DESCRIPTION
The OBO file specified for use in the experimental ontology support may have syntax errors, causing parsing failure.  The error messages around this were opaque, leading to confusion about root cause of startup failures (see bug #2034).

The error messaging is now includes specific information about the source of the error, line number and offset, in standard parser error format (file:lineno:offset).

Example:
```
Error: Unable to load ontology terms
http://purl.obolibrary.org/obo/cl.obo:31344:12 OBO syntax error, unable to read ontology
```

Fixes #2034
