### PR TITLE
feat: return two lists for diffexp

### DIFF
--- a/backend/czi_hosted/Makefile
+++ b/backend/czi_hosted/Makefile
@@ -12,7 +12,7 @@ unit-test: create-test-db
 		--source=app,auth,cli,common,compute,converters,data_anndata,data_common,data_cxg,eb \
 		--omit=.coverage,venv \
 		-m unittest discover \
-		--start-directory ../test/test_czi_hosted/unit/compute \
+		--start-directory ../test/test_czi_hosted/unit \
 		--top-level-directory ../.. \
 		--verbose; test_result=$$?; \
 	$(MAKE) clean-test-db; \

--- a/backend/czi_hosted/Makefile
+++ b/backend/czi_hosted/Makefile
@@ -12,7 +12,7 @@ unit-test: create-test-db
 		--source=app,auth,cli,common,compute,converters,data_anndata,data_common,data_cxg,eb \
 		--omit=.coverage,venv \
 		-m unittest discover \
-		--start-directory ../test/test_czi_hosted/unit \
+		--start-directory ../test/test_czi_hosted/unit/compute \
 		--top-level-directory ../.. \
 		--verbose; test_result=$$?; \
 	$(MAKE) clean-test-db; \

--- a/backend/czi_hosted/common/rest.py
+++ b/backend/czi_hosted/common/rest.py
@@ -260,7 +260,9 @@ def diffexp_obs_post(request, data_adaptor):
     try:
         # TODO: implement varfilter mode
         mode = DiffExpMode(args["mode"])
-
+        two_lists = False
+        if "two_lists" in args:
+            two_lists = True
         if mode == DiffExpMode.VAR_FILTER or "varFilter" in args:
             return abort_and_log(HTTPStatus.NOT_IMPLEMENTED, "varFilter not enabled")
 
@@ -277,7 +279,7 @@ def diffexp_obs_post(request, data_adaptor):
         return abort_and_log(HTTPStatus.BAD_REQUEST, str(e), include_exc_info=True)
 
     try:
-        diffexp = data_adaptor.diffexp_topN(set1_filter, set2_filter, count)
+        diffexp = data_adaptor.diffexp_topN(set1_filter, set2_filter, count, two_lists)
         return make_response(diffexp, HTTPStatus.OK, {"Content-Type": "application/json"})
     except (ValueError, DisabledFeatureError, FilterError, ExceedsLimitError) as e:
         return abort_and_log(HTTPStatus.BAD_REQUEST, str(e), include_exc_info=True)

--- a/backend/czi_hosted/common/rest.py
+++ b/backend/czi_hosted/common/rest.py
@@ -262,7 +262,7 @@ def diffexp_obs_post(request, data_adaptor):
         mode = DiffExpMode(args["mode"])
         two_lists = False
         if "two_lists" in args:
-            two_lists = True
+            two_lists = args["two_lists"]
         if mode == DiffExpMode.VAR_FILTER or "varFilter" in args:
             return abort_and_log(HTTPStatus.NOT_IMPLEMENTED, "varFilter not enabled")
 

--- a/backend/czi_hosted/compute/diffexp_cxg.py
+++ b/backend/czi_hosted/compute/diffexp_cxg.py
@@ -35,7 +35,7 @@ def get_thread_executor():
     return diffexp_thread_executor
 
 
-def diffexp_ttest(adaptor, maskA, maskB, two_lists, top_n=8, diffexp_lfc_cutoff=0.01):
+def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01, two_lists=False):
 
     matrix = adaptor.open_array("X")
     row_selector_A = np.where(maskA)[0]
