### PR TITLE
Remove updates coming from cookie banner since updates have already been executed.

### DIFF
--- a/client/src/components/termsPrompt/index.js
+++ b/client/src/components/termsPrompt/index.js
@@ -67,7 +67,7 @@ class TermsPrompt extends React.PureComponent {
           target="_blank"
           rel="noopener"
         >
-          terms of service (updates coming)
+          terms of service
         </a>
         .{" "}
       </span>
@@ -89,7 +89,7 @@ class TermsPrompt extends React.PureComponent {
           target="_blank"
           rel="noopener"
         >
-          privacy policy (updates coming)
+          privacy policy
         </a>
         .&nbsp;
       </span>


### PR DESCRIPTION
### Reviewers

**Functional:** @tihuan 

**Readability:** N/A

---

### Changes

#### Modifications

- Removed the words "updates coming" from the cookie banner because the CZIF changes have already been executed.
