### PR TITLE
increase default diffexp gene count to 50

### DIFF
--- a/backend/czi_hosted/requirements.txt
+++ b/backend/czi_hosted/requirements.txt
@@ -20,7 +20,7 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.3
 scipy>=1.0
 requests>=2.22.0
-tiledb>=0.5.9,>=0.6.2,!=0.7.2
+tiledb>=0.5.9,>=0.6.2,!=0.7.2, !=0.8.6
 s3fs==0.4.2
 scanpy==1.4.6 # Until we move to anndata 0.7.4 scanpy needs to be pinned here
 sqlalchemy>=1.3.18

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -161,7 +161,7 @@ const dispatchDiffExpErrors = (dispatch, response) => {
   }
 };
 
-const requestDifferentialExpression = (set1, set2, num_genes = 10) => async (
+const requestDifferentialExpression = (set1, set2, num_genes = 50) => async (
   dispatch,
   getState
 ) => {


### PR DESCRIPTION
Change:  when a differential expression request is made, return top 50 results (previously, was top 10).