### PR TITLE
pin numba req

### DIFF
--- a/local_server/requirements.txt
+++ b/local_server/requirements.txt
@@ -13,6 +13,7 @@ flatten-dict>=0.2.0
 fsspec>=0.4.4,<0.8.0
 gunicorn>=20.0.4
 h5py<3.0.0 # h5py>=3.0.0 had a breaking change; there is a fix in anndata>=0.7.5
+numba==0.52.0
 numpy>=1.15.0
 packaging>=20.0
 pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pandas/issues/35446

--- a/local_server/requirements.txt
+++ b/local_server/requirements.txt
@@ -13,7 +13,7 @@ flatten-dict>=0.2.0
 fsspec>=0.4.4,<0.8.0
 gunicorn>=20.0.4
 h5py<3.0.0 # h5py>=3.0.0 had a breaking change; there is a fix in anndata>=0.7.5
-numba==0.52.0
+numba>=0.49.1,<0.53.0
 numpy>=1.15.0
 packaging>=20.0
 pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pandas/issues/35446

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,7 +13,7 @@ flatten-dict>=0.2.0
 fsspec>=0.4.4,<0.8.0
 gunicorn>=20.0.4
 h5py<3.0.0 # h5py>=3.0.0 had a breaking change; there is a fix in anndata>=0.7.5
-numba>=0.49.1
+numba==0.52.0
 numpy>=1.15.0
 packaging>=20.0
 pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pandas/issues/35446

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,7 +13,7 @@ flatten-dict>=0.2.0
 fsspec>=0.4.4,<0.8.0
 gunicorn>=20.0.4
 h5py<3.0.0 # h5py>=3.0.0 had a breaking change; there is a fix in anndata>=0.7.5
-numba==0.52.0
+numba>=0.49.1,<0.53.0
 numpy>=1.15.0
 packaging>=20.0
 pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pandas/issues/35446


### PR DESCRIPTION
#### Reviewers
**Functional:** 
- @maniarathi 

**Readability:** 

---

## Changes
- pin numba version to fix failing test
```
Traceback (most recent call last):
numba.core.errors.LoweringError: Failed in nopython mode pipeline (step: nopython mode backend)
Storing i64 to ptr of i32 ('dim'). FE type int32
File "../../../../../../opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/site-packages/umap/layouts.py", line 52:
def rdist(x, y):
    <source elided>
    result = 0.0
    dim = x.shape[0]
    ^
During: lowering "dim = static_getitem(value=$8load_attr.2, index=0, index_var=$const10.3, fn=<built-in function getitem>)" at /opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/site-packages/umap/layouts.py (52)
```

Run unit tests with numba==0.53.0 to see failing tests