@@ -115,15 +115,15 @@ def diffexp_ttest(adaptor, maskA, maskB, two_lists, top_n=8, diffexp_lfc_cutoff=
             meanB += X_col_shift
 
     r = diffexp_ttest_from_mean_var(
-        meanA.astype(dtype),
-        varA.astype(dtype),
-        nA,
-        meanB.astype(dtype),
-        varB.astype(dtype),
-        nB,
-        top_n,
-        diffexp_lfc_cutoff,
-        two_lists
+        meanA=meanA.astype(dtype),
+        varA=varA.astype(dtype),
+        nA=nA,
+        meanB=meanB.astype(dtype),
+        varB=varB.astype(dtype),
+        nB=nB,
+        top_n=top_n,
+        diffexp_lfc_cutoff=diffexp_lfc_cutoff,
+        two_lists=two_lists
     )
 
     return r

--- a/backend/czi_hosted/compute/diffexp_cxg.py
+++ b/backend/czi_hosted/compute/diffexp_cxg.py
@@ -35,7 +35,7 @@ def get_thread_executor():
     return diffexp_thread_executor
 
 
-def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
+def diffexp_ttest(adaptor, maskA, maskB, two_lists, top_n=8, diffexp_lfc_cutoff=0.01):
 
     matrix = adaptor.open_array("X")
     row_selector_A = np.where(maskA)[0]
@@ -123,6 +123,7 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
         nB,
         top_n,
         diffexp_lfc_cutoff,
+        two_lists
     )
 
     return r

--- a/backend/czi_hosted/compute/diffexp_generic.py
+++ b/backend/czi_hosted/compute/diffexp_generic.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse, stats
 
 
-def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
+def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01, two_lists=False):
     """
     Return differential expression statistics for top N variables.
 
@@ -25,6 +25,8 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
     :param maskB: observation selection mask for set 2
     :param top_n: number of variables to return stats for
     :param diffexp_lfc_cutoff: minimum
+    :param two_lists: if true return a dict containing lists of max and min (most negative) values, default is false, return max based on
+    absolute value returning [ varindex, logfoldchange, pval, pval_adj ] for top N genes
     :return:  for top N genes, [ varindex, logfoldchange, pval, pval_adj ]
     """
 
@@ -34,12 +36,12 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
     # mean, variance, N - calculate for both selections
     meanA, vA, nA = mean_var_n(dataA)
     meanB, vB, nB = mean_var_n(dataB)
-    res = diffexp_ttest_from_mean_var(meanA, vA, nA, meanB, vB, nB, top_n, diffexp_lfc_cutoff)
+    res = diffexp_ttest_from_mean_var(meanA, vA, nA, meanB, vB, nB, two_lists, top_n, diffexp_lfc_cutoff)
 
     return res
 
 
-def diffexp_ttest_from_mean_var(meanA, varA, nA, meanB, varB, nB, top_n, diffexp_lfc_cutoff, two_lists=False):
+def diffexp_ttest_from_mean_var(meanA, varA, nA, meanB, varB, nB, two_lists, top_n, diffexp_lfc_cutoff):
     n_var = meanA.shape[0]
     top_n = min(top_n, n_var)
 
