### PR TITLE
Fix supported schema encoding check to allow version 0.2.0

### DIFF
--- a/server/common/corpora.py
+++ b/server/common/corpora.py
@@ -41,7 +41,8 @@ def corpora_is_version_supported(corpora_schema_version, corpora_encoding_versio
         corpora_schema_version
         and corpora_encoding_version
         and corpora_schema_version.startswith("1.")
-        and corpora_encoding_version.startswith("0.2.")
+        and (corpora_encoding_version.startswith("0.2.") 
+            or corpora_encoding_version.startswith("0.1."))
     )
 
 

--- a/server/common/corpora.py
+++ b/server/common/corpora.py
@@ -41,7 +41,7 @@ def corpora_is_version_supported(corpora_schema_version, corpora_encoding_versio
         corpora_schema_version
         and corpora_encoding_version
         and corpora_schema_version.startswith("1.")
-        and corpora_encoding_version.startswith("0.1.")
+        and corpora_encoding_version.startswith("0.2.")
     )
 
 


### PR DESCRIPTION
## Changes
Fixes `server/common/corpora.py` to support [corpora encoding version 0.2.0](https://github.com/chanzuckerberg/corpora-data-portal/blob/main/backend/schema/corpora_schema_h5ad_implementation.md) which was implemented in the schema version 1.1.0
