### PR TITLE
fix local_server unit-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,6 @@ smoke-test:
 smoke-test-annotations:
 	cd client && $(MAKE) smoke-test-annotations
 
-.PHONY: test-db-local
-test-db-local:
-	cd local_server && $(MAKE) test-db
-
 .PHONY: test-db
 test-db:
 	cd server && $(MAKE) test-db

--- a/local_server/Makefile
+++ b/local_server/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -f common/web/csp-hashes.json
 
 .PHONY: unit-test
-unit-test: create-test-db
+unit-test:
 	PYTHONWARNINGS=ignore:ResourceWarning coverage run \
 		--source=app,cli,common,compute,converters,data_anndata,data_common \
 		--omit=.coverage,data_common/fbs/NetEncoding,venv \
@@ -15,30 +15,7 @@ unit-test: create-test-db
 		--start-directory test/ \
 		--top-level-directory ../ \
 		--verbose; test_result=$$?; \
-	$(MAKE) clean-test-db; \
 	exit $$test_result \
-
-
-.PHONY: test-db
-test-db: create-test-db
-	PYTHONWARNINGS=ignore:ResourceWarning coverage run \
-		--source=app,cli,common,compute,converters,data_anndata,data_common \
-		--omit=.coverage,data_common/fbs/NetEncoding,venv \
-		-m unittest discover \
-		--start-directory test/test_database \
-		--top-level-directory ../ \
-		--verbose; test_result=$$?; \
-	$(MAKE) clean-test-db; \
-	exit $$test_result
-
-.PHONY: create-test-db
-create-test-db:
-	-docker run -d -p 5432:5432 --name test_db -e POSTGRES_PASSWORD=test_pw postgres
-
-.PHONY: clean-test-db
-clean-test-db:
-	-docker stop test_db
-	-docker rm test_db
 
 .PHONY: test-annotations-performance
 test-annotations-performance:


### PR DESCRIPTION
Removed obsolete local_server Makefile targets related to the annotations test DB.
