### PR TITLE
Correctly handle non-finite numbers in heuristic determination of X distribution

### DIFF
--- a/backend/common/compute/estimate_distribution.py
+++ b/backend/common/compute/estimate_distribution.py
@@ -8,10 +8,6 @@ from backend.common.constants import XApproximateDistribution
 @numba.njit(error_model="numpy", nogil=True)
 def min_max(arr: np.ndarray):
     """Return (min, max) values for the ndarray."""
-    n = arr.size
-    odd = n % 2
-    if odd:
-        n -= 1
 
     # initialize to first finite value in array.  Normally,
     # this will exit on the first value.
@@ -21,8 +17,10 @@ def min_max(arr: np.ndarray):
             break
 
     # now find min/max, unrolled by two
+    odd = arr.size % 2
+    unrolled_loop_limit = arr.size - 1 if odd else arr.size
     i = 0
-    while i < n:
+    while i < unrolled_loop_limit:
         x = arr[i]
         y = arr[i + 1]
 
@@ -36,8 +34,9 @@ def min_max(arr: np.ndarray):
         max_val = max(y, max_val)
         i += 2
 
+    # handle the tail if any
     if odd:
-        x = arr[n]
+        x = arr[arr.size - 1]
 
         # ignore non-finites
         x = x if np.isfinite(x) else min_val

--- a/backend/common/compute/estimate_distribution.py
+++ b/backend/common/compute/estimate_distribution.py
@@ -5,27 +5,51 @@ from scipy import sparse
 from backend.common.constants import XApproxDistribution
 
 
+def dtype_limits(arr: np.ndarray):
+    if arr.dtype.kind == "f":
+        finf = np.finfo(arr.dtype)
+        return (finf.min, finf.max)
+    if arr.dtype.kind in ["u", "i"]:
+        iinf = np.iinfo(arr.dtype)
+        return (iinf.min, iinf.max)
+    # error
+    return (0, 0)
+
+
 @numba.njit(fastmath=True, error_model="numpy", nogil=True)
-def min_max(arr):
+def min_max(arr: np.ndarray, min_limit, max_limit):
     """Return (min, max) values for the ndarray."""
     n = arr.size
     odd = n % 2
-    if not odd:
+    if odd:
         n -= 1
-    max_val = min_val = arr[0]
-    i = 1
+
+    max_val, min_val = min_limit, max_limit
+
+    i = 0
     while i < n:
         x = arr[i]
         y = arr[i + 1]
+
+        # ignore non-finites
+        x = x if np.isfinite(x) else min_val
+        y = y if np.isfinite(y) else min_val
+
         if x > y:
             x, y = y, x
         min_val = min(x, min_val)
         max_val = max(y, max_val)
         i += 2
-    if not odd:
+
+    if odd:
         x = arr[n]
+
+        # ignore non-finites
+        x = x if np.isfinite(x) else min_val
+
         min_val = min(x, min_val)
         max_val = max(x, max_val)
+
     return min_val, max_val
 
 
@@ -38,6 +62,10 @@ def estimate_approximate_distribution(X) -> XApproxDistribution:
     any (max-min) range in excess of 24 is implies tens of millions of
     observations of a single feature and so is extremely unlikely.
     """
+    if X.size == 0:
+        # default
+        return XApproxDistribution.NORMAL
+
     if sparse.isspmatrix_csc(X) or sparse.isspmatrix_csr(X):
         Xdata = X.data
     elif type(X) is np.ndarray:
@@ -47,16 +75,21 @@ def estimate_approximate_distribution(X) -> XApproxDistribution:
     else:
         raise TypeError(f"Unsupported matrix type: {str(type(X))}")
 
+    min_limit, max_limit = dtype_limits(Xdata)
+
     CHUNKSIZE = 1 << 24
     if Xdata.size > CHUNKSIZE:
         min_val = max_val = Xdata[0]
         with concurrent.futures.ThreadPoolExecutor() as tp:
-            for (_min, _max) in tp.map(min_max, [Xdata[i : i + CHUNKSIZE] for i in range(0, Xdata.size, CHUNKSIZE)]):
+            for (_min, _max) in tp.map(
+                lambda p: min_max(*p),
+                [[Xdata[i : i + CHUNKSIZE], min_limit, max_limit] for i in range(0, Xdata.size, CHUNKSIZE)],
+            ):
                 min_val = min(_min, min_val)
                 max_val = max(_max, max_val)
 
     else:
-        min_val, max_val = min_max(Xdata)
+        min_val, max_val = min_max(Xdata, min_limit, max_limit)
 
     excess_range = (max_val - min_val) > 24
     return XApproxDistribution.COUNT if excess_range else XApproxDistribution.NORMAL

--- a/backend/common/compute/estimate_distribution.py
+++ b/backend/common/compute/estimate_distribution.py
@@ -12,8 +12,8 @@ def dtype_limits(arr: np.ndarray):
     if arr.dtype.kind in ["u", "i"]:
         iinf = np.iinfo(arr.dtype)
         return (iinf.min, iinf.max)
-    # error
-    return (0, 0)
+    # error - should never occur
+    raise TypeError(f"Unsupported matrix dtype: {arr.dtype.name}")
 
 
 @numba.njit(fastmath=True, error_model="numpy", nogil=True)
@@ -62,8 +62,11 @@ def estimate_approximate_distribution(X) -> XApproxDistribution:
     any (max-min) range in excess of 24 is implies tens of millions of
     observations of a single feature and so is extremely unlikely.
     """
