### PR TITLE
propagate diffexp state through component tree

### DIFF
--- a/client/src/components/brushableHistogram/index.js
+++ b/client/src/components/brushableHistogram/index.js
@@ -452,6 +452,7 @@ class HistogramBrush extends React.PureComponent {
                 {!mini ? (
                   <HistogramFooter
                     isObs={isObs}
+                    isDiffExp={isDiffExp}
                     displayName={field}
                     hideRanges={asyncProps.isSingleValue}
                     rangeMin={asyncProps.unclippedRange[0]}

--- a/client/src/components/geneExpression/gene.js
+++ b/client/src/components/geneExpression/gene.js
@@ -62,7 +62,9 @@ class Gene extends React.Component {
       isColorAccessor,
       isScatterplotXXaccessor,
       isScatterplotYYaccessor,
-      isDiffexp,
+      isDiffExp,
+      pvalAdj,
+      logFoldChange,
     } = this.props;
     const { geneIsExpanded } = this.state;
     const genesetNameLengthVisible = 310; /* this magic number determines how much of a long geneset name we see */
@@ -114,11 +116,15 @@ class Gene extends React.Component {
               </Truncate>
             </div>
             {!geneIsExpanded ? (
-              <HistogramBrush isUserDefined field={gene} mini />
+              isDiffExp ? (
+                <HistogramBrush isDiffExp field={gene} mini />
+              ) : (
+                <HistogramBrush isUserDefined field={gene} mini />
+              )
             ) : null}
           </div>
           <div style={{ flexShrink: 0, marginLeft: 2 }}>
-            {!isDiffexp ? (
+            {!isDiffExp ? (
               <AnchorButton
                 minimal
                 small
@@ -174,7 +180,17 @@ class Gene extends React.Component {
             />
           </div>
         </div>
-        {geneIsExpanded ? <HistogramBrush isUserDefined field={gene} /> : null}
+        {geneIsExpanded &&
+          (isDiffExp ? (
+            <HistogramBrush
+              isDiffExp
+              field={gene}
+              pvalAdj={pvalAdj}
+              logFoldChange={logFoldChange}
+            />
+          ) : (
+            <HistogramBrush isUserDefined field={gene} />
+          ))}
       </div>
     );
   }

--- a/client/src/components/geneExpression/geneSet.js
+++ b/client/src/components/geneExpression/geneSet.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 import { connect } from "react-redux";
 import { Tooltip, Position, Switch } from "@blueprintjs/core";
 import { FaChevronRight, FaChevronDown } from "react-icons/fa";
@@ -85,8 +84,35 @@ class GeneSet extends React.Component {
     this.setState({ toggleSummaryHisto: !toggleSummaryHisto });
   };
 
+  renderGenes() {
+    const { setName, setGenes, isDiffExp, diffExp } = this.props;
+
+    if (isDiffExp) {
+      // [ [gene, logfoldchange, pval, pval_adj], ...]
+      return setGenes.map((gene, idx) => {
+        const logFoldChange = diffExp[idx][1];
+        const pvalAdj = diffExp[idx][3];
+        return (
+          <Gene
+            key={gene}
+            gene={gene}
+            geneset={setName}
+            isDiffExp
+            logFoldChange={logFoldChange}
+            pvalAdj={pvalAdj}
+          />
+        );
+      });
+    }
+
+    // otherwise...
+    return setGenes.map((gene) => {
+      return <Gene key={gene} gene={gene} geneset={setName} />;
+    });
+  }
+
   render() {
-    const { setName, setGenes, isDiffexp } = this.props;
+    const { setName, setGenes } = this.props;
     const { isOpen, toggleSummaryHisto } = this.state;
     const genesetNameLengthVisible = 120; /* this magic number determines how much of a long geneset name we see */
     return (
@@ -166,16 +192,7 @@ class GeneSet extends React.Component {
 
         {isOpen &&
           (!toggleSummaryHisto
-            ? _.map(setGenes, (gene) => {
-                return (
-                  <Gene
-                    key={gene}
-                    gene={gene}
-                    geneset={setName}
-                    isDiffexp={isDiffexp}
-                  />
-                );
-              })
+            ? this.renderGenes()
             : setGenes.length > 0 && (
                 <HistogramBrush
                   isGeneSetSummary

--- a/client/src/components/geneExpression/index.js
+++ b/client/src/components/geneExpression/index.js
@@ -31,23 +31,20 @@ class GeneExpression extends React.Component {
 
   renderDiffexpGeneSets = () => {
     const { differential } = this.props;
+    const { diffExp } = differential;
+    if (!diffExp) return null;
 
-    const setGenes = [];
-
-    if (differential.diffExp) {
-      differential.diffExp.forEach((diffexpGene) => {
-        setGenes.push(diffexpGene[0]);
-      });
-    }
-
-    return differential.diffExp ? (
+    // [ [gene, logfoldchange, pval, pval_adj], ...]
+    const setGenes = diffExp.map((diffExpGene) => diffExpGene[0]);
+    return (
       <GeneSet
         key="Temp DiffExp Set"
         setGenes={setGenes}
-        isDiffexp
+        isDiffExp
+        diffExp={diffExp}
         setName="Temp DiffExp Set"
       />
-    ) : null;
+    );
   };
 
   handleActivateCreateGenesetMode = () => {


### PR DESCRIPTION
The differential expression state was not correctly being propagated through the component tree, which manifest as a missing "p-val" and "lfc" on histograms related to diffexp. This PR makes the state available to the components that actually need it.

Fixes #2133 