### PR TITLE
Disabled @blueprintjs/classes-constants. #2288.

### DIFF
--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -1,3 +1,4 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
@@ -95,8 +96,6 @@ module.exports = {
         devDependencies: true,
       },
     ],
-    // Temporarily disabled due to "Parsing error: Property assignment expected" error introduced by rule on --fix
-    "@blueprintjs/classes-constants": "off",
   },
   overrides: [
     {
@@ -117,3 +116,4 @@ module.exports = {
     },
   ],
 };
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -95,6 +95,8 @@ module.exports = {
         devDependencies: true,
       },
     ],
+    // Temporarily disabled due to "Parsing error: Property assignment expected" error introduced by rule on --fix
+    "@blueprintjs/classes-constants": "off",
   },
   overrides: [
     {

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -1,3 +1,4 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
@@ -83,3 +84,4 @@ const devConfig = {
 };
 
 module.exports = merge(sharedConfig, devConfig);
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,8 +1,8 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 const path = require("path");
 const fs = require("fs");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
-// eslint-disable-next-line @blueprintjs/classes-constants -- incorrect match
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 const src = path.resolve("src");
@@ -75,3 +75,4 @@ module.exports = {
     }),
   ],
 };
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */


### PR DESCRIPTION
#### Reviewers
**Functional:**
@tihuan, @colinmegill 

---

## Changes
* Temporarily disabled `@blueprintjs/classes-constants` due to "Parsing error: Property assignment expected" error introduced by rule when running `eslint --fix` on commit.