+    if X.dtype not in ["i", "u", "f"]:
+        raise TypeError(f"Unsupported matrix dtype: {X.dtype.name}")
+
     if X.size == 0:
-        # default
+        # default - empty array
         return XApproxDistribution.NORMAL
 
     if sparse.isspmatrix_csc(X) or sparse.isspmatrix_csr(X):
@@ -73,7 +76,7 @@ def estimate_approximate_distribution(X) -> XApproxDistribution:
             X.size,
         )
     else:
-        raise TypeError(f"Unsupported matrix type: {str(type(X))}")
+        raise TypeError(f"Unsupported matrix format: {str(type(X))}")
 
     min_limit, max_limit = dtype_limits(Xdata)
 

--- a/backend/test/test_server/unit/compute/test_est_dist.py
+++ b/backend/test/test_server/unit/compute/test_est_dist.py
@@ -12,42 +12,42 @@ class EstDistTest(unittest.TestCase):
     """Tests the diffexp returns the expected results for one test case, using the h5ad
     adaptor types and different algorithms."""
 
-    # def load_dataset(self, path, extra_server_config={}, extra_dataset_config={}):
-    #     config = app_config(path, extra_server_config=extra_server_config, extra_dataset_config=extra_dataset_config)
-    #     loader = MatrixDataLoader(path)
-    #     adaptor = loader.open(config)
-    #     return adaptor
+    def load_dataset(self, path, extra_server_config={}, extra_dataset_config={}):
+        config = app_config(path, extra_server_config=extra_server_config, extra_dataset_config=extra_dataset_config)
+        loader = MatrixDataLoader(path)
+        adaptor = loader.open(config)
+        return adaptor
 
-    # def test_adaptestimate_approximate_distribution(self):
-    #     adaptor = self.load_dataset(f"{PROJECT_ROOT}/example-dataset/pbmc3k.h5ad")
-    #     self.assertEqual(adaptor.get_X_approximate_distribution(), XApproximateDistribution.NORMAL)
+    def test_adaptestimate_approximate_distribution(self):
+        adaptor = self.load_dataset(f"{PROJECT_ROOT}/example-dataset/pbmc3k.h5ad")
+        self.assertEqual(adaptor.get_X_approximate_distribution(), XApproximateDistribution.NORMAL)
 
-    # def test_estimate_approximate_distribution(self):
-    #     raw = np.random.exponential(scale=1000, size=(100, 40))
+    def test_estimate_approximate_distribution(self):
+        raw = np.random.exponential(scale=1000, size=(100, 40))
 
-    #     # empty
-    #     self.assertEqual(estimate_approximate_distribution(np.zeros((0,))), XApproximateDistribution.NORMAL)
+        # empty
+        self.assertEqual(estimate_approximate_distribution(np.zeros((0,))), XApproximateDistribution.NORMAL)
 
-    #     # ndarray
-    #     self.assertEqual(estimate_approximate_distribution(raw), XApproximateDistribution.COUNT)
-    #     self.assertEqual(estimate_approximate_distribution(np.log1p(raw)), XApproximateDistribution.NORMAL)
+        # ndarray
+        self.assertEqual(estimate_approximate_distribution(raw), XApproximateDistribution.COUNT)
+        self.assertEqual(estimate_approximate_distribution(np.log1p(raw)), XApproximateDistribution.NORMAL)
 
-    #     # csr_matrix
-    #     self.assertEqual(estimate_approximate_distribution(sparse.csr_matrix(raw)), XApproximateDistribution.COUNT)
-    #     self.assertEqual(
-    #         estimate_approximate_distribution(sparse.csr_matrix(np.log1p(raw))), XApproximateDistribution.NORMAL
-    #     )
+        # csr_matrix
+        self.assertEqual(estimate_approximate_distribution(sparse.csr_matrix(raw)), XApproximateDistribution.COUNT)
+        self.assertEqual(
+            estimate_approximate_distribution(sparse.csr_matrix(np.log1p(raw))), XApproximateDistribution.NORMAL
+        )
 
-    #     # csc_matrix
-    #     self.assertEqual(estimate_approximate_distribution(sparse.csc_matrix(raw)), XApproximateDistribution.COUNT)
-    #     self.assertEqual(
-    #         estimate_approximate_distribution(sparse.csc_matrix(np.log1p(raw))), XApproximateDistribution.NORMAL
-    #     )
+        # csc_matrix
+        self.assertEqual(estimate_approximate_distribution(sparse.csc_matrix(raw)), XApproximateDistribution.COUNT)
+        self.assertEqual(
+            estimate_approximate_distribution(sparse.csc_matrix(np.log1p(raw))), XApproximateDistribution.NORMAL
+        )
 
