### PR TITLE
fix: reset gene set colorScale on gene set deletion

### DIFF
--- a/client/src/actions/geneset.js
+++ b/client/src/actions/geneset.js
@@ -16,7 +16,7 @@ The behavior manifest in these action creators:
     Add a gene to a gene set, will:
       * drop index & clear selection state on the gene set summary
       * will NOT touch the selection state for the gene
-  
+
 Note that crossfilter indices are lazy created, as needed.
 */
 
@@ -26,6 +26,11 @@ export const genesetDelete = (genesetName) => (dispatch, getState) => {
   const gs = genesets?.genesets?.get(genesetName) ?? {};
   const geneSymbols = Array.from(gs.genes.keys());
   const obsCrossfilter = dropGeneset(dispatch, state, genesetName, geneSymbols);
+  if (genesetName === state.colors.colorAccessor) {
+    dispatch({
+      type: "reset colorscale",
+    });
+  }
   dispatch({
     type: "geneset: delete",
     genesetName,


### PR DESCRIPTION
#### Reviewers
**Functional:** @colinmegill 

---

## Changes
- add
* Check color accessor on gene set deletion and reset accordingly

----

#2231 