@@ -68,11 +70,14 @@ def diffexp_ttest_from_mean_var(meanA, varA, nA, meanB, varB, nB, top_n, diffexp
     stats_to_sort = np.abs(tscores)
 
     # find all with lfc > cutoff
+
     if two_lists:
+
         lfc_above_cutoff_idx = np.nonzero(logfoldchanges > diffexp_lfc_cutoff)[0]
         lfc_below_neg_cutoff_idx = np.nonzero(logfoldchanges < -diffexp_lfc_cutoff)[0]
 
         above_cutoff_sort_order = derive_sort_order(lfc_above_cutoff_idx, top_n, stats_to_sort)
+
         below_neg_cutoff_sort_order = derive_sort_order(lfc_below_neg_cutoff_idx, top_n, stats_to_sort)
 
         # top n slice based upon sort order for lfc above cutoff
@@ -104,12 +109,15 @@ def diffexp_ttest_from_mean_var(meanA, varA, nA, meanB, varB, nB, top_n, diffexp
 
         # varIndex, logfoldchange, pval, pval_adj
         result = [[sort_order[i], logfoldchanges_top_n[i], pvals_top_n[i], pvals_adj_top_n[i]] for i in range(top_n)]
+
     return result
 
 
 def derive_sort_order(lfc, top_n, stats_to_sort):
     if lfc.shape[0] > top_n:
         # partition top N
+        import pdb
+        pdb.set_trace()
         rel_t_partition = np.argpartition(stats_to_sort[lfc], -top_n)[-top_n:]
         t_partition = lfc[rel_t_partition]
         # sort the top N partition
@@ -122,6 +130,7 @@ def derive_sort_order(lfc, top_n, stats_to_sort):
         indices = np.indices(stats_to_sort.shape)[0]
         sort_order = indices[partition][rel_sort_order]
     return sort_order
+
 
 # Convenience function which handles sparse data
 def mean_var_n(X):

--- a/backend/czi_hosted/compute/diffexp_generic.py
+++ b/backend/czi_hosted/compute/diffexp_generic.py
@@ -66,13 +66,17 @@ def diffexp_ttest_from_mean_var(meanA, varA, nA, meanB, varB, nB, top_n, diffexp
     # logfoldchanges: log2(meanA / meanB)
     logfoldchanges = np.log2(np.abs((meanA + 1e-9) / (meanB + 1e-9)))
 
-    # find all with lfc > cutoff
-    lfc_above_cutoff_idx = np.nonzero(np.abs(logfoldchanges) > diffexp_lfc_cutoff)[0]
+    # find all with lfc > cutoff and all with lfc < -cutoff
+    lfc_above_cutoff_idx = np.nonzero(logfoldchanges > diffexp_lfc_cutoff)[0]
+    lfc_below_neg_cutoff_idx = np.nonzero(logfoldchanges < -diffexp_lfc_cutoff)[0]
+
     stats_to_sort = np.abs(tscores)
 
     # derive sort order
     if lfc_above_cutoff_idx.shape[0] > top_n:
         # partition top N
+        import pdb
+        pdb.set_trace()
         rel_t_partition = np.argpartition(stats_to_sort[lfc_above_cutoff_idx], -top_n)[-top_n:]
         t_partition = lfc_above_cutoff_idx[rel_t_partition]
         # sort the top N partition

--- a/backend/czi_hosted/data_anndata/anndata_adaptor.py
+++ b/backend/czi_hosted/data_anndata/anndata_adaptor.py
@@ -323,12 +323,12 @@ class AnndataAdaptor(DataAdaptor):
         self.data.obsm[f"X_{name}"] = X_umap
         return layout_schema
 
-    def compute_diffexp_ttest(self, maskA, maskB, top_n=None, lfc_cutoff=None):
+    def compute_diffexp_ttest(self, maskA, maskB, top_n=None, lfc_cutoff=None, two_lists=False):
         if top_n is None:
             top_n = self.dataset_config.diffexp__top_n
         if lfc_cutoff is None:
             lfc_cutoff = self.dataset_config.diffexp__lfc_cutoff
-        return diffexp_generic.diffexp_ttest(self, maskA, maskB, top_n, lfc_cutoff)
+        return diffexp_generic.diffexp_ttest(self, maskA, maskB, top_n, lfc_cutoff, two_lists)
 
     def get_colors(self):
         return convert_anndata_category_colors_to_cxg_category_colors(self.data)

--- a/backend/czi_hosted/data_common/data_adaptor.py
+++ b/backend/czi_hosted/data_common/data_adaptor.py
@@ -163,7 +163,7 @@ class DataAdaptor(metaclass=ABCMeta):
         mask = np.zeros((count,), dtype=np.bool)
         for i in filter:
             if type(i) == list:
-                mask[i[0] : i[1]] = True
+                mask[i[0]: i[1]] = True
             else:
                 mask[i] = True
         return mask
@@ -322,11 +322,12 @@ class DataAdaptor(metaclass=ABCMeta):
             top_n = self.dataset_config.diffexp__top_n
 
         if self.server_config.exceeds_limit(
-            "diffexp_cellcount_max", np.count_nonzero(obs_mask_A) + np.count_nonzero(obs_mask_B)
+                "diffexp_cellcount_max", np.count_nonzero(obs_mask_A) + np.count_nonzero(obs_mask_B)
         ):
             raise ExceedsLimitError("Diffexp request exceeds max cell count limit")
 
-        result = self.compute_diffexp_ttest(obs_mask_A, obs_mask_B, two_lists, top_n, self.dataset_config.diffexp__lfc_cutoff)
+        result = self.compute_diffexp_ttest(maskA=obs_mask_A, maskB=obs_mask_B, top_n=top_n,
+                                            lfc_cutoff=self.dataset_config.diffexp__lfc_cutoff, two_lists=two_lists)
 
         try:
             return jsonify_numpy(result)

--- a/backend/czi_hosted/data_common/data_adaptor.py
+++ b/backend/czi_hosted/data_common/data_adaptor.py
@@ -297,7 +297,7 @@ class DataAdaptor(metaclass=ABCMeta):
         col_idx = np.nonzero([] if var_selector is None else var_selector)[0]
         return encode_matrix_fbs(X, col_idx=col_idx, row_idx=None)
 
-    def diffexp_topN(self, obsFilterA, obsFilterB, top_n=None):
+    def diffexp_topN(self, obsFilterA, obsFilterB, top_n=None, two_lists=False):
         """
         Computes the top N differentially expressed variables between two observation sets. If mode
         is "TOP_N", then stats for the top N
@@ -307,6 +307,7 @@ class DataAdaptor(metaclass=ABCMeta):
         :param obsFilterA: filter: dictionary with filter params for first set of observations
         :param obsFilterB: filter: dictionary with filter params for second set of observations
         :param top_n: Limit results to top N (Top var mode only)
+        :param two_lists: Boolean to indicate should return the top_n of the most positive and most negative genes (instead of one list of the top_n based on the absolute value)
         :return: top N genes and corresponding stats
         """
         if Axis.VAR in obsFilterA or Axis.VAR in obsFilterB:
@@ -325,7 +326,7 @@ class DataAdaptor(metaclass=ABCMeta):
         ):
             raise ExceedsLimitError("Diffexp request exceeds max cell count limit")
 
-        result = self.compute_diffexp_ttest(obs_mask_A, obs_mask_B, top_n, self.dataset_config.diffexp__lfc_cutoff)
+        result = self.compute_diffexp_ttest(obs_mask_A, obs_mask_B, two_lists, top_n, self.dataset_config.diffexp__lfc_cutoff)
 
         try:
             return jsonify_numpy(result)
@@ -333,7 +334,7 @@ class DataAdaptor(metaclass=ABCMeta):
             raise JSONEncodingValueError("Error encoding differential expression to JSON")
 
     @abstractmethod
-    def compute_diffexp_ttest(self, maskA, maskB, top_n, lfc_cutoff):
+    def compute_diffexp_ttest(self, maskA, maskB, top_n, lfc_cutoff, two_lists):
         pass
 
     @staticmethod

--- a/backend/czi_hosted/data_cxg/cxg_adaptor.py
+++ b/backend/czi_hosted/data_cxg/cxg_adaptor.py
@@ -202,12 +202,13 @@ class CxgAdaptor(DataAdaptor):
     def compute_embedding(self, method, filter):
         raise NotImplementedError("CXG does not yet support re-embedding")
 
-    def compute_diffexp_ttest(self, maskA, maskB, two_lists, top_n=None, lfc_cutoff=None):
+    def compute_diffexp_ttest(self, maskA, maskB, top_n=None, lfc_cutoff=None, two_lists=False):
         if top_n is None:
             top_n = self.dataset_config.diffexp__top_n
         if lfc_cutoff is None:
             lfc_cutoff = self.dataset_config.diffexp__lfc_cutoff
-        return diffexp_cxg.diffexp_ttest(self, maskA, maskB, two_lists, top_n, lfc_cutoff)
+        return diffexp_cxg.diffexp_ttest(
+            adaptor=self, maskA=maskA, maskB=maskB, top_n=top_n, diffexp_lfc_cutoff=lfc_cutoff, two_lists=two_lists)
 
     def get_colors(self):
         if self.cxg_version == "0.0":

--- a/backend/czi_hosted/data_cxg/cxg_adaptor.py
+++ b/backend/czi_hosted/data_cxg/cxg_adaptor.py
@@ -202,12 +202,12 @@ class CxgAdaptor(DataAdaptor):
     def compute_embedding(self, method, filter):
         raise NotImplementedError("CXG does not yet support re-embedding")
 
-    def compute_diffexp_ttest(self, maskA, maskB, top_n=None, lfc_cutoff=None):
+    def compute_diffexp_ttest(self, maskA, maskB, two_lists, top_n=None, lfc_cutoff=None):
         if top_n is None:
             top_n = self.dataset_config.diffexp__top_n
         if lfc_cutoff is None:
             lfc_cutoff = self.dataset_config.diffexp__lfc_cutoff
-        return diffexp_cxg.diffexp_ttest(self, maskA, maskB, top_n, lfc_cutoff)
+        return diffexp_cxg.diffexp_ttest(self, maskA, maskB, two_lists, top_n, lfc_cutoff)
 
     def get_colors(self):
         if self.cxg_version == "0.0":

--- a/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
+++ b/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
@@ -80,6 +80,8 @@ class DiffExpTest(unittest.TestCase):
         self.check_1_10_2_10(results)
 
         # run it directly
+        import pdb
+        pdb.set_trace()
         results = diffexp_ttest(adaptor, maskA, maskB, 10)
         self.check_1_10_2_10(results)
 

--- a/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
+++ b/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
@@ -80,8 +80,7 @@ class DiffExpTest(unittest.TestCase):
         self.check_1_10_2_10(results)
 
         # run it directly
-        import pdb
-        pdb.set_trace()
+
         results = diffexp_ttest(adaptor, maskA, maskB, 10)
         self.check_1_10_2_10(results)
 

--- a/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
+++ b/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
@@ -61,7 +61,7 @@ class DiffExpTest(unittest.TestCase):
         varmask[cols] = True
         return adaptor.get_X_array(None, varmask)
 
-    def test_anndata_default(self):
+    def xtest_anndata_default(self):
         """Test an anndata adaptor with its default diffexp algorithm (diffexp_generic)"""
         adaptor = self.load_dataset(f"{PROJECT_ROOT}/example-dataset/pbmc3k.h5ad")
         maskA = self.get_mask(adaptor, 1, 10)
@@ -84,7 +84,26 @@ class DiffExpTest(unittest.TestCase):
         results = diffexp_ttest(adaptor, maskA, maskB, 10)
         self.check_1_10_2_10(results)
 
-    def test_cxg_generic(self):
+    def test_cxg_default_return_two_lists(self):
+        """Test a cxg adaptor with its default diffexp algorithm (diffexp_cxg)"""
+        adaptor = self.load_dataset(f"{FIXTURES_ROOT}/pbmc3k.cxg")
+        maskA = self.get_mask(adaptor, 1, 10)
+        maskB = self.get_mask(adaptor, 2, 10)
+
+        # run it through the adaptor
+        results = adaptor.compute_diffexp_ttest(maskA, maskB, 10, True)
+        import pdb
+        pdb.set_trace()
+        self.check_1_10_2_10(results)
+
+        # run it directly
+
+        results = diffexp_ttest(adaptor, maskA, maskB, 10, True)
+        import pdb
+        pdb.set_trace()
+        self.check_1_10_2_10(results)
+
+    def xtest_cxg_generic(self):
         """Test a cxg adaptor with the generic adaptor"""
         adaptor = self.load_dataset(f"{FIXTURES_ROOT}/pbmc3k.cxg")
         maskA = self.get_mask(adaptor, 1, 10)
@@ -93,10 +112,10 @@ class DiffExpTest(unittest.TestCase):
         results = diffexp_generic.diffexp_ttest(adaptor, maskA, maskB, 10)
         self.check_1_10_2_10(results)
 
-    def test_cxg_sparse(self):
+    def xtest_cxg_sparse(self):
         self.sparse_diffexp(False)
 
-    def test_cxg_sparse_col_shift(self):
+    def xtest_cxg_sparse_col_shift(self):
         self.sparse_diffexp(True)
 
     def sparse_diffexp(self, apply_col_shift):

--- a/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
+++ b/backend/test/test_czi_hosted/unit/compute/test_diffexp_cxg.py
@@ -56,12 +56,44 @@ class DiffExpTest(unittest.TestCase):
         ]
         self.compare_diffexp_results(results, expects)
 
+    def check_two_list_results(self, results):
+        """
+        Checks the results for the positive and negative lists
+        """
+        positive_expects = [
+            [956, 0.016060986, 0.0008649321884808977, 1.0],
+            [1124, 0.96602094, 0.0011717216548271284, 1.0],
+            [1809, 1.1110606, 0.0019304405196777848, 1.0],
+            [1754, 0.5201581, 0.005691734062127954, 1.0],
+            [948, 1.6390722, 0.006622111055981219, 1.0],
+            [1810, 0.78618884, 0.007055917428377063, 1.0],
+            [779, 1.5241305, 0.007202934422407284, 1.0],
+            [1575, 1.0317602, 0.007830310753043345, 1.0],
+            [576, 0.97873515, 0.008272092578813124, 1.0],
+            [693, 0.4703904, 0.008715846769131548, 1.0]
+        ]
+        negative_expects = [
+            [1712, -0.5525154, 0.0051788902660723345, 1.0],
+            [782, -1.0981874, 0.010161745218916036, 1.0],
+            [1025, -0.058413953, 0.015221339075168455, 1.0],
+            [1443, -0.8241895, 0.015337080567465522, 1.0],
+            [1762, -1.7930828, 0.016691309698229767, 1.0],
+            [1679, -0.41443065, 0.01838551371831012, 1.0],
+            [40, -0.9842073, 0.02299410136713407, 1.0],
+            [1455, -1.3472617, 0.023396125324503077, 1.0],
+            [527, -1.2274479, 0.025165792510816416, 1.0],
+            [655, -0.1650761, 0.02720396756274279, 1.0]
+        ]
+
+        self.compare_diffexp_results(results['positive'], positive_expects)
+        self.compare_diffexp_results(results['negative'], negative_expects)
+
     def get_X_col(self, adaptor, cols):
         varmask = np.zeros(adaptor.get_shape()[1], dtype=bool)
         varmask[cols] = True
         return adaptor.get_X_array(None, varmask)
 
-    def xtest_anndata_default(self):
+    def test_anndata_default(self):
         """Test an anndata adaptor with its default diffexp algorithm (diffexp_generic)"""
         adaptor = self.load_dataset(f"{PROJECT_ROOT}/example-dataset/pbmc3k.h5ad")
         maskA = self.get_mask(adaptor, 1, 10)
@@ -91,19 +123,24 @@ class DiffExpTest(unittest.TestCase):
         maskB = self.get_mask(adaptor, 2, 10)
 
         # run it through the adaptor
-        results = adaptor.compute_diffexp_ttest(maskA, maskB, 10, True)
-        import pdb
-        pdb.set_trace()
-        self.check_1_10_2_10(results)
+        results = adaptor.compute_diffexp_ttest(maskA, maskB, 10, two_lists=True)
+        self.check_two_list_results(results)
 
         # run it directly
 
-        results = diffexp_ttest(adaptor, maskA, maskB, 10, True)
-        import pdb
-        pdb.set_trace()
-        self.check_1_10_2_10(results)
+        results = diffexp_ttest(adaptor, maskA, maskB, 10, two_lists=True)
+        self.check_two_list_results(results)
 
-    def xtest_cxg_generic(self):
+    def test_cxg_generic_returns_two_lists(self):
+        """Test a cxg adaptor with the generic adaptor"""
+        adaptor = self.load_dataset(f"{FIXTURES_ROOT}/pbmc3k.cxg")
+        maskA = self.get_mask(adaptor, 1, 10)
+        maskB = self.get_mask(adaptor, 2, 10)
+        # run it directly
+        results = diffexp_generic.diffexp_ttest(adaptor, maskA, maskB, 10, two_lists=True)
+        self.check_two_list_results(results)
+
+    def test_cxg_generic(self):
         """Test a cxg adaptor with the generic adaptor"""
         adaptor = self.load_dataset(f"{FIXTURES_ROOT}/pbmc3k.cxg")
         maskA = self.get_mask(adaptor, 1, 10)
@@ -112,10 +149,10 @@ class DiffExpTest(unittest.TestCase):
         results = diffexp_generic.diffexp_ttest(adaptor, maskA, maskB, 10)
         self.check_1_10_2_10(results)
 
-    def xtest_cxg_sparse(self):
+    def test_cxg_sparse(self):
         self.sparse_diffexp(False)
 
-    def xtest_cxg_sparse_col_shift(self):
+    def test_cxg_sparse_col_shift(self):
         self.sparse_diffexp(True)
 
     def sparse_diffexp(self, apply_col_shift):


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@maniarathi 
**Readability:** 
@seve 
---

## Changes
- modify DiffExpObsAPI "/diffexp/obs" -- when two_lists=True is passed as part of the request body, return two separate lists for the diffexp results. If two_lists is not passed in as an arg the endpoint will return a single list of diffexp values (current functionality)
currently the endpoint returns  
for top N genes, [ varindex, logfoldchange, pval, pval_adj ] 

if two_lists is True the endpoint returns 
{"positive": for top N genes, [ varindex, logfoldchange, pval, pval_adj ], 
"negative": for top N genes, [ varindex, logfoldchange, pval, pval_adj ]}

