### PR TITLE
Add `--url-prefix` launch option

### DIFF
--- a/backend/server/app/app.py
+++ b/backend/server/app/app.py
@@ -267,20 +267,23 @@ class Server:
         secret_key = server_config.app__flask_secret_key
         self.app.config.update(SECRET_KEY=secret_key)
 
+        url_prefix = server_config.app__url_prefix or ""
+
+        webbp.url_prefix = url_prefix
         self.app.register_blueprint(webbp)
 
         api_version = "/api/v0.2"
         api_path = "/"
 
-        bp_base = Blueprint("bp_base", __name__, url_prefix=api_path)
+        bp_base = Blueprint("bp_base", __name__, url_prefix=f"{url_prefix}{api_path}")
         base_resources = get_api_base_resources(bp_base)
         self.app.register_blueprint(base_resources.blueprint)
 
-        bp_api = Blueprint("api", __name__, url_prefix=f"{api_path}{api_version}")
+        bp_api = Blueprint("api", __name__, url_prefix=f"{url_prefix}{api_path}{api_version}")
         resources = get_api_dataroot_resources(bp_api)
         self.app.register_blueprint(resources.blueprint)
         self.app.add_url_rule(
-            "/static/<path:filename>",
+            f"{url_prefix}/static/<path:filename>",
             "static_assets",
             view_func=lambda filename: send_from_directory("../common/web/static", filename),
             methods=["GET"],

--- a/backend/server/cli/launch.py
+++ b/backend/server/cli/launch.py
@@ -191,6 +191,11 @@ def server_args(func):
         show_default=False,
         help="Host IP address. By default cellxgene will use localhost (e.g. 127.0.0.1).",
     )
+    @click.option("--url-prefix",
+        default=DEFAULT_CONFIG.server_config.app__url_prefix,
+        show_default=True,
+        help="The base path for the URL at which the app will be served (e.g. `/my/cellxgene/app`)."
+    )
     @click.option(
         "--scripts",
         "-s",
@@ -300,6 +305,7 @@ def launch(
     open_browser,
     port,
     host,
+    url_prefix,
     embedding,
     obs_names,
     var_names,
@@ -356,6 +362,7 @@ def launch(
             app__debug=debug,
             app__host=host,
             app__port=port,
+            app__url_prefix=url_prefix,
             app__open_browser=open_browser,
             single_dataset__datapath=datapath,
             single_dataset__title=title,
@@ -411,7 +418,7 @@ def launch(
         log = logging.getLogger("werkzeug")
         log.setLevel(logging.ERROR)
 
-    cellxgene_url = f"http://{app_config.server_config.app__host}:{app_config.server_config.app__port}"
+    cellxgene_url = f"http://{app_config.server_config.app__host}:{app_config.server_config.app__port}{app_config.server_config.app__url_prefix or ''}"
     if server_config.app__open_browser:
         click.echo(f"[cellxgene] Launching! Opening your browser to {cellxgene_url} now.")
         webbrowser.open(cellxgene_url)

--- a/backend/server/common/config/server_config.py
+++ b/backend/server/common/config/server_config.py
@@ -28,6 +28,7 @@ class ServerConfig(BaseConfig):
             self.app__force_https = default_config["app"]["force_https"]
             self.app__flask_secret_key = default_config["app"]["flask_secret_key"]
             self.app__generate_cache_control_headers = default_config["app"]["generate_cache_control_headers"]
+            self.app__url_prefix = default_config["app"]["url_prefix"]
 
             self.authentication__type = default_config["authentication"]["type"]
             self.authentication__insecure_test_environment = default_config["authentication"][
@@ -75,6 +76,7 @@ class ServerConfig(BaseConfig):
         self.validate_correct_type_of_configuration_attribute("app__force_https", bool)
         self.validate_correct_type_of_configuration_attribute("app__flask_secret_key", str)
         self.validate_correct_type_of_configuration_attribute("app__generate_cache_control_headers", bool)
+        self.validate_correct_type_of_configuration_attribute("app__url_prefix", (type(None), str))
 
         if self.app__port:
             try:

--- a/backend/server/default_config.py
+++ b/backend/server/default_config.py
@@ -11,6 +11,7 @@ server:
     force_https: false
     flask_secret_key: null
     generate_cache_control_headers: false
+    url_prefix: null
 
   authentication:
     # The authentication types may be "none" or "session"


### PR DESCRIPTION
This attempts to address #2319 

## Changes
- Adds a `--url-prefix` launch CLI option
- Adds a `url_prefix` server app config option and sane default value
- Attempts to prefix all of the app URLs the new config option when setting up the server

### Open questions

- [ ] Is `--url-prefix` the right name for this? I can see `--base-url-path` being nice too
- [ ] This appears to properly prefix static assets but does it for all cases?
- [ ] I'm not sure what the intent of the `czi_hosted` server is, should that also have this option?
