### PR TITLE
add final slash to datasets in default index page

### DIFF
--- a/backend/czi_hosted/app/app.py
+++ b/backend/czi_hosted/app/app.py
@@ -205,7 +205,7 @@ def dataroot_test_index():
     data += "<ul>"
     datasets.sort()
     for url_dataroot, dataset in datasets:
-        data += f"<li><a href={url_dataroot}/{dataset}>{dataset}</a></li>"
+        data += f"<li><a href={url_dataroot}/{dataset}/>{dataset}</a></li>"
     data += "</ul>"
     data += "</body></html>"
 


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add final slash to url for all datasets in list on the default index page
