### PR TITLE
Turn on caching for AnnotationsObs API and Schema API since we don't need recent information from user annotations.

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -240,7 +240,7 @@ class DatasetResource(Resource):
 
 class SchemaAPI(DatasetResource):
     # TODO @mdunitz separate dataset schema and user schema
-    @cache_control(no_store=True)
+    @cache_control(public=True, max_age=ONE_WEEK)
     @rest_get_data_adaptor
     def get(self, data_adaptor):
         return common_rest.schema_get(data_adaptor)

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -261,7 +261,7 @@ class UserInfoAPI(DatasetResource):
 
 
 class AnnotationsObsAPI(DatasetResource):
-    @cache_control(public=True, no_store=True)
+    @cache_control(public=True, max_age=ONE_WEEK)
     @rest_get_data_adaptor
     def get(self, data_adaptor):
         return common_rest.annotations_obs_get(request, data_adaptor)


### PR DESCRIPTION
## Reviewers

**Functional:** @mckinsel 
**Readability:** @MDunitz 

---

## Changes

Modifying the AnnotationsObs API so that subsequent API calls to `obs?` are loaded from disk cache instead of fetching from the database, refreshing on a one week cycle. Also turning on caching for Schema API with similar caching behavior.

Please note that this PR is merging into @mckinsel's branch splitting the backend, instead of merging into `main` directly.

Below is a screenshot of this change deployed to `dev`: I hit the same dataset pbmc3k twice and the second time, made sure to note that it was pulling data from cache.
![Screen Shot 2021-02-13 at 11 38 11 AM](https://user-images.githubusercontent.com/4887796/107862334-0a31f180-6e01-11eb-844b-0d88251b5b7a.png)