-    #     # BIG (ie, trigger MT)
-    #     big = np.random.exponential(scale=100, size=(1_000_000, 100))
-    #     self.assertEqual(estimate_approximate_distribution(big), XApproximateDistribution.COUNT)
-    #     self.assertEqual(estimate_approximate_distribution(np.log1p(big)), XApproximateDistribution.NORMAL)
+        # BIG (ie, trigger MT)
+        big = np.random.exponential(scale=100, size=(1_000_000, 100))
+        self.assertEqual(estimate_approximate_distribution(big), XApproximateDistribution.COUNT)
+        self.assertEqual(estimate_approximate_distribution(np.log1p(big)), XApproximateDistribution.NORMAL)
 
     def test_unsupported_throws(self):
         # dtypes and matrix formats we do not support

--- a/backend/test/test_server/unit/compute/test_est_dist.py
+++ b/backend/test/test_server/unit/compute/test_est_dist.py
@@ -25,6 +25,9 @@ class EstDistTest(unittest.TestCase):
     def test_estimate_approximate_distribution(self):
         raw = np.random.exponential(scale=1000, size=(100, 40))
 
+        # empty
+        self.assertEqual(estimate_approximate_distribution(np.zeros((0,))), XApproxDistribution.NORMAL)
+
         # ndarray
         self.assertEqual(estimate_approximate_distribution(raw), XApproxDistribution.COUNT)
         self.assertEqual(estimate_approximate_distribution(np.log1p(raw)), XApproxDistribution.NORMAL)
@@ -35,7 +38,82 @@ class EstDistTest(unittest.TestCase):
             estimate_approximate_distribution(sparse.csr_matrix(np.log1p(raw))), XApproxDistribution.NORMAL
         )
 
+        # csc_matrix
+        self.assertEqual(estimate_approximate_distribution(sparse.csc_matrix(raw)), XApproxDistribution.COUNT)
+        self.assertEqual(
+            estimate_approximate_distribution(sparse.csc_matrix(np.log1p(raw))), XApproxDistribution.NORMAL
+        )
+
         # BIG (ie, trigger MT)
         big = np.random.exponential(scale=100, size=(1_000_000, 100))
         self.assertEqual(estimate_approximate_distribution(big), XApproxDistribution.COUNT)
         self.assertEqual(estimate_approximate_distribution(np.log1p(big)), XApproxDistribution.NORMAL)
+
+    def test_unsupported_throws(self):
+
+        # dtypes and matrix formats we do not support
+        with self.assertRaises(TypeError):
+            estimate_approximate_distribution(np.array(["a", "b"]))
+        with self.assertRaises(TypeError):
+            estimate_approximate_distribution(sparse.coo_matrix(np.array([[0, 1, 2], [3, 0, 2]])))
+
+    def test_nonfinites(self):
+        def put(arr, ind, vals):
+            # like np.put, but creates and returns a modified copy of original array
+            a = arr.copy()
+            np.put(a, ind, vals)
+            return a
+
+        # non-finites
+        self.assertEqual(estimate_approximate_distribution(np.array([np.nan])), XApproxDistribution.COUNT)
+        self.assertEqual(estimate_approximate_distribution(np.array([np.PINF])), XApproxDistribution.COUNT)
+        self.assertEqual(estimate_approximate_distribution(np.array([np.NINF])), XApproxDistribution.COUNT)
+        self.assertEqual(estimate_approximate_distribution(np.array([np.PINF, np.NINF])), XApproxDistribution.COUNT)
+        self.assertEqual(
+            estimate_approximate_distribution(np.array([np.nan, np.PINF, np.NINF])), XApproxDistribution.COUNT
+        )
+
+        raw = np.random.exponential(scale=1000, size=(100, 40))
+        logged = np.log1p(raw)
+
+        self.assertEqual(
+            estimate_approximate_distribution(put(raw, [np.nan], [1])),
+            XApproxDistribution.COUNT,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(raw, [np.PINF], [1])),
+            XApproxDistribution.COUNT,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(raw, [np.NINF], [1])),
+            XApproxDistribution.COUNT,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(raw, [np.nan, np.PINF, np.NINF], [1, 3, 88])),
+            XApproxDistribution.COUNT,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(raw, [np.nan, np.nan], [0, 1])),
+            XApproxDistribution.COUNT,
+        )
+
+        self.assertEqual(
+            estimate_approximate_distribution(put(logged, [np.nan], [1])),
+            XApproxDistribution.NORMAL,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(logged, [np.PINF], [1])),
+            XApproxDistribution.NORMAL,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(logged, [np.NINF], [1])),
+            XApproxDistribution.NORMAL,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(logged, [np.nan, np.PINF, np.NINF], [1, 3, 88])),
+            XApproxDistribution.NORMAL,
+        )
+        self.assertEqual(
+            estimate_approximate_distribution(put(logged, [np.nan, np.nan], [0, 1])),
+            XApproxDistribution.NORMAL,
+        )


### PR DESCRIPTION
The existing heuristic did not account for non-finites.  This PR:
* Adds explicit support to the algorithm for non-finites, plus a few other edge conditions (eg, sparse array in an  unsupported format)
* adds test cases for the above

Fixes #2329 
