### PR TITLE
Fix command to EB to use the artifact.zip file during deployment instead of the source code in the directory.

### DIFF
--- a/backend/czi_hosted/eb/Makefile
+++ b/backend/czi_hosted/eb/Makefile
@@ -54,6 +54,6 @@ build: clean
 	(cd artifact.dir; \
 	  cp -r backend/czi_hosted/common/web/static static; \
 	  zip -r ../artifact.zip . --exclude backend/czi_hosted/test/\* backend/czi_hosted/eb/\* ; ); \
-	if ! [ -f .elasticbeanstalk/config.yml ] ; then \
+	if ! grep artifact.zip .elasticbeanstalk/config.yml ; then \
 	    mkdir -p .elasticbeanstalk ; cat config_deploy.yaml >> .elasticbeanstalk/config.yml ; fi
 


### PR DESCRIPTION
### Reviewers

**Functional:** @seve 

---

### Changes

#### Modifications

- Revert code to check if artifact.zip is in the config.yml file because we need to specify in config.yml to use artifact.zip instead of the source code in the directory, the latter of which is the default behavior of `eb deploy`.
