### PR TITLE
Update unit tests for CXG conversion to check for actual content rather than file names alone which have changed with the recent 0.9 release of tiledb's python package.

### DIFF
--- a/backend/test/test_czi_hosted/unit/converters/test_h5ad_data_file.py
+++ b/backend/test/test_czi_hosted/unit/converters/test_h5ad_data_file.py
@@ -197,7 +197,6 @@ class TestH5ADDataFile(unittest.TestCase):
         expected_index_data = anndata_object.obs.index.to_numpy()
         index_name = json.loads(obs_array.meta["cxg_schema"])["index"]
         actual_index_data = obs_array.query(attrs=[index_name])[:][index_name]
-        actual_index_data = obs_array
         self.assertTrue(np.array_equal(expected_index_data, actual_index_data))
 
         # Validate obs columns


### PR DESCRIPTION
### Reviewers

**Functional:** @bkmartinjr 

**Readability:** @MDunitz 

---

### Changes

#### Modifications

With the recent upgrade of tiledb's Python PyPi package, when Dataframes are converted to tileDB arrays, the names of the columns are automatically reassigned to be a0, a1, etc.. Previously the test suite was checking to make sure that the array names matched the name of the column, but that no longer is valid check to make sure that the CXG was formed correctly. I've updated the test to actually ensure that the _content_ of the arrays are the same. Note that no changes are required to the way that the arrays are read and I verified that the tests are backwards compatible with older versions of tileDB.
