### PR TITLE
Added @typescript-eslint/recommended config with suppressions

### DIFF
--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -134,8 +134,14 @@ export async function resetCategory(category: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-async function calcCoordinate(testId: any, xAsPercent: any, yAsPercent: any) {
+export async function calcCoordinate(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  testId: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  xAsPercent: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  yAsPercent: any
+) {
   const el = await waitByID(testId);
   // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
   const size = await el.boxModel();
@@ -148,8 +154,12 @@ async function calcCoordinate(testId: any, xAsPercent: any, yAsPercent: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-async function calcDragCoordinates(testId: any, coordinateAsPercent: any) {
+export async function calcDragCoordinates(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  testId: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  coordinateAsPercent: any
+) {
   return {
     start: await calcCoordinate(
       testId,
@@ -383,8 +393,12 @@ export async function duplicateCategory(categoryName: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-async function renameCategory(oldCategoryName: any, newCategoryName: any) {
+export async function renameCategory(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  oldCategoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+  newCategoryName: any
+) {
   await clickOn(`${oldCategoryName}:see-actions`);
   await clickOn(`${oldCategoryName}:edit-category-mode`);
   await clearInputAndTypeInto(

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -18,6 +18,7 @@ import {
 
 import { appUrlBase, TEST_EMAIL, TEST_PASSWORD } from "./config";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function drag(testId: any, start: any, end: any, lasso = false) {
   const layout = await waitByID(testId);
   // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -43,6 +44,7 @@ export async function drag(testId: any, start: any, end: any, lasso = false) {
   await page.mouse.up();
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function clickOnCoordinate(testId: any, coord: any) {
   const layout = await expect(page).toMatchElement(getTestId(testId));
   const elBox = await layout.boxModel();
@@ -56,7 +58,9 @@ export async function clickOnCoordinate(testId: any, coord: any) {
   await page.mouse.click(x, y);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getAllHistograms(testclass: any, testIds: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const histTestIds = testIds.map((tid: any) => `histogram-${tid}`);
 
   // these load asynchronously, so we need to wait for each histogram individually,
@@ -77,6 +81,7 @@ export async function getAllHistograms(testclass: any, testIds: any) {
   return testIDs.map((id) => id.replace(/^histogram-/, ""));
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getAllCategoriesAndCounts(category: any) {
   // these load asynchronously, so we have to wait for the specific category.
   await waitByID(`category-${category}`);
@@ -93,6 +98,7 @@ export async function getAllCategoriesAndCounts(category: any) {
 
           const count = (row.querySelector(
             "[data-testclass='categorical-value-count']"
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           ) as any).innerText;
 
           return [cat, count];
@@ -101,11 +107,13 @@ export async function getAllCategoriesAndCounts(category: any) {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getCellSetCount(num: any) {
   await clickOn(`cellset-button-${num}`);
   return getOneElementInnerText(`[data-testid='cellset-count-${num}']`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function resetCategory(category: any) {
   const checkboxId = `${category}:category-select`;
   await waitByID(checkboxId);
@@ -125,11 +133,9 @@ export async function resetCategory(category: any) {
   if (isExpanded) await clickOn(`${category}:category-expand`);
 }
 
-export async function calcCoordinate(
-  testId: any,
-  xAsPercent: any,
-  yAsPercent: any
-) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+async function calcCoordinate(testId: any, xAsPercent: any, yAsPercent: any) {
   const el = await waitByID(testId);
   // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
   const size = await el.boxModel();
@@ -141,10 +147,9 @@ export async function calcCoordinate(
   };
 }
 
-export async function calcDragCoordinates(
-  testId: any,
-  coordinateAsPercent: any
-) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+async function calcDragCoordinates(testId: any, coordinateAsPercent: any) {
   return {
     start: await calcCoordinate(
       testId,
@@ -159,6 +164,7 @@ export async function calcDragCoordinates(
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function selectCategory(category: any, values: any, reset = true) {
   if (reset) await resetCategory(category);
 
@@ -170,6 +176,7 @@ export async function selectCategory(category: any, values: any, reset = true) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function expandCategory(category: any) {
   const expand = await waitByID(`${category}:category-expand`);
   // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -179,6 +186,7 @@ export async function expandCategory(category: any) {
   if (notExpanded) await clickOn(`${category}:category-expand`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export async function clip(min = 0, max = 100) {
   await clickOn("visualization-settings");
   await clearInputAndTypeInto("clip-min-input", min);
@@ -186,6 +194,7 @@ export async function clip(min = 0, max = 100) {
   await clickOn("clip-commit");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function createCategory(categoryName: any) {
   await clickOnUntil("open-annotation-dialog", async () => {
     await expect(page).toMatchElement(getTestId("new-category-name"));
@@ -201,14 +210,17 @@ export async function createCategory(categoryName: any) {
 
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function colorByGeneset(genesetName: any) {
   await clickOn(`${genesetName}:colorby-entire-geneset`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function colorByGene(gene: any) {
   await clickOn(`colorby-${gene}`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertColorLegendLabel(label: any) {
   const handle = await waitByID("continuous_legend_color_by_label");
 
@@ -220,6 +232,7 @@ export async function assertColorLegendLabel(label: any) {
   return expect(result).toBe(label);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function expandGeneset(genesetName: any) {
   const expand = await waitByID(`${genesetName}:geneset-expand`);
   // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -229,6 +242,7 @@ export async function expandGeneset(genesetName: any) {
   if (notExpanded) await clickOn(`${genesetName}:geneset-expand`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function createGeneset(genesetName: any) {
   await clickOnUntil("open-create-geneset-dialog", async () => {
     await expect(page).toMatchElement(getTestId("create-geneset-input"));
@@ -239,6 +253,7 @@ export async function createGeneset(genesetName: any) {
   await waitByClass("autosave-complete");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function editGenesetName(genesetName: any, editText: any) {
   const editButton = `${genesetName}:edit-genesetName-mode`;
   const submitButton = `${genesetName}:submit-geneset`;
@@ -250,6 +265,7 @@ export async function editGenesetName(genesetName: any, editText: any) {
   await clickOn(submitButton);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function deleteGeneset(genesetName: any) {
   const targetId = `${genesetName}:delete-geneset`;
 
@@ -263,6 +279,7 @@ export async function deleteGeneset(genesetName: any) {
   await waitByClass("autosave-complete");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertGenesetDoesNotExist(genesetName: any) {
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
   const result = await isElementPresent(
@@ -271,6 +288,7 @@ export async function assertGenesetDoesNotExist(genesetName: any) {
   await expect(result).toBe(false);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertGenesetExists(genesetName: any) {
   const handle = await waitByID(`${genesetName}:geneset-name`);
 
@@ -288,6 +306,7 @@ export async function assertGenesetExists(genesetName: any) {
 
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function addGeneToSet(genesetName: any, geneToAddToSet: any) {
   const submitButton = `${genesetName}:submit-gene`;
 
@@ -296,6 +315,7 @@ export async function addGeneToSet(genesetName: any, geneToAddToSet: any) {
   await clickOn(submitButton);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function removeGene(geneSymbol: any) {
   const targetId = `delete-from-geneset:${geneSymbol}`;
 
@@ -304,6 +324,7 @@ export async function removeGene(geneSymbol: any) {
   await waitByClass("autosave-complete");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertGeneExistsInGeneset(geneSymbol: any) {
   const handle = await waitByID(`${geneSymbol}:gene-label`);
 
@@ -315,6 +336,7 @@ export async function assertGeneExistsInGeneset(geneSymbol: any) {
   return expect(result).toBe(geneSymbol);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertGeneDoesNotExist(geneSymbol: any) {
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
   const result = await isElementPresent(getTestId(`${geneSymbol}:gene-label`));
@@ -322,6 +344,7 @@ export async function assertGeneDoesNotExist(geneSymbol: any) {
   await expect(result).toBe(false);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function expandGene(geneSymbol: any) {
   await clickOn(`maximize-${geneSymbol}`);
 }
@@ -332,6 +355,7 @@ export async function expandGene(geneSymbol: any) {
 
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function duplicateCategory(categoryName: any) {
   await clickOn("open-annotation-dialog");
 
@@ -358,10 +382,9 @@ export async function duplicateCategory(categoryName: any) {
   await waitByClass("autosave-complete");
 }
 
-export async function renameCategory(
-  oldCategoryName: any,
-  newCategoryName: any
-) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+async function renameCategory(oldCategoryName: any, newCategoryName: any) {
   await clickOn(`${oldCategoryName}:see-actions`);
   await clickOn(`${oldCategoryName}:edit-category-mode`);
   await clearInputAndTypeInto(
@@ -371,6 +394,7 @@ export async function renameCategory(
   await clickOn(`${oldCategoryName}:submit-category-edit`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function deleteCategory(categoryName: any) {
   const targetId = `${categoryName}:delete-category`;
 
@@ -384,6 +408,7 @@ export async function deleteCategory(categoryName: any) {
   await assertCategoryDoesNotExist();
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function createLabel(categoryName: any, labelName: any) {
   /**
    * (thuang): This explicit wait is needed, since currently showing
@@ -409,15 +434,20 @@ export async function createLabel(categoryName: any, labelName: any) {
   await clickOn(`${categoryName}:submit-label`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function deleteLabel(categoryName: any, labelName: any) {
   await expandCategory(categoryName);
   await clickOn(`${categoryName}:${labelName}:see-actions`);
   await clickOn(`${categoryName}:${labelName}:delete-label`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export async function renameLabel(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   oldLabelName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   newLabelName: any
 ) {
   await expandCategory(categoryName);
@@ -430,12 +460,14 @@ export async function renameLabel(
   await clickOn(`${categoryName}:${oldLabelName}:submit-label-edit`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function addGeneToSearch(geneName: any) {
   await typeInto("gene-search", geneName);
   await page.keyboard.press("Enter");
   await page.waitForSelector(`[data-testid='histogram-${geneName}']`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function subset(coordinatesAsPercent: any) {
   // In order to deselect the selection after the subset, make sure we have some clear part
   // of the scatterplot we can click on
@@ -450,7 +482,9 @@ export async function subset(coordinatesAsPercent: any) {
   await clickOnCoordinate("layout-graph", clearCoordinate);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function setSellSet(cellSet: any, cellSetNum: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const selections = cellSet.filter((sel: any) => sel.kind === "categorical");
 
   for (const selection of selections) {
@@ -460,18 +494,21 @@ export async function setSellSet(cellSet: any, cellSetNum: any) {
   await getCellSetCount(cellSetNum);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function runDiffExp(cellSet1: any, cellSet2: any) {
   await setSellSet(cellSet1, 1);
   await setSellSet(cellSet2, 2);
   await clickOn("diffexp-button");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function bulkAddGenes(geneNames: any) {
   await clickOn("section-bulk-add");
   await typeInto("input-bulk-add", geneNames.join(","));
   await page.keyboard.press("Enter");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function assertCategoryDoesNotExist(categoryName: any) {
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
   const result = await isElementPresent(
@@ -481,6 +518,7 @@ export async function assertCategoryDoesNotExist(categoryName: any) {
   await expect(result).toBe(false);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export async function login() {
   await goToPage(appUrlBase);
 
@@ -502,6 +540,7 @@ export async function login() {
   expect(page.url()).toContain(appUrlBase);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export async function logout() {
   await clickOnUntil("user-info", async () => {
     await waitByID("log-out");
@@ -514,6 +553,7 @@ export async function logout() {
   await waitByID("log-in");
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function waitUntilFormFieldStable(selector: any) {
   const MAX_RETRY = 10;
   const WAIT_FOR_MS = 200;

--- a/client/__tests__/e2e/e2eAnnotations.test.ts
+++ b/client/__tests__/e2e/e2eAnnotations.test.ts
@@ -76,6 +76,7 @@ const brushThisGeneGeneset = "brush_this_gene";
 const geneBrushedCellCount = "109";
 const subsetGeneBrushedCellCount = "96";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function setup(config: any) {
   await goToPage(appUrlBase);
 
@@ -150,6 +151,7 @@ describe.each([
     await expect(page).toClick(getTestClass("pop-1-geneset-expand"));
 
     await page.waitForFunction(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (selector: any) => !document.querySelector(selector),
       {},
       getTestClass("gene-loading-spinner")
@@ -165,6 +167,7 @@ describe.each([
     await expect(page).toClick(getTestClass("pop-2-geneset-expand"));
 
     await page.waitForFunction(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (selector: any) => !document.querySelector(selector),
       {},
       getTestClass("gene-loading-spinner")
@@ -362,9 +365,11 @@ describe.each([
     expect(actualLabelName).toBe(expectedLabelName);
     expect(actualLabelCount).toBe(expectedLabelCount);
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     async function getInnerText(element: any, className: any) {
       return element.$eval(
         getTestClass(className),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (node: any) => node?.innerText
       );
     }
@@ -531,6 +536,7 @@ describe.each([
     expect(result).toMatchSnapshot();
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   async function assertCategoryExists(categoryName: any) {
     const handle = await waitByID(`${categoryName}:category-label`);
 
@@ -542,6 +548,7 @@ describe.each([
     return expect(result).toBe(categoryName);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   async function assertLabelExists(categoryName: any, labelName: any) {
     await expect(page).toMatchElement(
       getTestId(`${categoryName}:category-expand`)
@@ -559,6 +566,7 @@ describe.each([
     ).toBe(labelName);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   async function assertLabelDoesNotExist(categoryName: any, labelName: any) {
     await expandCategory(categoryName);
     const result = await page.$(

--- a/client/__tests__/e2e/puppeteer.setup.ts
+++ b/client/__tests__/e2e/puppeteer.setup.ts
@@ -50,6 +50,7 @@ beforeEach(async () => {
         }
         const errorMsgText = await Promise.all(
           // TODO can we do this without internal properties?
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           msg.args().map((arg: any) => arg._remoteObject.description)
         );
         throw new Error(`Console error: ${errorMsgText}`);

--- a/client/__tests__/e2e/puppeteerUtils.ts
+++ b/client/__tests__/e2e/puppeteerUtils.ts
@@ -1,30 +1,38 @@
 /* eslint-disable no-await-in-loop -- await in loop is needed to emulate sequential user actions */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export function getTestId(id: any) {
   return `[data-testid='${id}']`;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export function getTestClass(className: any) {
   return `[data-testclass='${className}']`;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function waitByID(testId: any, props = {}) {
   return page.waitForSelector(getTestId(testId), props);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function waitByClass(testClass: any, props = {}) {
   return page.waitForSelector(`[data-testclass='${testClass}']`, props);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function waitForAllByIds(testIds: any) {
   await Promise.all(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     testIds.map((testId: any) => page.waitForSelector(getTestId(testId)))
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getAllByClass(testClass: any) {
   return page.$$(`[data-testclass=${testClass}]`);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function typeInto(testId: any, text: any) {
   // blueprint's  typeahead is treating typing weird, clicking & waiting first solves this
   // only works for text without special characters
@@ -36,6 +44,7 @@ export async function typeInto(testId: any, text: any) {
   await page.type(selector, text);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function clearInputAndTypeInto(testId: any, text: any) {
   await waitByID(testId);
   const selector = getTestId(testId);
@@ -49,6 +58,7 @@ export async function clearInputAndTypeInto(testId: any, text: any) {
   await page.type(selector, text);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function clickOn(testId: any, options = {}) {
   await expect(page).toClick(getTestId(testId), options);
 }
@@ -57,6 +67,7 @@ export async function clickOn(testId: any, options = {}) {
  * (thuang): There are times when Puppeteer clicks on a button and the page doesn't respond.
  * So I added clickOnUntil() to retry clicking until a given condition is met.
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function clickOnUntil(testId: any, assert: any) {
   const MAX_RETRY = 10;
   const WAIT_FOR_MS = 200;
@@ -81,18 +92,22 @@ export async function clickOnUntil(testId: any, assert: any) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getOneElementInnerHTML(selector: any, options = {}) {
   await page.waitForSelector(selector, options);
 
   return page.$eval(selector, (el) => el.innerHTML);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getOneElementInnerText(selector: any) {
   expect(page).toMatchElement(selector);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return page.$eval(selector, (el) => (el as any).innerText);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function getElementCoordinates(testId: any) {
   return page.$eval(getTestId(testId), (elem) => {
     const { left, top } = elem.getBoundingClientRect();
@@ -118,6 +133,7 @@ async function nameNewAnnotation() {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function goToPage(url: any) {
   await page.goto(url, {
     waitUntil: "networkidle0",
@@ -127,6 +143,7 @@ export async function goToPage(url: any) {
   await clickTermsOfService();
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 export async function isElementPresent(selector: any, options: any) {
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
   return Boolean(await page.$(selector, options));

--- a/client/__tests__/e2e/screenshot_env.js
+++ b/client/__tests__/e2e/screenshot_env.js
@@ -1,8 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const PuppeteerEnvironment = require("jest-environment-puppeteer");
 require("jest-circus");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ENV_DEFAULT = require("../../../environment.default.json");
 
 // @ts-expect-error ts-migrate(2451) FIXME: Cannot redeclare block-scoped variable 'takeScreen... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const takeScreenshot = require("./takeScreenshot");
 
 class ScreenshotEnvironment extends PuppeteerEnvironment {

--- a/client/__tests__/globalSetup.ts
+++ b/client/__tests__/globalSetup.ts
@@ -1,9 +1,10 @@
-// @ts-ignore FIXME revisit from ts-migrate
 const {
   SecretsManagerClient,
   GetSecretValueCommand,
+  // eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 } = require("@aws-sdk/client-secrets-manager");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const { setup } = require("jest-environment-puppeteer");
 
 const client = new SecretsManagerClient({ region: "us-west-2" });

--- a/client/__tests__/globalSetup.ts
+++ b/client/__tests__/globalSetup.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment --- FIXME: disabled temporarily on migrate to TS.
+// @ts-ignore FIXME: 'globalSetup.ts' cannot be compiled under '--isola... Remove this comment to see the full error message
 const {
   SecretsManagerClient,
   GetSecretValueCommand,

--- a/client/__tests__/reducers/cascade.test.ts
+++ b/client/__tests__/reducers/cascade.test.ts
@@ -21,9 +21,13 @@ describe("cascade", () => {
       [
         "foo",
         (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           currentState: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           action: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           nextSharedState: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           prevSharedState: any
         ) => {
           expect(currentState).toBeUndefined();
@@ -36,9 +40,13 @@ describe("cascade", () => {
       [
         "bar",
         (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           currentState: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           action: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           nextSharedState: any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           prevSharedState: any
         ) => {
           expect(currentState).toBeUndefined();

--- a/client/__tests__/reducers/undoable.test.ts
+++ b/client/__tests__/reducers/undoable.test.ts
@@ -24,6 +24,7 @@ describe("create", () => {
 describe("undo", () => {
   test("expected state modifications", () => {
     const initialState = { a: 0, b: 1000 };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const reducer = (state: any) => {
       return { a: state.a + 1, b: state.b + 1 };
     };
@@ -44,9 +45,11 @@ describe("undo", () => {
 
 describe("redo", () => {
   const initialState = { a: 0, b: 1000 };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const reducer = (state: any) => {
     return { a: state.a + 1, b: state.b + 1 };
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let UR: any;
 
   beforeEach(() => {

--- a/client/__tests__/util/annoMatrix/annoMatrix.test.ts
+++ b/client/__tests__/util/annoMatrix/annoMatrix.test.ts
@@ -14,9 +14,11 @@ import { Dataframe } from "../../../src/util/dataframe";
 enableFetchMocks();
 
 describe("AnnoMatrix", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let annoMatrix: any;
 
   beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (fetch as any).resetMocks(); // reset all fetch mocking state
     // reset all fetch mocking state
     annoMatrix = new AnnoMatrixLoader(
@@ -37,6 +39,7 @@ describe("AnnoMatrix", () => {
     });
 
     test("simple single column fetch", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(serverMocks.annotationsObs(["name_0"]));
 
       const df = await annoMatrix.fetch("obs", "name_0");
@@ -46,6 +49,7 @@ describe("AnnoMatrix", () => {
     });
 
     test("simple multi column fetch", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any)
         .once(serverMocks.annotationsObs(["name_0"]))
         .once(serverMocks.annotationsObs(["n_genes"]));
@@ -56,8 +60,10 @@ describe("AnnoMatrix", () => {
     });
 
     describe("fetch from field", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const getLastTwo = async (field: any) => {
         const columnNames = annoMatrix.getMatrixColumns(field).slice(-2);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (fetch as any).mockResponses(
           ...columnNames.map(() => serverMocks.responder)
         );
@@ -73,18 +79,21 @@ describe("AnnoMatrix", () => {
 
     test("fetch - test all query forms", async () => {
       // single string is a column name
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(serverMocks.annotationsObs(["n_genes"]));
       await expect(annoMatrix.fetch("obs", "n_genes")).resolves.toBeInstanceOf(
         Dataframe
       );
 
       // array of column names, expecting n_genes to be cached.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(serverMocks.annotationsObs(["percent_mito"]));
       await expect(
         annoMatrix.fetch("obs", ["n_genes", "percent_mito"])
       ).resolves.toBeInstanceOf(Dataframe);
 
       // more complex value filter query, enumerated
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(serverMocks.responder);
       await expect(
         annoMatrix.fetch("X", {
@@ -98,6 +107,7 @@ describe("AnnoMatrix", () => {
 
       // more complex value filter query, range
       const varIndex = annoMatrix.schema.annotations.var.index;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any)
         .once(
           serverMocks.withExpected("/data/var", [[`var:${varIndex}`, "SUMO3"]])
@@ -174,6 +184,7 @@ describe("AnnoMatrix", () => {
       expect(am1.nObs).toEqual(am2.nObs);
       expect(am1.nVar).toEqual(am2.nVar);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any)
         .once(serverMocks.annotationsObs(["n_genes"]))
         .once(serverMocks.annotationsObs(["n_genes"]));
@@ -191,6 +202,7 @@ describe("AnnoMatrix", () => {
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'base' implicitly has an 'any' type.
     async function addDrop(base) {
       expect(base.getMatrixColumns("obs")).not.toContain("foo");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(base.fetch("obs", "foo")).rejects.toThrow(
         "unknown column name"
@@ -216,6 +228,7 @@ describe("AnnoMatrix", () => {
       const am2 = am1.dropObsColumn("foo");
       expect(base.getMatrixColumns("obs")).not.toContain("foo");
       expect(am2.getMatrixColumns("obs")).not.toContain("foo");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(am2.fetch("obs", "foo")).rejects.toThrow(
         "unknown column name"
@@ -239,6 +252,7 @@ describe("AnnoMatrix", () => {
       const am4 = clip(am3, 0, 1);
       await addDrop(am4);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockResponse(serverMocks.responder);
 
       await am1.fetch("obs", am1.getMatrixColumns("obs"));
@@ -246,6 +260,7 @@ describe("AnnoMatrix", () => {
       await am3.fetch("obs", am3.getMatrixColumns("obs"));
       await am4.fetch("obs", am4.getMatrixColumns("obs"));
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).resetMocks();
 
       await addDrop(am1);
@@ -292,6 +307,7 @@ describe("AnnoMatrix", () => {
       );
 
       /* drop column */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       am = am1.dropObsColumn("test");
       await expect(am.fetch("obs", "test")).rejects.toThrow(
@@ -313,6 +329,7 @@ describe("AnnoMatrix", () => {
       const am3 = isubset(annoMatrix, [10, 1, 0, 30, 2]);
       await addSetDrop(am3);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockResponse(serverMocks.responder);
 
       await am1.fetch("obs", am1.getMatrixColumns("obs"));

--- a/client/__tests__/util/annoMatrix/crossfilter.test.ts
+++ b/client/__tests__/util/annoMatrix/crossfilter.test.ts
@@ -17,10 +17,13 @@ import { rangeFill } from "../../../src/util/range";
 enableFetchMocks();
 
 describe("AnnoMatrixCrossfilter", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let annoMatrix: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let crossfilter: any;
 
   beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (fetch as any).resetMocks(); // reset all fetch mocking state
     // reset all fetch mocking state
     annoMatrix = new AnnoMatrixLoader(
@@ -68,6 +71,7 @@ describe("AnnoMatrixCrossfilter", () => {
         crossfilter.obsCrossfilter.hasDimension("obs/louvain")
       ).toBeFalsy();
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(["louvain"], [obsLouvain])
       );
@@ -79,6 +83,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         newCrossfilter.obsCrossfilter.hasDimension("obs/louvain")
       ).toBeTruthy();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       expect((fetch as any).mock.calls).toHaveLength(1);
 
       newCrossfilter = await crossfilter.select("obs", "louvain", {
@@ -90,6 +95,7 @@ describe("AnnoMatrixCrossfilter", () => {
     test("simple column select", async () => {
       let xfltr;
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(["louvain"], [obsLouvain])
       );
@@ -130,10 +136,12 @@ describe("AnnoMatrixCrossfilter", () => {
       const values = df.col("louvain").asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (val: any, idx: any) =>
           !["NK cells", "B cells"].includes(val) !== !selected[idx]
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(["n_genes"], [new Int32Array(obsNGenes)])
       );
@@ -168,6 +176,7 @@ describe("AnnoMatrixCrossfilter", () => {
       const varIndex = annoMatrix.schema.annotations.var.index;
 
       const { nObs } = annoMatrix.schema.dataframe;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(
           ["TEST"],
@@ -205,14 +214,17 @@ describe("AnnoMatrixCrossfilter", () => {
       const values = df.icol(0).asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (val: any, idx: any) => !(val >= 0 && val <= 50) !== !selected[idx]
       );
       expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         selected.reduce((acc: any, val: any) => (val ? acc + 1 : acc), 0)
       ).toEqual(xfltr.countSelected());
     });
 
     test("spatial column select", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(
           ["umap_0", "umap_1"],
@@ -241,6 +253,7 @@ describe("AnnoMatrixCrossfilter", () => {
       let xfltr = new AnnoMatrixObsCrossfilter(annoMatrixSubset);
       expect(xfltr.countSelected()).toEqual(annoMatrixSubset.nObs);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(["louvain"], [obsLouvain])
       );
@@ -256,6 +269,7 @@ describe("AnnoMatrixCrossfilter", () => {
       const values = df.col("louvain").asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (val: any, idx: any) =>
           !["NK cells", "B cells"].includes(val) !== !selected[idx]
       );
@@ -270,6 +284,7 @@ describe("AnnoMatrixCrossfilter", () => {
         "unable to obsSelect upon the var dimension"
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(crossfilter.select("obs", "foo")).rejects.toThrow(
         "unknown column name"
@@ -281,6 +296,7 @@ describe("AnnoMatrixCrossfilter", () => {
     /*
     test the matrix mutators via crossfilter proxy
     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     async function helperAddTestCol(cf: any, colName: any, colSchema = null) {
       expect(
         cf.annoMatrix.getMatrixColumns("obs").includes(colName)
@@ -301,6 +317,7 @@ describe("AnnoMatrixCrossfilter", () => {
       const xfltr = cf.addObsColumn(colSchema, Array, initValue);
       expect(
         xfltr.annoMatrix.schema.annotations.obs.columns.filter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (v: any) => v.name === colName
         )
       ).toHaveLength(1);
@@ -331,6 +348,7 @@ describe("AnnoMatrixCrossfilter", () => {
       });
       expect(
         xfltr.annoMatrix.schema.annotations.obs.columns.filter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (v: any) => v.name === "foo"
         )
       ).toHaveLength(1);
@@ -340,7 +358,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         df
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .every((v: any) => v === "A")
       ).toBeTruthy();
 
@@ -378,10 +396,12 @@ describe("AnnoMatrixCrossfilter", () => {
       xfltr = xfltr.dropObsColumn("foo");
       expect(
         xfltr.annoMatrix.schema.annotations.obs.columns.filter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (v: any) => v.name === "foo"
         )
       ).toHaveLength(0);
       expect(xfltr.annoMatrix.schema.annotations.obsByName.foo).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(xfltr.annoMatrix.fetch("obs", "foo")).rejects.toThrow(
         "unknown column name"
@@ -395,6 +415,7 @@ describe("AnnoMatrixCrossfilter", () => {
       });
       xfltr = xfltr.dropObsColumn("bar");
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(xfltr.select("obs", "bar", { mode: "all" })).rejects.toThrow(
         "unknown column name"
@@ -421,6 +442,7 @@ describe("AnnoMatrixCrossfilter", () => {
         type: "categorical",
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(xfltr.annoMatrix.fetch("obs", "foo")).rejects.toThrow(
         "unknown column name"
@@ -436,6 +458,7 @@ describe("AnnoMatrixCrossfilter", () => {
       });
       xfltr = xfltr.renameObsColumn("bar", "xyz");
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).mockRejectOnce(new Error("unknown column name"));
       await expect(xfltr.select("obs", "bar", { mode: "all" })).rejects.toThrow(
         "unknown column name"
@@ -446,6 +469,7 @@ describe("AnnoMatrixCrossfilter", () => {
     });
 
     test("addObsAnnoCategory", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       let xfltr: any;
 
       // catch unknown or readonly columns
@@ -515,7 +539,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .every((v: any) => v === "unassigned")
       ).toBeTruthy();
       expect(xfltr.annoMatrix.getColumnSchema("obs", "foo")).toMatchObject({
@@ -534,7 +558,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr1.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .every((v: any) => v === "unassigned")
       ).toBeTruthy();
       expect(xfltr1.annoMatrix.getColumnSchema("obs", "foo")).toMatchObject({
@@ -557,7 +581,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr2.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .every((v: any) => v === "red")
       ).toBeTruthy();
       expect(xfltr2.annoMatrix.getColumnSchema("obs", "foo")).toMatchObject({
@@ -593,7 +617,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .every((v: any) => v === "unassigned")
       ).toBeTruthy();
       const xfltr1 = await xfltr.setObsColumnValues("foo", [0, 10], "purple");
@@ -602,6 +626,7 @@ describe("AnnoMatrixCrossfilter", () => {
           .col("foo")
           .asArray()
           .every(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             (v: any, i: any) =>
               v === "unassigned" || (v === "purple" && (i === 0 || i === 10))
           )
@@ -660,7 +685,7 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr1.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .filter((v: any) => v === "purple")
       ).toHaveLength(2);
 
@@ -668,13 +693,13 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(
         (await xfltr1.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .filter((v: any) => v === "magenta")
       ).toHaveLength(2);
       expect(
         (await xfltr1.annoMatrix.fetch("obs", "foo"))
           .col("foo")
-          .asArray()
+          .asArray() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           .filter((v: any) => v === "purple")
       ).toHaveLength(0);
       expect(xfltr1.annoMatrix.getColumnSchema("obs", "foo")).toMatchObject({
@@ -695,6 +720,7 @@ describe("AnnoMatrixCrossfilter", () => {
   describe("edge cases", () => {
     test("transition from empty annoMatrix", async () => {
       // select before fetch needs to work
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (fetch as any).once(
         serverMocks.dataframeResponse(["louvain"], [obsLouvain])
       );
@@ -702,6 +728,7 @@ describe("AnnoMatrixCrossfilter", () => {
         mode: "exact",
         values: "B cells",
       });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       expect((fetch as any).mock.calls).toHaveLength(1);
       expect(xfltr.obsCrossfilter.hasDimension("obs/louvain")).toBeTruthy();
       expect(xfltr.obsCrossfilter.all()).toBe(xfltr.annoMatrix._cache.obs);

--- a/client/__tests__/util/annoMatrix/serverMocks/index.ts
+++ b/client/__tests__/util/annoMatrix/serverMocks/index.ts
@@ -1,5 +1,6 @@
 export const baseDataURL = "https://a.fake.url/api/v0.2";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 (window as any).CELLXGENE = {
   API: {
     prefix: baseDataURL,

--- a/client/__tests__/util/annoMatrix/serverMocks/routes.ts
+++ b/client/__tests__/util/annoMatrix/serverMocks/routes.ts
@@ -14,6 +14,7 @@ const indexedSchema = {
   ),
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function makeMockColumn(s: any, length: any) {
   const { type } = s;
   switch (type) {
@@ -37,8 +38,10 @@ function makeMockColumn(s: any, length: any) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function getEncodedDataframe(colNames: any, length: any, colSchemas: any) {
   const colIndex = new KeyIndex(colNames);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const columns = colSchemas.map((s: any) => makeMockColumn(s, length));
   // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
   const df = new Dataframe([length, colNames.length], columns, null, colIndex);
@@ -46,6 +49,7 @@ function getEncodedDataframe(colNames: any, length: any, colSchemas: any) {
   return body;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function dataframeResponse(colNames: any, columns: any) {
   const colIndex = new KeyIndex(colNames);
   const df = new Dataframe(
@@ -62,8 +66,10 @@ export function dataframeResponse(colNames: any, columns: any) {
   return () => Promise.resolve({ body, init: { status: 200, headers } });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function annotationObsResponse(request: any) {
   const url = new URL(request.url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const params = Array.from((url.searchParams as any).entries());
   const names = params
     // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
@@ -91,8 +97,10 @@ function annotationObsResponse(request: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function annotationVarResponse(request: any) {
   const url = new URL(request.url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const params = Array.from((url.searchParams as any).entries());
   const names = params
     // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
@@ -120,8 +128,10 @@ function annotationVarResponse(request: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function layoutObsResponse(request: any) {
   const url = new URL(request.url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const params = Array.from((url.searchParams as any).entries());
   // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
   const names = params.filter(([k]) => k === "layout-name").map(([, v]) => v);
@@ -150,10 +160,13 @@ function layoutObsResponse(request: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function dataVarResponse(request: any) {
   const url = new URL(request.url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const params = Array.from((url.searchParams as any).entries());
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const colNames = params.map((v) => `${(v as any)[0]}/${(v as any)[1]}`);
   const colSchemas = colNames.map(() => schema.schema.dataframe);
   const body = getEncodedDataframe(
@@ -171,6 +184,7 @@ function dataVarResponse(request: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function responder(request: any) {
   const url = new URL(request.url);
   const { pathname } = url;
@@ -189,29 +203,34 @@ export function responder(request: any) {
   return Promise.reject(new Error("bad URL"));
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function withExpected(expectedURL: any, expectedParams: any) {
   /*
   Do some additional error checking
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   return (request: any) => {
     // if URL is bogus, reject the promise
     const url = new URL(request.url);
     if (!url.pathname.endsWith(expectedURL)) {
       return Promise.reject(new Error("Unexpected URL!"));
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const params = Array.from((url.searchParams as any).entries()).sort(
       // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(a: unknown, b: unknown) => bool... Remove this comment to see the full error message
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (a, b) => (a as any)[0] < (b as any)[0]
     );
     expectedParams = expectedParams
-      .slice()
+      .slice() // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .sort((a: any, b: any) => a[0] < b[0]);
 
     if (
       params.length !== expectedParams.length ||
       !params.every(
         (p, i) =>
-          (p as any)[0] === expectedParams[i][0] &&
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+          (p as any)[0] === expectedParams[i][0] && // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (p as any)[1] === expectedParams[i][1]
       )
     ) {
@@ -222,9 +241,11 @@ export function withExpected(expectedURL: any, expectedParams: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function annotationsObs(names: any) {
   return withExpected(
     "/annotations/obs",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     names.map((name: any) => ["annotation-name", name])
   );
 }

--- a/client/__tests__/util/annoMatrix/whereCache.test.ts
+++ b/client/__tests__/util/annoMatrix/whereCache.test.ts
@@ -219,13 +219,16 @@ describe("whereCache", () => {
       })
     );
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     expect((wc.where as any).field.queryField.has("queryColumn")).toEqual(true);
     expect(
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (wc.where as any).field.queryField.get("queryColumn")
     ).toBeInstanceOf(Map);
     expect(
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (wc.where as any).field.queryField.get("queryColumn").has("queryValue")
     ).toEqual(true);
     expect(_whereCacheGet(wc, schema, "field", query)).toEqual([0, 1, 2]);

--- a/client/__tests__/util/centroid.test.ts
+++ b/client/__tests__/util/centroid.test.ts
@@ -8,8 +8,11 @@ import { indexEntireSchema } from "../../src/util/stateManager/schemaHelpers";
 import { _normalizeCategoricalSchema } from "../../src/annoMatrix/schema";
 
 describe("centroid", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let schema: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let obsAnnotations: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let obsLayout: any;
 
   beforeAll(() => {
@@ -44,6 +47,7 @@ describe("centroid", () => {
       quantile([0.5], obsLayout.col("umap_1").asArray())[0],
     ];
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     centroidResult.forEach((coordinate: any) => {
       expect(coordinate).toEqual(expectedResult);
     });
@@ -68,6 +72,7 @@ describe("centroid", () => {
       quantile([0.5], obsLayout.col("umap_1").asArray())[0],
     ];
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     centroidResult.forEach((coordinate: any) => {
       expect(coordinate).toEqual(expectedResult);
     });

--- a/client/__tests__/util/dataframe/dataframe.test.ts
+++ b/client/__tests__/util/dataframe/dataframe.test.ts
@@ -811,6 +811,7 @@ describe("dataframe factories", () => {
           new Float64Array(3).fill(1.1),
         ]
       );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const dfB = dfA.mapColumns((col: any, idx: any) => {
         expect(dfA.icol(idx).asArray()).toBe(col);
         return col;
@@ -869,6 +870,7 @@ describe("dataframe factories", () => {
 });
 
 describe("dataframe col", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let df: any = null;
   beforeEach(() => {
     df = new Dataframe.Dataframe(

--- a/client/__tests__/util/dataframe/summarize.test.ts
+++ b/client/__tests__/util/dataframe/summarize.test.ts
@@ -1,5 +1,6 @@
 import * as Dataframe from "../../../src/util/dataframe";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function float32Conversion(f: any) {
   return new Float32Array([f])[0];
 }

--- a/client/__tests__/util/promiseLimit.test.ts
+++ b/client/__tests__/util/promiseLimit.test.ts
@@ -1,6 +1,7 @@
 import PromiseLimit from "../../src/util/promiseLimit";
 import { range } from "../../src/util/range";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const delay = (t: any) => new Promise((resolve) => setTimeout(resolve, t));
 
 describe("PromiseLimit", () => {
@@ -52,6 +53,7 @@ describe("PromiseLimit", () => {
     };
 
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 1.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     await Promise.all(range(10).map((i: any) => plimit.add(() => callback(i))));
 
     expect(maxRunning).toEqual(2);

--- a/client/__tests__/util/stateManager/colorHelpers.test.ts
+++ b/client/__tests__/util/stateManager/colorHelpers.test.ts
@@ -125,6 +125,7 @@ describe("categorical color helpers", () => {
       Array.from(schema.annotations.obsByName.categoricalColumn.categories)
     );
     const userDefinedColorTable = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       categoricalColumn: shuffleCats.reduce((acc: any, label: any) => {
         acc[label] = randRGBColor();
         return acc;
@@ -159,23 +160,29 @@ TODO:
 2. user defined colors
 */
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function indexSchema(schema: any) {
   schema.annotations.obsByName = Object.fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.annotations?.obs?.columns?.map((v: any) => [v.name, v]) ?? []
   );
   schema.annotations.varByName = Object.fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.annotations?.var?.columns?.map((v: any) => [v.name, v]) ?? []
   );
   schema.layout.obsByName = Object.fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.layout?.obs?.map((v: any) => [v.name, v]) ?? []
   );
   schema.layout.varByName = Object.fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.layout?.var?.map((v: any) => [v.name, v]) ?? []
   );
 
   return schema;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function makeScale(rgb: any) {
   // make a scale string from a rgb float triple
   return `rgb(${(rgb[0] * 255) >>> 0}, ${(rgb[1] * 255) >>> 0}, ${
@@ -183,6 +190,7 @@ function makeScale(rgb: any) {
   })`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function shuffle(array: any) {
   for (let i = array.length - 1; i > 0; i -= 1) {
     const j = (Math.random() * (i + 1)) >>> 0;

--- a/client/__tests__/util/stateManager/sampleResponses.ts
+++ b/client/__tests__/util/stateManager/sampleResponses.ts
@@ -109,7 +109,9 @@ const anAnnotationsVarJSONResponse = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function encodeTypedArray(builder: any, uType: any, uData: any) {
+  // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
   const uTypeName = NetEncoding.TypedArray[uType];
+  // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
   const ArrayType = NetEncoding[uTypeName];
   const dv = ArrayType.createDataVector(builder, uData);
   builder.startObject(1);

--- a/client/__tests__/util/stateManager/sampleResponses.ts
+++ b/client/__tests__/util/stateManager/sampleResponses.ts
@@ -107,6 +107,7 @@ const anAnnotationsVarJSONResponse = {
     .value(),
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function encodeTypedArray(builder: any, uType: any, uData: any) {
   const uTypeName = NetEncoding.TypedArray[uType];
   const ArrayType = NetEncoding[uTypeName];
@@ -116,6 +117,7 @@ function encodeTypedArray(builder: any, uType: any, uData: any) {
   return builder.endObject();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function encodeMatrix(columns: any, colIndex = undefined) {
   /*
   IMPORTANT: this is not a general purpose encoder.  in particular,

--- a/client/__tests__/util/typedCrossfilter/crossfilter.test.ts
+++ b/client/__tests__/util/typedCrossfilter/crossfilter.test.ts
@@ -126,6 +126,7 @@ const someData = [
   },
 ];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 let payments: any = null;
 beforeEach(() => {
   payments = new Crossfilter(someData);
@@ -141,6 +142,7 @@ describe("ImmutableTypedCrossfilter", () => {
       .addDimension(
         "quantity",
         "scalar",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (i: any, d: any) => d[i].quantity,
         Int32Array
       )
@@ -163,6 +165,7 @@ describe("ImmutableTypedCrossfilter", () => {
     const p2 = payments.addDimension(
       "quantity",
       "scalar",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (i: any, data: any) => data[i].quantity,
       Int32Array
     );
@@ -183,16 +186,18 @@ describe("ImmutableTypedCrossfilter", () => {
       .addDimension(
         "quantity",
         "scalar",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (i: any, d: any) => d[i].quantity,
         Int32Array
-      )
+      ) // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .addDimension("tip", "scalar", (i: any, d: any) => d[i].tip, Float32Array)
       .addDimension(
         "total",
         "scalar",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (i: any, d: any) => d[i].total,
         Float32Array
-      )
+      ) // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .addDimension("type", "enum", (i: any, d: any) => d[i].type);
     expect(p).toBeDefined();
 
@@ -245,18 +250,21 @@ describe("ImmutableTypedCrossfilter", () => {
   });
 
   describe("scalar dimension", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let p: any;
     beforeEach(() => {
       p = payments
         .addDimension(
           "quantity",
           "scalar",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (i: any, d: any) => d[i].quantity,
           Int32Array
         )
         .addDimension(
           "tip",
           "scalar",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (i: any, d: any) => d[i].tip,
           Float32Array
         )
@@ -302,8 +310,10 @@ describe("ImmutableTypedCrossfilter", () => {
   });
 
   describe("enum dimension", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let p: any;
     beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       p = payments.addDimension("type", "enum", (i: any, d: any) => d[i].type);
     });
 
@@ -342,6 +352,7 @@ describe("ImmutableTypedCrossfilter", () => {
   });
 
   describe("spatial dimension", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let p: any;
     beforeEach(() => {
       const X = someData.map((r) => r.coords[0]);
@@ -431,18 +442,21 @@ describe("ImmutableTypedCrossfilter", () => {
   });
 
   describe("non-finite scalars", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let p: any;
     beforeEach(() => {
       p = payments
         .addDimension(
           "quantity",
           "scalar",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (i: any, d: any) => d[i].quantity,
           Int32Array
         )
         .addDimension(
           "nonFinite",
           "scalar",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (i: any, d: any) => d[i].nonFinite,
           Float32Array
         )

--- a/client/__tests__/util/typedCrossfilter/sort.test.ts
+++ b/client/__tests__/util/typedCrossfilter/sort.test.ts
@@ -15,6 +15,7 @@ paths for:
 const pInf = Number.POSITIVE_INFINITY;
 const nInf = Number.NEGATIVE_INFINITY;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function fillRange(arr: any, start = 0) {
   const larr = arr;
   for (let i = 0, len = larr.length; i < len; i += 1) {
@@ -23,6 +24,7 @@ function fillRange(arr: any, start = 0) {
   return larr;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function fillRand(arr: any) {
   for (let i = 0, len = arr.length; i < len; i += 1) {
     arr[i] = Math.random();
@@ -140,6 +142,7 @@ describe("sortIndex", () => {
         const source1 = Type.from([6, 5, 4, 3, 2, 1, 0]);
         const index1 = fillRange(new Uint32Array(source1.length));
         expect(sortIndex(index1, source1)).toMatchObject(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           index1.sort((a: any, b: any) => source1[a] - source1[b])
         );
 
@@ -147,12 +150,14 @@ describe("sortIndex", () => {
         const source2 = Type.from([6, 5, 4, 3, 2, 1]);
         const index2 = fillRange(new Uint32Array(source2.length));
         expect(sortIndex(index2, source2)).toMatchObject(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           index2.sort((a: any, b: any) => source1[a] - source1[b])
         );
 
         const source3 = fillRand(new Type(1000));
         const index3 = fillRange(new Uint32Array(source3.length));
         expect(sortIndex(index3, source3)).toMatchObject(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           index3.sort((a: any, b: any) => source1[a] - source1[b])
         );
       })

--- a/client/configuration/babel/babel.prod.js
+++ b/client/configuration/babel/babel.prod.js
@@ -10,6 +10,7 @@ module.exports = {
       },
     ],
     "@babel/preset-react",
+    // eslint-disable-next-line prettier/prettier --- FIXME: disabled temporarily on migrate to TS.
     "@babel/preset-typescript"
   ],
   plugins: [

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -1,3 +1,4 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
@@ -95,8 +96,6 @@ module.exports = {
         devDependencies: true,
       },
     ],
-    // Temporarily disabled due to "Parsing error: Property assignment expected" error introduced by rule on --fix
-    "@blueprintjs/classes-constants": "off",
   },
   overrides: [
     {
@@ -117,3 +116,4 @@ module.exports = {
     },
   ],
 };
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -4,6 +4,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   extends: [
     "airbnb-typescript",
+    "plugin:@typescript-eslint/recommended",
     "plugin:eslint-comments/recommended",
     "plugin:@blueprintjs/recommended",
     "plugin:compat/recommended",

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -95,6 +95,8 @@ module.exports = {
         devDependencies: true,
       },
     ],
+    // Temporarily disabled due to "Parsing error: Property assignment expected" error introduced by rule on --fix
+    "@blueprintjs/classes-constants": "off",
   },
   overrides: [
     {

--- a/client/configuration/webpack/cspHashPlugin.js
+++ b/client/configuration/webpack/cspHashPlugin.js
@@ -1,6 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies -- this file is a devDependency*/
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const cheerio = require("cheerio");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const crypto = require("crypto");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const digest = (str) => {
@@ -50,4 +54,5 @@ class CspHashPlugin {
 }
 
 module.exports = CspHashPlugin;
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */
 /* eslint-enable import/no-extraneous-dependencies -- enable*/

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -1,3 +1,4 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
@@ -83,3 +84,4 @@ const devConfig = {
 };
 
 module.exports = merge(sharedConfig, devConfig);
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */

--- a/client/configuration/webpack/webpack.config.dev.js
+++ b/client/configuration/webpack/webpack.config.dev.js
@@ -1,14 +1,23 @@
 /* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const webpack = require("webpack");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const { merge } = require("webpack-merge");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const sharedConfig = require("./webpack.config.shared");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const babelOptions = require("../babel/babel.dev");
 
 const fonts = path.resolve("src/fonts");

--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -1,18 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const webpack = require("webpack");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const TerserJSPlugin = require("terser-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const CleanCss = require("clean-css");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const { merge } = require("webpack-merge");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const babelOptions = require("../babel/babel.prod");
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const CspHashPlugin = require("./cspHashPlugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const sharedConfig = require("./webpack.config.shared");
 
 const fonts = path.resolve("src/fonts");

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,8 +1,8 @@
+/* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
 const path = require("path");
 const fs = require("fs");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
-// eslint-disable-next-line @blueprintjs/classes-constants -- incorrect match
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 const src = path.resolve("src");
@@ -75,3 +75,4 @@ module.exports = {
     }),
   ],
 };
+/* eslint-enable @blueprintjs/classes-constants -- we don't import blueprint here  */

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,8 +1,13 @@
 /* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const fs = require("fs");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
+// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 const src = path.resolve("src");

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -146,6 +146,7 @@
         "script-ext-html-webpack-plugin": "^2.1.4",
         "serve-favicon": "^2.5.0",
         "style-loader": "^2.0.0",
+        "suppress-eslint-errors": "^2.0.4",
         "sw-precache-webpack-plugin": "^1.0.0",
         "terser-webpack-plugin": "^5.1.1",
         "typescript": "^4.3.5",
@@ -1743,6 +1744,21 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-function-bind": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-bind/-/plugin-syntax-function-bind-7.12.13.tgz",
@@ -1955,6 +1971,22 @@
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
@@ -2325,6 +2357,23 @@
         "babel-plugin-polyfill-regenerator": "^0.2.0",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -5028,6 +5077,18 @@
       "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
       "dev": true
     },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -5108,6 +5169,15 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
+    },
+    "node_modules/babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true,
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
@@ -10047,6 +10117,15 @@
         "npm": ">=5"
       }
     },
+    "node_modules/flow-parser": {
+      "version": "0.156.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
+      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
@@ -12770,6 +12849,171 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "node_modules/jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/jsdom": {
       "version": "16.5.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
@@ -14145,6 +14389,18 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "dev": true
+    },
+    "node_modules/node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.5"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -17962,6 +18218,30 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -20131,6 +20411,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/suppress-eslint-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/suppress-eslint-errors/-/suppress-eslint-errors-2.0.4.tgz",
+      "integrity": "sha512-Qf4gSrlCznlDzDBJyT7SPEB+67PI7wrfIfbNwFGyRCGyLsYDCgAUBiv74eMyhhKOuQmxyOTiMQGorIShSveY3Q==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "jscodeshift": "^0.11.0",
+        "please-upgrade-node": "^3.1.1"
+      },
+      "bin": {
+        "suppress-eslint-errors": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -20566,6 +20864,30 @@
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/term-size": {
@@ -24013,6 +24335,15 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-syntax-function-bind": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-bind/-/plugin-syntax-function-bind-7.12.13.tgz",
@@ -24219,6 +24550,16 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -24583,6 +24924,17 @@
         "babel-plugin-polyfill-regenerator": "^0.2.0",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
+      }
+    },
+    "@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
       }
     },
     "@babel/preset-modules": {
@@ -26992,6 +27344,15 @@
       "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
       "dev": true
     },
+    "ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -27054,6 +27415,13 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
+    },
+    "babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -31162,6 +31530,12 @@
         "rematrix": "0.2.2"
       }
     },
+    "flow-parser": {
+      "version": "0.156.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
+      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
@@ -33356,6 +33730,149 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "jsdom": {
       "version": "16.5.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
@@ -34505,6 +35022,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "dev": true
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -37631,6 +38157,26 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -39474,6 +40020,18 @@
         }
       }
     },
+    "suppress-eslint-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/suppress-eslint-errors/-/suppress-eslint-errors-2.0.4.tgz",
+      "integrity": "sha512-Qf4gSrlCznlDzDBJyT7SPEB+67PI7wrfIfbNwFGyRCGyLsYDCgAUBiv74eMyhhKOuQmxyOTiMQGorIShSveY3Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "jscodeshift": "^0.11.0",
+        "please-upgrade-node": "^3.1.1"
+      }
+    },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -39851,6 +40409,26 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
+        }
+      }
+    },
+    "temp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "dev": true,
+      "requires": {
+        "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -146,7 +146,6 @@
         "script-ext-html-webpack-plugin": "^2.1.4",
         "serve-favicon": "^2.5.0",
         "style-loader": "^2.0.0",
-        "suppress-eslint-errors": "^2.0.4",
         "sw-precache-webpack-plugin": "^1.0.0",
         "terser-webpack-plugin": "^5.1.1",
         "typescript": "^4.3.5",
@@ -1744,21 +1743,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
-      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-function-bind": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-bind/-/plugin-syntax-function-bind-7.12.13.tgz",
@@ -1971,22 +1955,6 @@
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
-      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-flow": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
@@ -2357,23 +2325,6 @@
         "babel-plugin-polyfill-regenerator": "^0.2.0",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
-      }
-    },
-    "node_modules/@babel/preset-flow": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
-      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -5077,18 +5028,6 @@
       "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
       "dev": true
     },
-    "node_modules/ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -5169,15 +5108,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
-    },
-    "node_modules/babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
@@ -10117,15 +10047,6 @@
         "npm": ">=5"
       }
     },
-    "node_modules/flow-parser": {
-      "version": "0.156.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
-      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
@@ -12849,171 +12770,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
-    "node_modules/jscodeshift": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
-      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.1.6",
-        "@babel/parser": "^7.1.6",
-        "@babel/plugin-proposal-class-properties": "^7.1.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-        "@babel/preset-flow": "^7.0.0",
-        "@babel/preset-typescript": "^7.1.0",
-        "@babel/register": "^7.0.0",
-        "babel-core": "^7.0.0-bridge.0",
-        "colors": "^1.1.2",
-        "flow-parser": "0.*",
-        "graceful-fs": "^4.2.4",
-        "micromatch": "^3.1.10",
-        "neo-async": "^2.5.0",
-        "node-dir": "^0.1.17",
-        "recast": "^0.20.3",
-        "temp": "^0.8.1",
-        "write-file-atomic": "^2.3.0"
-      },
-      "bin": {
-        "jscodeshift": "bin/jscodeshift.js"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "dev": true,
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dev": true,
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/jsdom": {
       "version": "16.5.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
@@ -14389,18 +14145,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "dev": true
-    },
-    "node_modules/node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10.5"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -18218,30 +17962,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
-      "dev": true,
-      "dependencies": {
-        "ast-types": "0.14.2",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -20411,24 +20131,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/suppress-eslint-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/suppress-eslint-errors/-/suppress-eslint-errors-2.0.4.tgz",
-      "integrity": "sha512-Qf4gSrlCznlDzDBJyT7SPEB+67PI7wrfIfbNwFGyRCGyLsYDCgAUBiv74eMyhhKOuQmxyOTiMQGorIShSveY3Q==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "cross-spawn": "^7.0.3",
-        "jscodeshift": "^0.11.0",
-        "please-upgrade-node": "^3.1.1"
-      },
-      "bin": {
-        "suppress-eslint-errors": "bin/index.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -20864,30 +20566,6 @@
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/term-size": {
@@ -24335,15 +24013,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/plugin-syntax-flow": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
-      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
     "@babel/plugin-syntax-function-bind": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-bind/-/plugin-syntax-function-bind-7.12.13.tgz",
@@ -24550,16 +24219,6 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
-      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-flow": "^7.14.5"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -24924,17 +24583,6 @@
         "babel-plugin-polyfill-regenerator": "^0.2.0",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
-      }
-    },
-    "@babel/preset-flow": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
-      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
       }
     },
     "@babel/preset-modules": {
@@ -27344,15 +26992,6 @@
       "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
       "dev": true
     },
-    "ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.1"
-      }
-    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -27415,13 +27054,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
-    },
-    "babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -31530,12 +31162,6 @@
         "rematrix": "0.2.2"
       }
     },
-    "flow-parser": {
-      "version": "0.156.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
-      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
-      "dev": true
-    },
     "follow-redirects": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
@@ -33730,149 +33356,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
-    "jscodeshift": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
-      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.1.6",
-        "@babel/parser": "^7.1.6",
-        "@babel/plugin-proposal-class-properties": "^7.1.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-        "@babel/preset-flow": "^7.0.0",
-        "@babel/preset-typescript": "^7.1.0",
-        "@babel/register": "^7.0.0",
-        "babel-core": "^7.0.0-bridge.0",
-        "colors": "^1.1.2",
-        "flow-parser": "0.*",
-        "graceful-fs": "^4.2.4",
-        "micromatch": "^3.1.10",
-        "neo-async": "^2.5.0",
-        "node-dir": "^0.1.17",
-        "recast": "^0.20.3",
-        "temp": "^0.8.1",
-        "write-file-atomic": "^2.3.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        }
-      }
-    },
     "jsdom": {
       "version": "16.5.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
@@ -35022,15 +34505,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "dev": true
-    },
-    "node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.2"
-      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -38157,26 +37631,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.14.2",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -40020,18 +39474,6 @@
         }
       }
     },
-    "suppress-eslint-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/suppress-eslint-errors/-/suppress-eslint-errors-2.0.4.tgz",
-      "integrity": "sha512-Qf4gSrlCznlDzDBJyT7SPEB+67PI7wrfIfbNwFGyRCGyLsYDCgAUBiv74eMyhhKOuQmxyOTiMQGorIShSveY3Q==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "cross-spawn": "^7.0.3",
-        "jscodeshift": "^0.11.0",
-        "please-upgrade-node": "^3.1.1"
-      }
-    },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -40409,26 +39851,6 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
-        }
-      }
-    },
-    "temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
-      "dev": true,
-      "requires": {
-        "rimraf": "~2.6.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -175,6 +175,7 @@
     "script-ext-html-webpack-plugin": "^2.1.4",
     "serve-favicon": "^2.5.0",
     "style-loader": "^2.0.0",
+    "suppress-eslint-errors": "^2.0.4",
     "sw-precache-webpack-plugin": "^1.0.0",
     "terser-webpack-plugin": "^5.1.1",
     "typescript": "^4.3.5",

--- a/client/package.json
+++ b/client/package.json
@@ -175,7 +175,6 @@
     "script-ext-html-webpack-plugin": "^2.1.4",
     "serve-favicon": "^2.5.0",
     "style-loader": "^2.0.0",
-    "suppress-eslint-errors": "^2.0.4",
     "sw-precache-webpack-plugin": "^1.0.0",
     "terser-webpack-plugin": "^5.1.1",
     "typescript": "^4.3.5",

--- a/client/src/actions/annotation.ts
+++ b/client/src/actions/annotation.ts
@@ -9,8 +9,11 @@ import { MatrixFBS, AnnotationsHelpers } from "../util/stateManager";
 const { isUserAnnotation } = AnnotationsHelpers;
 
 export const annotationCreateCategoryAction = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   newCategoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryToDuplicate: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   /*
   Add a new user-created category to the obs annotations.
@@ -89,8 +92,11 @@ export const annotationCreateCategoryAction = (
 };
 
 export const annotationRenameCategoryAction = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   oldCategoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   newCategoryName: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => (dispatch: any, getState: any) => {
   /*
   Rename a user-created annotation category
@@ -124,8 +130,11 @@ export const annotationRenameCategoryAction = (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const annotationDeleteCategoryAction = (categoryName: any) => (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   /*
@@ -149,9 +158,12 @@ export const annotationDeleteCategoryAction = (categoryName: any) => (
 };
 
 export const annotationCreateLabelInCategory = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labelName: any,
-  assignSelected: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  assignSelected: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   /*
   Add a new label to a user-defined category.  If assignSelected is true, assign
@@ -188,8 +200,10 @@ export const annotationCreateLabelInCategory = (
 };
 
 export const annotationDeleteLabelFromCategory = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
-  labelName: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  labelName: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   /*
   delete a label from a user-defined category
@@ -218,9 +232,13 @@ export const annotationDeleteLabelFromCategory = (
 };
 
 export const annotationRenameLabelInCategory = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   oldLabelName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   newLabelName: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   /*
   label name change
@@ -255,8 +273,11 @@ export const annotationRenameLabelInCategory = (
 };
 
 export const annotationLabelCurrentSelection = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labelName: any
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   /*
   set the label on all currently selected
@@ -284,14 +305,22 @@ export const annotationLabelCurrentSelection = (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function writableAnnotations(annoMatrix: any) {
-  return annoMatrix.schema.annotations.obs.columns
-    .filter((s: any) => s.writable)
-    .map((s: any) => s.name);
+  return (
+    annoMatrix.schema.annotations.obs.columns
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      .filter((s: any) => s.writable)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      .map((s: any) => s.name)
+  );
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const needToSaveObsAnnotations = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   annoMatrix: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   lastSavedAnnoMatrix: any
 ) => {
   /*
@@ -317,12 +346,16 @@ export const needToSaveObsAnnotations = (
 
   // no schema changes; check for change in contents
   return currentWritable.some(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (col: any) => annoMatrix.col(col) !== lastSavedAnnoMatrix.col(col)
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const saveObsAnnotationsAction = () => async (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   /*
@@ -394,8 +427,11 @@ export const saveObsAnnotationsAction = () => async (
   }
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const saveGenesetsAction = () => async (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const state = getState();

--- a/client/src/actions/embedding.ts
+++ b/client/src/actions/embedding.ts
@@ -5,9 +5,13 @@ action creators related to embeddings choice
 import { AnnoMatrixObsCrossfilter } from "../annoMatrix";
 import { _setEmbeddingSubset } from "../util/stateManager/viewStackHelpers";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export async function _switchEmbedding(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   prevAnnoMatrix: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   prevCrossfilter: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   newEmbeddingName: any
 ) {
   /*
@@ -25,8 +29,11 @@ export async function _switchEmbedding(
   return [annoMatrix, obsCrossfilter];
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const layoutChoiceAction = (newLayoutChoice: any) => async (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   /*

--- a/client/src/actions/geneset.ts
+++ b/client/src/actions/geneset.ts
@@ -21,8 +21,11 @@ The behavior manifest in these action creators:
 Note that crossfilter indices are lazy created, as needed.
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const genesetDelete = (genesetName: any) => (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const state = getState();
@@ -43,8 +46,11 @@ export const genesetDelete = (genesetName: any) => (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const genesetAddGenes = (genesetName: any, genes: any) => async (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const state = getState();
@@ -53,6 +59,7 @@ export const genesetAddGenes = (genesetName: any, genes: any) => async (
   const varIndex = schema.annotations.var.index;
   const df = await annoMatrix.fetch("var", varIndex);
   const geneNames = df.col(varIndex).asArray();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genes = genes.reduce((acc: any, gene: any) => {
     if (geneNames.indexOf(gene.geneSymbol) === -1) {
       postUserErrorToast(
@@ -81,8 +88,11 @@ export const genesetAddGenes = (genesetName: any, genes: any) => async (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const genesetDeleteGenes = (genesetName: any, geneSymbols: any) => (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const state = getState();
@@ -101,8 +111,11 @@ Private
 */
 
 function dropGenesetSummaryDimension(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   obsCrossfilter: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   state: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesetName: any
 ) {
   const { annoMatrix, genesets } = state;
@@ -120,6 +133,7 @@ function dropGenesetSummaryDimension(
   return obsCrossfilter.dropDimension("X", query);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function dropGeneDimension(obsCrossfilter: any, state: any, gene: any) {
   const { annoMatrix } = state;
   const varIndex = annoMatrix.schema.annotations?.var?.index;
@@ -134,13 +148,18 @@ function dropGeneDimension(obsCrossfilter: any, state: any, gene: any) {
 }
 
 function dropGeneset(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   state: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesetName: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   geneSymbols: any
 ) {
   const { obsCrossfilter: prevObsCrossfilter } = state;
   const obsCrossfilter = geneSymbols.reduce(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (crossfilter: any, gene: any) =>
       dropGeneDimension(crossfilter, state, gene),
     dropGenesetSummaryDimension(prevObsCrossfilter, state, genesetName)
@@ -150,6 +169,7 @@ function dropGeneset(
     continuousNamespace: { isGeneSetSummary: true },
     selection: genesetName,
   });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   geneSymbols.forEach((g: any) =>
     dispatch({
       type: "continuous metadata histogram cancel",

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -15,6 +15,7 @@ import * as genesetActions from "./geneset";
 /*
 return promise fetching user-configured colors
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function userColorsFetchAndLoad(dispatch: any) {
   return fetchJson("colors").then((response) =>
     dispatch({
@@ -28,6 +29,7 @@ async function schemaFetch() {
   return fetchJson("schema");
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function configFetch(dispatch: any) {
   return fetchJson("config").then((response) => {
     const config = { ...globals.configDefaults, ...response.config };
@@ -39,6 +41,7 @@ async function configFetch(dispatch: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function userInfoFetch(dispatch: any) {
   return fetchJson("userinfo").then((response) => {
     const { userinfo: userInfo } = response || {};
@@ -50,6 +53,7 @@ async function userInfoFetch(dispatch: any) {
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 async function genesetsFetch(dispatch: any, config: any) {
   /* request genesets ONLY if the backend supports the feature */
   const defaultResponse = {
@@ -71,19 +75,24 @@ async function genesetsFetch(dispatch: any, config: any) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function prefetchEmbeddings(annoMatrix: any) {
   /*
   prefetch requests for all embeddings
   */
   const { schema } = annoMatrix;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const available = schema.layout.obs.map((v: any) => v.name);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   available.forEach((embName: any) => annoMatrix.prefetch("emb", embName));
 }
 
 /*
 Application bootstrap
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const doInitialDataLoad = () =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   catchErrorsWrap(async (dispatch: any) => {
     dispatch({ type: "initial data load start" });
 
@@ -114,6 +123,7 @@ const doInitialDataLoad = () =>
       const layoutSchema = schema?.schema?.layout?.obs ?? [];
       if (
         defaultEmbedding &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         layoutSchema.some((s: any) => s.name === defaultEmbedding)
       ) {
         dispatch(embActions.layoutChoiceAction(defaultEmbedding));
@@ -123,6 +133,7 @@ const doInitialDataLoad = () =>
     }
   }, true);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 function requestSingleGeneExpressionCountsForColoringPOST(gene: any) {
   return {
     type: "color by expression",
@@ -130,6 +141,7 @@ function requestSingleGeneExpressionCountsForColoringPOST(gene: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const requestUserDefinedGene = (gene: any) => ({
   type: "request user defined gene success",
 
@@ -138,6 +150,7 @@ const requestUserDefinedGene = (gene: any) => ({
   },
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const dispatchDiffExpErrors = (dispatch: any, response: any) => {
   switch (response.status) {
     case 403:
@@ -162,9 +175,12 @@ const dispatchDiffExpErrors = (dispatch: any, response: any) => {
 };
 
 const requestDifferentialExpression = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   set1: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   set2: any,
   num_genes = 50
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   dispatch({ type: "request differential expression started" });
   try {
@@ -214,6 +230,7 @@ const requestDifferentialExpression = (
     const diffexpLists = { negative: [], positive: [] };
     for (const polarity of Object.keys(diffexpLists)) {
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       diffexpLists[polarity] = response[polarity].map((v: any) => [
         varIndex.at(v[0], varIndexName),
         ...v.slice(1),
@@ -233,6 +250,7 @@ const requestDifferentialExpression = (
   }
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function fetchJson(pathAndQuery: any) {
   return doJsonRequest(
     `${globals.API.prefix}${globals.API.version}${pathAndQuery}`

--- a/client/src/actions/selection.ts
+++ b/client/src/actions/selection.ts
@@ -2,10 +2,13 @@
 Action creators for selection 
 */
 export const selectContinuousMetadataAction = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   type: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   query: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   range: any,
-  oldProps = {}
+  oldProps = {} // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   const { obsCrossfilter: prevObsCrossfilter } = getState();
 
@@ -29,12 +32,21 @@ export const selectContinuousMetadataAction = (
 };
 
 export const selectCategoricalMetadataAction = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   type: any, // action type
-  metadataField: any, // annotation category name
+  // annotation category name
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  metadataField: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labels: any,
-  label: any, // the label being selected/deselected
-  isSelected: any, // bool
+  // the label being selected/deselected
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  label: any,
+  // bool
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  isSelected: any,
   oldProps = {}
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   const {
     obsCrossfilter: prevObsCrossfilter,
@@ -43,6 +55,7 @@ export const selectCategoricalMetadataAction = (
 
   const labelSelectionState = new Map(categoricalSelection[metadataField]);
   labels.forEach(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (l: any) => labelSelectionState.has(l) || labelSelectionState.set(l, true)
   );
   labelSelectionState.set(label, isSelected);
@@ -70,11 +83,18 @@ export const selectCategoricalMetadataAction = (
 };
 
 export const selectCategoricalAllMetadataAction = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   type: any, // action type
-  metadataField: any, // annotation category name
+  // annotation category name
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  metadataField: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labels: any,
-  isSelected: any, // bool, select all or none
+  // bool, select all or none
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  isSelected: any,
   oldProps = {}
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   const {
     obsCrossfilter: prevObsCrossfilter,
@@ -82,6 +102,7 @@ export const selectCategoricalAllMetadataAction = (
   } = getState();
 
   const labelSelectionState = new Map(categoricalSelection[metadataField]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   labels.forEach((label: any) => labelSelectionState.set(label, isSelected));
 
   const selection = { mode: isSelected ? "all" : "none" };
@@ -104,14 +125,19 @@ export const selectCategoricalAllMetadataAction = (
  ** Graph selection-related actions
  **/
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const graphBrushStartAction = () =>
   /* no change to crossfilter until a change fires */
   ({ type: "graph brush start" });
 
 const _graphBrushWithinRectAction = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   type: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   embName: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   brushCoords: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 ) => async (dispatch: any, getState: any) => {
   const { obsCrossfilter: prevObsCrossfilter } = getState();
 
@@ -129,8 +155,11 @@ const _graphBrushWithinRectAction = (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const _graphAllAction = (type: any, embName: any) => async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const { obsCrossfilter: prevObsCrossfilter } = getState();
@@ -145,29 +174,39 @@ const _graphAllAction = (type: any, embName: any) => async (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphBrushChangeAction = (embName: any, brushCoords: any) =>
   _graphBrushWithinRectAction("graph brush change", embName, brushCoords);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphBrushEndAction = (embName: any, brushCoords: any) =>
   _graphBrushWithinRectAction("graph brush end", embName, brushCoords);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphBrushCancelAction = (embName: any) =>
   _graphAllAction("graph brush cancel", embName);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphBrushDeselectAction = (embName: any) =>
   _graphAllAction("graph brush deselect", embName);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const graphLassoStartAction = () =>
   /* no change to crossfilter until a change fires */
   ({ type: "graph lasso start" });
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphLassoCancelAction = (embName: any) =>
   _graphAllAction("graph lasso cancel", embName);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphLassoDeselectAction = (embName: any) =>
   _graphAllAction("graph lasso cancel", embName);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphLassoEndAction = (embName: any, polygon: any) => async (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const { obsCrossfilter: prevObsCrossfilter } = getState();
@@ -192,8 +231,11 @@ export const graphLassoEndAction = (embName: any, polygon: any) => async (
 /*
 Differential expression set selection
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const setCellSetFromSelection = (cellSetId: any) => (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   const { obsCrossfilter } = getState();

--- a/client/src/actions/viewStack.ts
+++ b/client/src/actions/viewStack.ts
@@ -18,8 +18,11 @@ import {
   _userResetSubsetAnnoMatrix,
 } from "../util/stateManager/viewStackHelpers";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const clipAction = (min: any, max: any) => (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dispatch: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getState: any
 ) => {
   /*
@@ -37,6 +40,7 @@ export const clipAction = (min: any, max: any) => (
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const subsetAction = () => (dispatch: any, getState: any) => {
   /*
   Subset the annoMatrix to the current crossfilter selection by pushing a 
@@ -61,6 +65,7 @@ export const subsetAction = () => (dispatch: any, getState: any) => {
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const resetSubsetAction = () => (dispatch: any, getState: any) => {
   /*
   Reset the annoMatrix to all data.  Because we may have multiple views

--- a/client/src/annoMatrix/annoMatrix.ts
+++ b/client/src/annoMatrix/annoMatrix.ts
@@ -17,26 +17,37 @@ import { _queryValidate, _queryCacheKey } from "./query";
 const _dataframeCache = dataframeMemo(128);
 
 export default class AnnoMatrix {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public isView: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public nObs: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public nVar: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public rowIndex: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public schema: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public userFlags: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   public viewOf: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   protected _cache: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   private _pendingLoad: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   private _whereCache: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   private _gcInfo: any;
 
   /*
@@ -69,6 +80,7 @@ export default class AnnoMatrix {
       subset(annoMatrix, rowLabels) -> annoMatrix
   etc.
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   static fields() {
     /*
     return the fields present in the AnnoMatrix instance.
@@ -76,6 +88,7 @@ export default class AnnoMatrix {
     return ["obs", "var", "emb", "X"];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(schema: any, nObs: any, nVar: any, rowIndex = null) {
     /*
     Private constructor - this is an abstract base class.  Do not use.
@@ -132,6 +145,7 @@ export default class AnnoMatrix {
    ** Schema helper/accessors
    **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getMatrixColumns(field) {
     /*
     Return array of column names in the field.  ONLY supported on the
@@ -144,7 +158,7 @@ export default class AnnoMatrix {
     return _schemaColumns(this.schema, field);
   }
 
-  // eslint-disable-next-line class-methods-use-this -- need to be able to call this on instances
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types -- need to be able to call this on instances
   getMatrixFields() {
     /*
     Return array of fields in this annoMatrix.  Currently hard-wired to
@@ -156,6 +170,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getColumnSchema(field, col) {
     /*
     Return the schema for the field & column ,eg,
@@ -169,6 +184,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getColumnDimensions(field, col) {
     /*
     Return the dimensions on this field / column.  For most fields, which are 1D,
@@ -187,10 +203,12 @@ export default class AnnoMatrix {
   /**
    ** General utility methods
    **/
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   base() {
     /*
     return the base of view, or `this` if not a view.
     */
+    // eslint-disable-next-line @typescript-eslint/no-this-alias --- FIXME: disabled temporarily on migrate to TS.
     let annoMatrix = this;
     while (annoMatrix.isView) annoMatrix = annoMatrix.viewOf;
     return annoMatrix;
@@ -200,6 +218,7 @@ export default class AnnoMatrix {
    ** Load / read interfaces
    **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   fetch(field, q) {
     /*
 		Return the given query on a single matrix field as a single dataframe.
@@ -258,6 +277,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   prefetch(field, q) {
     /*
 		Start a data fetch & cache fill.  Identical to fetch() except it does
@@ -289,7 +309,7 @@ export default class AnnoMatrix {
    **/
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'col' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   addObsAnnoCategory(col, category) {
     /*
     Add a new category value (aka "label") to a writable obs column, and return the new AnnoMatrix.
@@ -307,7 +327,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'col' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   async removeObsAnnoCategory(col, category, unassignedCategory) {
     /*
     Remove a category value from an obs column, reassign any obs having that value
@@ -329,7 +349,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'col' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   dropObsColumn(col) {
     /*
     Drop an entire writable column, eg a user-created obs annotation.  Typical use
@@ -346,7 +366,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'colSchema' is declared but its value is never rea... Remove this comment to see the full error message
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   addObsColumn(colSchema, Ctor, value) {
     /*
     Add a new writable OBS annotation column, with the caller-specified schema, initial value
@@ -376,7 +396,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'oldCol' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   renameObsColumn(oldCol, newCol) {
     /*
     Rename the obs column 'oldCol' to have name 'newCol' and returns new AnnoMatrix.
@@ -392,7 +412,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'col' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   async setObsColumnValues(col, obsLabels, value) {
     /*
     Set all obs with label in array 'obsLabels' to have 'value'.  Typical use would be
@@ -411,7 +431,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'col' is declared but its value is never read.
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   async resetObsColumnValues(col, oldValue, newValue) {
     /*
     Set by value - all elements in the column with value 'oldValue' are set to 'newValue'.
@@ -429,7 +449,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'colSchema' is declared but its value is never rea... Remove this comment to see the full error message
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   addEmbedding(colSchema) {
     /*
     Add a new obs embedding to the AnnoMatrix, with provided schema.
@@ -443,6 +463,7 @@ export default class AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getCacheKeys(field, query) {
     /*
 Return cache keys for columns associated with this query.  May return
@@ -455,6 +476,7 @@ Return cache keys for columns associated with this query.  May return
    ** Private interfaces below.
    **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _resolveCachedQueries(field, queries) {
     return (
       queries
@@ -471,6 +493,7 @@ Return cache keys for columns associated with this query.  May return
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async _fetch(field, q) {
     if (!AnnoMatrix.fields().includes(field)) return undefined;
     const queries = Array.isArray(q) ? q : [q];
@@ -518,6 +541,7 @@ Return cache keys for columns associated with this query.  May return
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async _getPendingLoad(field, query, fetchFn) {
     /*
     Given a query on a field, ensure that we only have a single outstanding
@@ -539,7 +563,7 @@ Return cache keys for columns associated with this query.  May return
     return this._pendingLoad[field][key];
   }
 
-  // eslint-disable-next-line class-methods-use-this -- make sure subclass implements
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types -- make sure subclass implements
   async _doLoad() {
     _subclassResponsibility();
   }
@@ -574,6 +598,7 @@ Return cache keys for columns associated with this query.  May return
   as much of the cache is pinned by that data structure.
   */
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _gcField(field, isHot, pinnedColumns) {
     const maxColumns = isHot ? 256 : 10;
     const cache = this._cache[field];
@@ -616,6 +641,7 @@ Return cache keys for columns associated with this query.  May return
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _gcFetchCleanup(field, pinnedColumns) {
     /*
     Called during data load/fetch.  By definition, this is 'hot', so we
@@ -631,6 +657,7 @@ Return cache keys for columns associated with this query.  May return
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'hints' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _gc(hints) {
     /*
     Called from middleware, or elsewhere.  isHot is true if we are in the active store, 
@@ -644,6 +671,7 @@ Return cache keys for columns associated with this query.  May return
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _gcUpdateStats(field, dataframe) {
     /*
     called each time a query is performed, allowing the gc to update any bookkeeping
@@ -672,6 +700,7 @@ Return cache keys for columns associated with this query.  May return
   Do not override _clone();
   **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'clone' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _cloneDeeper(clone) {
     clone._cache = _shallowClone(this._cache);
     clone._gcInfo = new Map();
@@ -684,6 +713,7 @@ Return cache keys for columns associated with this query.  May return
     return clone;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _clone() {
     const clone = _shallowClone(this);
     this._cloneDeeper(clone);

--- a/client/src/annoMatrix/clone.ts
+++ b/client/src/annoMatrix/clone.ts
@@ -1,6 +1,7 @@
 /*
 Shallow clone an object, correctly handling prototype
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function _shallowClone(orig: any) {
   return Object.assign(Object.create(Object.getPrototypeOf(orig)), orig);
 }

--- a/client/src/annoMatrix/crossfilter.ts
+++ b/client/src/annoMatrix/crossfilter.ts
@@ -24,16 +24,22 @@ function _dimensionName(field, colNames) {
 
 export default class AnnoMatrixObsCrossfilter {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(annoMatrix, _obsCrossfilter = null) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).annoMatrix = annoMatrix;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).obsCrossfilter =
       _obsCrossfilter || new Crossfilter(annoMatrix._cache.obs);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).obsCrossfilter = (this as any).obsCrossfilter.setData(
       annoMatrix._cache.obs
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   size() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return (this as any).obsCrossfilter.size();
   }
 
@@ -45,12 +51,15 @@ export default class AnnoMatrixObsCrossfilter {
   See API documentation in annoMatrix.js.
   **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'colSchema' implicitly has an 'any' type... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   addObsColumn(colSchema, Ctor, value) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = (this as any).annoMatrix.addObsColumn(
       colSchema,
       Ctor,
       value
     );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const obsCrossfilter = (this as any).obsCrossfilter.setData(
       annoMatrix._cache.obs
     );
@@ -58,7 +67,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   dropObsColumn(col) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = (this as any).annoMatrix.dropObsColumn(col);
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'obsCrossfilter' does not exist on type '... Remove this comment to see the full error message
     let { obsCrossfilter } = this;
@@ -70,7 +81,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'oldCol' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renameObsColumn(oldCol, newCol) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = (this as any).annoMatrix.renameObsColumn(oldCol, newCol);
     const oldDimName = _dimensionName("obs", oldCol);
     const newDimName = _dimensionName("obs", newCol);
@@ -83,7 +96,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   addObsAnnoCategory(col, category) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = (this as any).annoMatrix.addObsAnnoCategory(
       col,
       category
@@ -98,7 +113,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async removeObsAnnoCategory(col, category, unassignedCategory) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = await (this as any).annoMatrix.removeObsAnnoCategory(
       col,
       category,
@@ -114,7 +131,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async setObsColumnValues(col, rowLabels, value) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = await (this as any).annoMatrix.setObsColumnValues(
       col,
       rowLabels,
@@ -130,7 +149,9 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async resetObsColumnValues(col, oldValue, newValue) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = await (this as any).annoMatrix.resetObsColumnValues(
       col,
       oldValue,
@@ -146,10 +167,13 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'colSchema' implicitly has an 'any' type... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   addEmbedding(colSchema) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const annoMatrix = (this as any).annoMatrix.addEmbedding(colSchema);
     return new AnnoMatrixObsCrossfilter(
       annoMatrix,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter
     );
   }
@@ -160,6 +184,7 @@ export default class AnnoMatrixObsCrossfilter {
    * annomatrix cache.
    */
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   dropDimension(field, query) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Anno... Remove this comment to see the full error message
     const { annoMatrix } = this;
@@ -182,6 +207,7 @@ export default class AnnoMatrixObsCrossfilter {
   **/
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async select(field, query, spec) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Anno... Remove this comment to see the full error message
     const { annoMatrix } = this;
@@ -214,62 +240,83 @@ export default class AnnoMatrixObsCrossfilter {
     return new AnnoMatrixObsCrossfilter(annoMatrix, obsCrossfilter);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   selectAll() {
     /*
 		Select all on any dimension in this field.
 		*/
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Anno... Remove this comment to see the full error message
     const { annoMatrix } = this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const currentDims = (this as any).obsCrossfilter.dimensionNames();
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'xfltr' implicitly has an 'any' type.
     const obsCrossfilter = currentDims.reduce((xfltr, dim) => {
       return xfltr.select(dim, { mode: "all" });
-    }, (this as any).obsCrossfilter);
+    }, (this as any).obsCrossfilter); // eslint-disable-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return new AnnoMatrixObsCrossfilter(annoMatrix, obsCrossfilter);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   countSelected() {
     /* if no data yet indexed in the crossfilter, just say everything is selected */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     if ((this as any).obsCrossfilter.size() === 0)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return (this as any).annoMatrix.nObs;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return (this as any).obsCrossfilter.countSelected();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allSelectedMask() {
     /* if no data yet indexed in the crossfilter, just say everything is selected */
     if (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.size() === 0 ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.dimensionNames().length === 0
     ) {
       /* fake the mask */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return new Uint8Array((this as any).annoMatrix.nObs).fill(1);
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return (this as any).obsCrossfilter.allSelectedMask();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allSelectedLabels() {
     /* if no data yet indexed in the crossfilter, just say everything is selected */
     if (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.size() === 0 ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.dimensionNames().length === 0
     ) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return (this as any).annoMatrix.rowIndex.labels();
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const mask = (this as any).obsCrossfilter.allSelectedMask();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const index = (this as any).annoMatrix.rowIndex.isubsetMask(mask);
     return index.labels();
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'array' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   fillByIsSelected(array, selectedValue, deselectedValue) {
     /* if no data yet indexed in the crossfilter, just say everything is selected */
     if (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.size() === 0 ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).obsCrossfilter.dimensionNames().length === 0
     ) {
       return array.fill(selectedValue);
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return (this as any).obsCrossfilter.fillByIsSelected(
       array,
       selectedValue,
@@ -282,6 +329,7 @@ export default class AnnoMatrixObsCrossfilter {
    **/
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _addObsCrossfilterDimension(annoMatrix, obsCrossfilter, field, df) {
     if (field === "var") return obsCrossfilter;
     const dimName = _dimensionNameFromDf(field, df);
@@ -293,9 +341,11 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _getColumnBaseType(field, col) {
     /* Look up the primitive type for this field/col */
     const colSchema = _getColumnSchema(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).annoMatrix.schema,
       field,
       col
@@ -304,6 +354,7 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _getObsDimensionParams(field, df) {
     /* return the crossfilter dimensiontype type and params for this field/dataframe */
 

--- a/client/src/annoMatrix/fetchHelpers.ts
+++ b/client/src/annoMatrix/fetchHelpers.ts
@@ -1,18 +1,22 @@
 export { doBinaryRequest, doFetch } from "../util/actionHelpers";
 
 /* double URI encode - needed for query-param filters */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _dubEncURIComp(s: any) {
   return encodeURIComponent(encodeURIComponent(s));
 }
 
 /* currently unused, consider deleting */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _fetchResult(promise: any) {
   let _status = "pending";
   const res = promise.then(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (r: any) => {
       _status = "success";
       return r;
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (e: any) => {
       _status = "error";
       throw e;

--- a/client/src/annoMatrix/loader.ts
+++ b/client/src/annoMatrix/loader.ts
@@ -23,6 +23,7 @@ import {
 const promiseThrottle = new PromiseLimit(5);
 
 export default class AnnoMatrixLoader extends AnnoMatrix {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   baseURL: any;
 
   /*
@@ -35,6 +36,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     new AnnoMatrixLoader(serverBaseURL, schema) -> instance
 
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(baseURL: any, schema: any) {
     const { nObs, nVar } = schema.dataframe;
     super(schema, nObs, nVar);
@@ -50,6 +52,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
   /**
    ** Public.  API described in base class.
    **/
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   addObsAnnoCategory(col: any, category: any) {
     /*
     Add a new category (aka label) to the schema for an obs column.
@@ -62,9 +65,13 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async removeObsAnnoCategory(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     col: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     category: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     unassignedCategory: any
   ) {
     /*
@@ -86,6 +93,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dropObsColumn(col: any) {
     /*
 		drop column from field
@@ -94,12 +102,14 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     _writableCheck(colSchema); // throws on error
 
     const newAnnoMatrix = this._clone();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     newAnnoMatrix._cache.obs = (this as any)._cache.obs.dropCol(col);
     newAnnoMatrix.schema = removeObsAnnoColumn(this.schema, col);
     return newAnnoMatrix;
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'colSchema' implicitly has an 'any' type... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   addObsColumn(colSchema, Ctor, value) {
     /*
 		add a column to field, initializing with value.  Value may 
@@ -112,6 +122,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     const colName = colSchema.name;
     if (
       _getColumnSchema(this.schema, "obs", colName) ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any)._cache.obs.hasCol(colName)
     ) {
       throw new Error("column already exists");
@@ -128,6 +139,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     } else {
       data = new Ctor(this.nObs).fill(value);
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     newAnnoMatrix._cache.obs = (this as any)._cache.obs.withCol(colName, data);
     _normalizeCategoricalSchema(
       colSchema,
@@ -138,14 +150,17 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'oldCol' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renameObsColumn(oldCol, newCol) {
     /*
     Rename the obs oldColName to newColName.  oldCol must be writable.
     */
     const oldColSchema = _getColumnSchema(this.schema, "obs", oldCol);
     _writableCheck(oldColSchema);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const value = (this as any)._cache.obs.hasCol(oldCol)
-      ? (this as any)._cache.obs.col(oldCol).asArray()
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+        (this as any)._cache.obs.col(oldCol).asArray()
       : undefined;
     return this.dropObsColumn(oldCol).addObsColumn(
       {
@@ -158,6 +173,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async setObsColumnValues(col, rowLabels, value) {
     /*
 		Set all rows identified by rowLabels to value.
@@ -167,10 +183,12 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
 
     // ensure that we have the data in cache before we manipulate it
     await this.fetch("obs", col);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     if (!(this as any)._cache.obs.hasCol(col))
       throw new Error("Internal error - user annotation data missing");
 
     const rowIndices = this.rowIndex.getOffsets(rowLabels);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const data = (this as any)._cache.obs.col(col).asArray().slice();
     for (let i = 0, len = rowIndices.length; i < len; i += 1) {
       const idx = rowIndices[i];
@@ -179,6 +197,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     }
 
     const newAnnoMatrix = this._clone();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     newAnnoMatrix._cache.obs = (this as any)._cache.obs.replaceColData(
       col,
       data
@@ -191,6 +210,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'col' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async resetObsColumnValues(col, oldValue, newValue) {
     /*
     Set all rows with value 'oldValue' to 'newValue'.
@@ -204,15 +224,18 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
 
     // ensure that we have the data in cache before we manipulate it
     await this.fetch("obs", col);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     if (!(this as any)._cache.obs.hasCol(col))
       throw new Error("Internal error - user annotation data missing");
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const data = (this as any)._cache.obs.col(col).asArray().slice();
     for (let i = 0, l = data.length; i < l; i += 1) {
       if (data[i] === oldValue) data[i] = newValue;
     }
 
     const newAnnoMatrix = this._clone();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     newAnnoMatrix._cache.obs = (this as any)._cache.obs.replaceColData(
       col,
       data
@@ -225,6 +248,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'colSchema' implicitly has an 'any' type... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   addEmbedding(colSchema) {
     /*
     add new layout to the obs embeddings
@@ -243,6 +267,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
    ** Private below
    **/
   // @ts-expect-error ts-migrate(2416) FIXME: Property '_doLoad' in type 'AnnoMatrixLoader' is n... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async _doLoad(field, query) {
     /*
     _doLoad - evaluates the query against the field. Returns:

--- a/client/src/annoMatrix/middleware.ts
+++ b/client/src/annoMatrix/middleware.ts
@@ -11,6 +11,7 @@ Undoable metareducer and the AnnoMatrix private API.  It would be helpful
 to make the Undoable interface better factored.
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const annoMatrixGC = (store: any) => (next: any) => (action: any) => {
   if (_itIsTimeForGC()) {
     _doGC(store);
@@ -34,6 +35,7 @@ function _itIsTimeForGC() {
   return false;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _doGC(store: any) {
   const state = store.getState();
 
@@ -43,7 +45,9 @@ function _doGC(store: any) {
   const undoableFuture = state["@@undoable/future"];
   const undoableStack = undoablePast
     .concat(undoableFuture)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     .flatMap((snapshot: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       snapshot.filter((v: any) => v[0] === "annoMatrix").map((v: any) => v[1])
     );
   const currentAnnoMatrix = state.annoMatrix;
@@ -53,6 +57,7 @@ function _doGC(store: any) {
   as our current gc algo is more aggressive with those not hot.
   */
   const allAnnoMatrices = new Map(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     undoableStack.map((m: any) => [m, { isHot: false }])
   );
   let am = currentAnnoMatrix;
@@ -61,6 +66,7 @@ function _doGC(store: any) {
     am = am.viewOf;
   }
   allAnnoMatrices.forEach((hints, annoMatrix) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (annoMatrix as any)._gc(hints)
   );
 }

--- a/client/src/annoMatrix/query.ts
+++ b/client/src/annoMatrix/query.ts
@@ -10,6 +10,7 @@ import { _dubEncURIComp } from "./fetchHelpers";
  * @param {object | string} query - the query
  * @returns {object | string} - the normalized query
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _queryValidate(query: any) {
   if (typeof query !== "object") return query;
 
@@ -40,10 +41,12 @@ export function _queryValidate(query: any) {
   throw new Error("query must specify one of where or summarize");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _expectSimpleQuery(query: any) {
   if (typeof query === "object") throw new Error("expected simple query");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _expectComplexQuery(query: any) {
   if (typeof query !== "object") throw new Error("expected complex query");
 }
@@ -55,6 +58,7 @@ export function _expectComplexQuery(query: any) {
  * @param {string|object} query
  * @returns the key
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _queryCacheKey(field: any, query: any) {
   if (typeof query === "object") {
     // complex query
@@ -84,6 +88,7 @@ export function _queryCacheKey(field: any, query: any) {
   return `${field}/${query}`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _urlEncodeWhereQuery(q: any) {
   const { field: queryField, column: queryColumn, value: queryValue } = q;
   return `${_dubEncURIComp(queryField)}:${_dubEncURIComp(
@@ -91,14 +96,16 @@ function _urlEncodeWhereQuery(q: any) {
   )}=${_dubEncURIComp(queryValue)}`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _urlEncodeSummarizeQuery(q: any) {
   const { method, field, column, values } = q;
-  const filter = values
+  const filter = values // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     .map((value: any) => _urlEncodeWhereQuery({ field, column, value }))
     .join("&");
   return `method=${method}&${filter}`;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _urlEncodeComplexQuery(q: any) {
   if (typeof q === "object") {
     if (q.where) {
@@ -111,6 +118,7 @@ export function _urlEncodeComplexQuery(q: any) {
   throw new Error("Unrecognized complex query type");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _urlEncodeLabelQuery(colKey: any, q: any) {
   if (!colKey) throw new Error("Unsupported query by name");
   if (typeof q !== "string") throw new Error("Query must be a simple label.");
@@ -120,6 +128,7 @@ export function _urlEncodeLabelQuery(colKey: any, q: any) {
 /**
  * Generate the column key the server will send us for this query.
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _hashStringValues(arrayOfString: any) {
   const hash = sha1(arrayOfString.join(""));
   return hash;

--- a/client/src/annoMatrix/schema.ts
+++ b/client/src/annoMatrix/schema.ts
@@ -4,6 +4,7 @@ Private helper functions related to schema
 import catLabelSort from "../util/catLabelSort";
 import { unassignedCategoryLabel } from "../globals";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _getColumnSchema(schema: any, field: any, col: any) {
   /* look up the column definition */
   switch (field) {
@@ -26,6 +27,7 @@ export function _getColumnSchema(schema: any, field: any, col: any) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function _getColumnDimensionNames(schema: any, field: any, col: any) {
   /*
 		field/col may be an alias for multiple columns. Currently used to map ND 
@@ -40,6 +42,7 @@ export function _getColumnDimensionNames(schema: any, field: any, col: any) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'schema' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _schemaColumns(schema, field) {
   switch (field) {
     case "obs":
@@ -54,6 +57,7 @@ export function _schemaColumns(schema, field) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'schema' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _getWritableColumns(schema, field) {
   if (field !== "obs") return [];
   return (
@@ -66,12 +70,14 @@ export function _getWritableColumns(schema, field) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'schema' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _isContinuousType(schema) {
   const { type } = schema;
   return !(type === "string" || type === "boolean" || type === "categorical");
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'colSchema' implicitly has an 'any' type... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _normalizeCategoricalSchema(colSchema, col) {
   /*
   Ensure all enum schema types have a categories array, that

--- a/client/src/annoMatrix/viewCreators.ts
+++ b/client/src/annoMatrix/viewCreators.ts
@@ -5,6 +5,7 @@ instances of AnnoMatrix, implementing common UI functions.
 
 import { AnnoMatrixRowSubsetView, AnnoMatrixClipView } from "./views";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isubsetMask(annoMatrix: any, obsMask: any) {
   /*
 		Subset annomatrix to contain the rows which have truish value in the mask.
@@ -14,6 +15,7 @@ export function isubsetMask(annoMatrix: any, obsMask: any) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function isubset(annoMatrix, obsOffsets) {
   /*
 		Subset annomatrix to contain the positions contained in the obsOffsets array
@@ -27,6 +29,7 @@ export function isubset(annoMatrix, obsOffsets) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function subset(annoMatrix, obsLabels) {
   /*
 		subset based on labels
@@ -36,6 +39,7 @@ export function subset(annoMatrix, obsLabels) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function subsetByIndex(annoMatrix, obsIndex) {
   /*
   subset based upon the new obs index.
@@ -44,6 +48,7 @@ export function subsetByIndex(annoMatrix, obsIndex) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function clip(annoMatrix, qmin, qmax) {
   /*
 		Create a view that clips all continuous data to the [min, max] range.

--- a/client/src/annoMatrix/views.ts
+++ b/client/src/annoMatrix/views.ts
@@ -9,6 +9,7 @@ import { _whereCacheCreate } from "./whereCache";
 import { _isContinuousType, _getColumnSchema } from "./schema";
 
 class AnnoMatrixView extends AnnoMatrix {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   constructor(viewOf: any, rowIndex = null) {
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     const nObs = rowIndex ? rowIndex.size() : viewOf.nObs;
@@ -17,6 +18,7 @@ class AnnoMatrixView extends AnnoMatrix {
     this.isView = true;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   addObsAnnoCategory(col: any, category: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.addObsAnnoCategory(col, category);
@@ -25,8 +27,11 @@ class AnnoMatrixView extends AnnoMatrix {
   }
 
   async removeObsAnnoCategory(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     col: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     category: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     unassignedCategory: any
   ) {
     const newAnnoMatrix = this._clone();
@@ -39,6 +44,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dropObsColumn(col: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.dropObsColumn(col);
@@ -47,6 +53,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   addObsColumn(colSchema: any, Ctor: any, value: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.addObsColumn(colSchema, Ctor, value);
@@ -54,6 +61,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   renameObsColumn(oldCol: any, newCol: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.renameObsColumn(oldCol, newCol);
@@ -61,6 +69,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   async setObsColumnValues(col: any, rowLabels: any, value: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = await this.viewOf.setObsColumnValues(
@@ -73,6 +82,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   async resetObsColumnValues(col: any, oldValue: any, newValue: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = await this.viewOf.resetObsColumnValues(
@@ -85,6 +95,7 @@ class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   addEmbedding(colSchema: any) {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.addEmbedding(colSchema);
@@ -100,6 +111,7 @@ class AnnoMatrixMapView extends AnnoMatrixView {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'viewOf' implicitly has an 'any' type.
   constructor(viewOf, mapFn) {
     super(viewOf);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).mapFn = mapFn;
   }
 
@@ -110,6 +122,7 @@ class AnnoMatrixMapView extends AnnoMatrixView {
     const dfMapped = df.mapColumns((colData, colIdx) => {
       const colLabel = df.colIndex.getLabel(colIdx);
       const colSchema = _getColumnSchema(this.schema, field, colLabel);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return (this as any).mapFn(field, colLabel, colSchema, colData, df);
     });
     const whereCacheUpdate = _whereCacheCreate(
@@ -126,12 +139,15 @@ export class AnnoMatrixClipView extends AnnoMatrixMapView {
 	A view which is a clipped transformation of its parent
 	*/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'viewOf' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(viewOf, qmin, qmax) {
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
     super(viewOf, (field, colLabel, colSchema, colData, df) =>
       _clipAnnoMatrix(field, colLabel, colSchema, colData, df, qmin, qmax)
     );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).isClipped = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).clipRange = [qmin, qmax];
     Object.seal(this);
   }
@@ -142,12 +158,14 @@ export class AnnoMatrixRowSubsetView extends AnnoMatrixView {
 	A view which is a subset of total rows.
 	*/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'viewOf' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(viewOf, rowIndex) {
     super(viewOf, rowIndex);
     Object.seal(this);
   }
 
   // @ts-expect-error ts-migrate(2416) FIXME: Property '_doLoad' in type 'AnnoMatrixRowSubsetVie... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async _doLoad(field, query) {
     const df = await this.viewOf._fetch(field, query);
 

--- a/client/src/annoMatrix/whereCache.ts
+++ b/client/src/annoMatrix/whereCache.ts
@@ -52,8 +52,16 @@ import { _getColumnDimensionNames } from "./schema";
 import { _hashStringValues } from "./query";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-function _whereCacheGet(whereCache: any, schema: any, field: any, query: any) {
+export function _whereCacheGet(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  whereCache: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  schema: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  field: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  query: any
+) {
   /* 
 	query will either be an where query (object) or a column name (string).
 

--- a/client/src/annoMatrix/whereCache.ts
+++ b/client/src/annoMatrix/whereCache.ts
@@ -51,12 +51,9 @@ creates a cache entry of:
 import { _getColumnDimensionNames } from "./schema";
 import { _hashStringValues } from "./query";
 
-export function _whereCacheGet(
-  whereCache: any,
-  schema: any,
-  field: any,
-  query: any
-) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+export // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+function _whereCacheGet(whereCache: any, schema: any, field: any, query: any) {
   /* 
 	query will either be an where query (object) or a column name (string).
 
@@ -91,6 +88,7 @@ export function _whereCacheGet(
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _whereCacheCreate(field, query, columnLabels) {
   /*
 	Create a new whereCache
@@ -141,6 +139,7 @@ export function _whereCacheCreate(field, query, columnLabels) {
 function __mergeQueries(dst, src) {
   for (const [queryField, columnMap] of Object.entries(src)) {
     dst[queryField] = dst[queryField] || new Map();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     for (const [queryColumn, valueMap] of columnMap as any) {
       if (!dst[queryField].has(queryColumn))
         dst[queryField].set(queryColumn, new Map());
@@ -181,6 +180,7 @@ function __whereCacheMerge(dst, src) {
 }
 
 // @ts-expect-error ts-migrate(7019) FIXME: Rest parameter 'caches' implicitly has an 'any[]' ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _whereCacheMerge(...caches) {
   return caches.reduce(__whereCacheMerge, {});
 }

--- a/client/src/components/annoDialog.tsx
+++ b/client/src/components/annoDialog.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { Button, Tooltip, Dialog, Classes, Colors } from "@blueprintjs/core";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class AnnoDialog extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {};
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'isActive' does not exist on type 'Readon... Remove this comment to see the full error message

--- a/client/src/components/app.tsx
+++ b/client/src/components/app.tsx
@@ -17,11 +17,15 @@ import actions from "../actions";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   loading: (state as any).controls.loading,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   error: (state as any).controls.error,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   graphRenderCounter: (state as any).controls.graphRenderCounter,
 }))
 class App extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -33,12 +37,14 @@ class App extends React.Component {
     this.forceUpdate();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _onURLChanged() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     dispatch({ type: "url changed", url: document.location.href });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'loading' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { loading, error, graphRenderCounter } = this.props;
@@ -72,6 +78,7 @@ class App extends React.Component {
         {loading || error ? null : (
           <Layout>
             <LeftSideBar />
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
             {(viewportRef: any) => (
               <>
                 <MenuBar />

--- a/client/src/components/autosave/filenameDialog.tsx
+++ b/client/src/components/autosave/filenameDialog.tsx
@@ -11,22 +11,31 @@ import {
   Tooltip,
 } from "@blueprintjs/core";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
   idhash:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).config?.parameters?.["annotations-user-data-idhash"] ?? null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   auth: (state as any).config?.authentication,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   userInfo: (state as any).userInfo,
   writableCategoriesEnabled:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).config?.parameters?.annotations ?? false,
   writableGenesetsEnabled: !(
-    (state as any).config?.parameters?.annotations_genesets_readonly ?? true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+    ((state as any).config?.parameters?.annotations_genesets_readonly ?? true)
   ),
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class FilenameDialog extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -34,8 +43,10 @@ class FilenameDialog extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   dismissFilenameDialog = () => {};
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleCreateFilename = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -46,6 +57,7 @@ class FilenameDialog extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   filenameError = () => {
     const legalNames = /^\w+$/;
     const { filenameText } = this.state;
@@ -66,6 +78,7 @@ class FilenameDialog extends React.Component<{}, State> {
     return err;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   filenameErrorMessage = () => {
     const err = this.filenameError();
     let markup = null;
@@ -101,6 +114,7 @@ class FilenameDialog extends React.Component<{}, State> {
     return markup;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'writableCategoriesEnabled' does not exis... Remove this comment to see the full error message

--- a/client/src/components/autosave/index.tsx
+++ b/client/src/components/autosave/index.tsx
@@ -3,29 +3,40 @@ import { connect } from "react-redux";
 import actions from "../../actions";
 import FilenameDialog from "./filenameDialog";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
   obsAnnotationSaveInProgress:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).autosave?.obsAnnotationSaveInProgress ?? false,
   genesetSaveInProgress:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).autosave?.genesetSaveInProgress ?? false,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   error: (state as any).autosave?.error,
   writableCategoriesEnabled:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).config?.parameters?.annotations ?? false,
   writableGenesetsEnabled: !(
-    (state as any).config?.parameters?.annotations_genesets_readonly ?? true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+    ((state as any).config?.parameters?.annotations_genesets_readonly ?? true)
   ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annoMatrix: (state as any).annoMatrix,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   lastSavedAnnoMatrix: (state as any).autosave?.lastSavedAnnoMatrix,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   lastSavedGenesets: (state as any).autosave?.lastSavedGenesets,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Autosave extends React.Component<{}, State> {
-  clearInterval: any;
-
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -33,6 +44,7 @@ class Autosave extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'writableCategoriesEnabled' does not exis... Remove this comment to see the full error message
     const { writableCategoriesEnabled, writableGenesetsEnabled } = this.props;
@@ -46,11 +58,13 @@ class Autosave extends React.Component<{}, State> {
     this.setState({ timer });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentWillUnmount() {
     const { timer } = this.state;
-    if (timer) this.clearInterval(timer);
+    if (timer) clearInterval(timer);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   tick = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -68,6 +82,7 @@ class Autosave extends React.Component<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   needToSaveObsAnnotations = () => {
     /* return true if we need to save obs cell labels, false if we don't */
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
@@ -75,6 +90,7 @@ class Autosave extends React.Component<{}, State> {
     return actions.needToSaveObsAnnotations(annoMatrix, lastSavedAnnoMatrix);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   needToSaveGenesets = () => {
     /* return true if we need to save gene ses, false if we do not */
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'genesets' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -82,16 +98,19 @@ class Autosave extends React.Component<{}, State> {
     return genesets.initialized && genesets.genesets !== lastSavedGenesets;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   needToSave() {
     return this.needToSaveGenesets() || this.needToSaveObsAnnotations();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   saveInProgress() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'obsAnnotationSaveInProgress' does not ex... Remove this comment to see the full error message
     const { obsAnnotationSaveInProgress, genesetSaveInProgress } = this.props;
     return obsAnnotationSaveInProgress || genesetSaveInProgress;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   statusMessage() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'error' does not exist on type 'Readonly<... Remove this comment to see the full error message
     const { error } = this.props;
@@ -101,6 +120,7 @@ class Autosave extends React.Component<{}, State> {
     return this.needToSave() ? "Unsaved" : "All saved";
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'writableCategoriesEnabled' does not exis... Remove this comment to see the full error message

--- a/client/src/components/brushableHistogram/error.tsx
+++ b/client/src/components/brushableHistogram/error.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as globals from "../../globals";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const ErrorLoading = ({ displayName, zebra }: any) => {
   return (
     <div

--- a/client/src/components/brushableHistogram/histogram.tsx
+++ b/client/src/components/brushableHistogram/histogram.tsx
@@ -5,6 +5,7 @@ import * as d3 from "d3";
 import maybeScientific from "../../util/maybeScientific";
 import clamp from "../../util/clamp";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Histogram = ({
   field,
   fieldForId,
@@ -17,7 +18,7 @@ const Histogram = ({
   margin,
   isColorBy,
   selectionRange,
-  mini,
+  mini, // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 }: any) => {
   const svgRef = useRef(null);
   const [brush, setBrush] = useState(null);
@@ -80,6 +81,7 @@ const Histogram = ({
           // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
           isColorBy
             ? // @ts-expect-error ts-migrate(6133) FIXME: 'd' is declared but its value is never read.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
               (d: any, i: any) => colorScale(histogramScale(binStart(i)))
             : defaultBarColor
         );
@@ -134,6 +136,7 @@ const Histogram = ({
             .tickFormat(
               // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
               d3.format(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                 y.domain().some((n: any) => Math.abs(n) >= 10000) ? ".0e" : ","
               )
             )

--- a/client/src/components/brushableHistogram/index.tsx
+++ b/client/src/components/brushableHistogram/index.tsx
@@ -38,21 +38,28 @@ const HEIGHT_MINI = 15 - MARGIN_MINI.TOP - MARGIN_MINI.BOTTOM;
     field
   );
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annoMatrix: (state as any).annoMatrix,
     isScatterplotXXaccessor:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).controls.scatterplotXXaccessor === field,
     isScatterplotYYaccessor:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).controls.scatterplotYYaccessor === field,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     continuousSelectionRange: (state as any).continuousSelection[myName],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     isColorAccessor: (state as any).colors.colorAccessor === field,
   };
 })
 class HistogramBrush extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
 
   /* memoized closure to prevent HistogramHeader unecessary repaint */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   handleColorAction = memoize((dispatch) => (field: any, isObs: any) => {
     if (isObs) {
       dispatch({
@@ -65,6 +72,7 @@ class HistogramBrush extends React.PureComponent {
   });
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'selection' is declared but its value is never rea... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   onBrush = (selection: any, x: any, eventType: any) => {
     const type = `continuous metadata histogram ${eventType}`;
     return () => {
@@ -82,13 +90,17 @@ class HistogramBrush extends React.PureComponent {
       } = this.props;
 
       // ignore programmatically generated events
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       if (!(d3 as any).event.sourceEvent) return;
       // ignore cascading events, which are programmatically generated
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       if ((d3 as any).event.sourceEvent.sourceEvent) return;
 
       const query = this.createQuery();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const range = (d3 as any).event.selection
-        ? [x((d3 as any).event.selection[0]), x((d3 as any).event.selection[1])]
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+          [x((d3 as any).event.selection[0]), x((d3 as any).event.selection[1])]
         : null;
       const otherProps = {
         selection: field,
@@ -105,7 +117,9 @@ class HistogramBrush extends React.PureComponent {
   };
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'selection' is declared but its value is never rea... Remove this comment to see the full error message
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   onBrushEnd = (selection: any, x: any) => {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
     return () => {
       const {
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -123,30 +137,38 @@ class HistogramBrush extends React.PureComponent {
       const smallAmountToAvoidInfiniteLoop = 0.1;
 
       // ignore programmatically generated events
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       if (!(d3 as any).event.sourceEvent) return;
       // ignore cascading events, which are programmatically generated
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       if ((d3 as any).event.sourceEvent.sourceEvent) return;
 
       let type;
       let range = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       if ((d3 as any).event.selection) {
         type = "continuous metadata histogram end";
         if (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           (d3 as any).event.selection[1] - (d3 as any).event.selection[0] >
           minAllowedBrushSize
         ) {
           range = [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             x((d3 as any).event.selection[0]),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             x((d3 as any).event.selection[1]),
           ];
         } else {
           /* the user selected range is too small and will be hidden #587, so take control of it procedurally */
           /* https://stackoverflow.com/questions/12354729/d3-js-limit-size-of-brush */
           const procedurallyResizedBrushWidth =
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             (d3 as any).event.selection[0] +
             minAllowedBrushSize +
             smallAmountToAvoidInfiniteLoop; //
           range = [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             x((d3 as any).event.selection[0]),
             x(procedurallyResizedBrushWidth),
           ];
@@ -170,6 +192,7 @@ class HistogramBrush extends React.PureComponent {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSetGeneAsScatterplotX = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, field } = this.props;
@@ -179,6 +202,7 @@ class HistogramBrush extends React.PureComponent {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSetGeneAsScatterplotY = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, field } = this.props;
@@ -188,6 +212,7 @@ class HistogramBrush extends React.PureComponent {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   removeHistogram = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -224,6 +249,7 @@ class HistogramBrush extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   fetchAsyncProps = async () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, width } = this.props;
@@ -289,7 +315,7 @@ class HistogramBrush extends React.PureComponent {
     };
   };
 
-  // eslint-disable-next-line class-methods-use-this -- instance method allows for memoization per annotation
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- instance method allows for memoization per annotation
   calcHistogramCache(col: any, newMargin: any, newWidth: any, newHeight: any) {
     /*
      recalculate expensive stuff, notably bins, summaries, etc.
@@ -299,28 +325,38 @@ class HistogramBrush extends React.PureComponent {
     const { min: domainMin, max: domainMax } = summary;
     const numBins = 40;
     const { TOP: topMargin, LEFT: leftMargin } = newMargin;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (histogramCache as any).domain = [domainMin, domainMax];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     /* doesn't change with mini */ (histogramCache as any).x = d3
       .scaleLinear()
       .domain([domainMin, domainMax])
       .range([leftMargin, leftMargin + newWidth]);
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (histogramCache as any).bins = col.histogram(numBins, [
       domainMin,
       domainMax,
     ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     /* memoized */ (histogramCache as any).binWidth =
       (domainMax - domainMin) / numBins;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (histogramCache as any).binStart = (i: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       domainMin + i * (histogramCache as any).binWidth;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (histogramCache as any).binEnd = (i: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       domainMin + (i + 1) * (histogramCache as any).binWidth;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const yMax = (histogramCache as any).bins.reduce((l: any, r: any) =>
       l > r ? l : r
     );
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (histogramCache as any).y = d3
       .scaleLinear()
       .domain([0, yMax])
@@ -329,6 +365,7 @@ class HistogramBrush extends React.PureComponent {
     return histogramCache;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createQuery() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'isObs' does not exist on type 'Readonly<... Remove this comment to see the full error message
     const { isObs, isGeneSetSummary, field, setGenes, annoMatrix } = this.props;
@@ -366,6 +403,7 @@ class HistogramBrush extends React.PureComponent {
     ];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -425,6 +463,7 @@ class HistogramBrush extends React.PureComponent {
         </Async.Rejected>
         <Async.Fulfilled>
           {(asyncProps) =>
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             (asyncProps as any).OK2Render ? (
               <div
                 id={`histogram_${fieldForId}`}
@@ -456,11 +495,14 @@ class HistogramBrush extends React.PureComponent {
                 <Histogram
                   field={field}
                   fieldForId={fieldForId}
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                   display={(asyncProps as any).isSingleValue ? "none" : "block"}
                   histogram={
                     mini
-                      ? (asyncProps as any).miniHistogram
-                      : (asyncProps as any).histogram
+                      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+                        (asyncProps as any).miniHistogram
+                      : // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+                        (asyncProps as any).histogram
                   }
                   width={width}
                   height={mini ? HEIGHT_MINI : HEIGHT}
@@ -477,10 +519,15 @@ class HistogramBrush extends React.PureComponent {
                     isGeneSetSummary={isGeneSetSummary}
                     isObs={isObs}
                     displayName={field}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     hideRanges={(asyncProps as any).isSingleValue}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     rangeMin={(asyncProps as any).unclippedRange[0]}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     rangeMax={(asyncProps as any).unclippedRange[1]}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     rangeColorMin={(asyncProps as any).unclippedRangeColor[0]}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     rangeColorMax={(asyncProps as any).unclippedRangeColor[1]}
                   />
                 )}

--- a/client/src/components/brushableHistogram/loading.tsx
+++ b/client/src/components/brushableHistogram/loading.tsx
@@ -3,6 +3,7 @@ import { Button } from "@blueprintjs/core";
 
 import * as globals from "../../globals";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const StillLoading = ({ zebra, displayName }: any) => {
   /*
     Render a loading indicator for the field.

--- a/client/src/components/categorical/annoSelect.tsx
+++ b/client/src/components/categorical/annoSelect.tsx
@@ -2,14 +2,18 @@ import React from "react";
 import { Button, MenuItem } from "@blueprintjs/core";
 import { Select } from "@blueprintjs/select";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class DuplicateCategorySelect extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {};
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'allCategoryNames' does not exist on type... Remove this comment to see the full error message

--- a/client/src/components/categorical/category/annoDialogAddLabel.tsx
+++ b/client/src/components/categorical/category/annoDialogAddLabel.tsx
@@ -5,15 +5,21 @@ import LabelInput from "../../labelInput";
 import { labelPrompt, isLabelErroneous } from "../labelUtil";
 import actions from "../../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   obsCrossfilter: (state as any).obsCrossfilter,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Category extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -21,6 +27,7 @@ class Category extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   disableAddNewLabelMode = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -33,6 +40,7 @@ class Category extends React.PureComponent<{}, State> {
     if (e) e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleAddNewLabelToCategory = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -49,6 +57,7 @@ class Category extends React.PureComponent<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   addLabelAndAssignCells = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -61,20 +70,24 @@ class Category extends React.PureComponent<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labelNameError = (name: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
     const { metadataField, schema } = this.props;
     return isLabelErroneous(name, metadataField, schema);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   instruction = (label: any) => {
     return labelPrompt(this.labelNameError(label), "New, unique label", ":");
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChangeOrSelect = (label: any) => {
     this.setState({ newLabelText: label });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { newLabelText } = this.state;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message

--- a/client/src/components/categorical/category/annoDialogEditCategoryName.tsx
+++ b/client/src/components/categorical/category/annoDialogEditCategoryName.tsx
@@ -7,14 +7,19 @@ import { labelPrompt } from "../labelUtil";
 import { AnnotationsHelpers } from "../../../util/stateManager";
 import actions from "../../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -23,12 +28,14 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChangeOrSelect = (name: any) => {
     this.setState({
       newCategoryText: name,
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   disableEditCategoryMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -38,6 +45,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     this.setState({ newCategoryText: metadataField });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleEditCategory = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -49,6 +57,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { schema } = this.props;
     const allCategoryNames = schema.annotations.obs.columns.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (c: any) => c.name
     );
     if (
@@ -66,6 +75,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   editedCategoryNameError = (name: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
     const { metadataField } = this.props;
@@ -82,6 +92,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { schema } = this.props;
     const allCategoryNames = schema.annotations.obs.columns.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (c: any) => c.name
     );
     const categoryNameAlreadyExists = allCategoryNames.indexOf(name) > -1;
@@ -93,6 +104,7 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     return false;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   instruction = (name: any) => {
     return labelPrompt(
       this.editedCategoryNameError(name),
@@ -101,12 +113,15 @@ class AnnoDialogEditCategoryName extends React.PureComponent<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allCategoryNames() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { schema } = this.props;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return schema.annotations.obs.columns.map((c: any) => c.name);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { newCategoryText } = this.state;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message

--- a/client/src/components/categorical/category/annoMenuCategory.tsx
+++ b/client/src/components/categorical/category/annoMenuCategory.tsx
@@ -16,18 +16,23 @@ import { IconNames } from "@blueprintjs/icons";
 import * as globals from "../../../globals";
 import actions from "../../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class AnnoMenuCategory extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {};
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   activateAddNewLabelMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -37,6 +42,7 @@ class AnnoMenuCategory extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   activateEditCategoryMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -46,12 +52,14 @@ class AnnoMenuCategory extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDeleteCategory = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
     dispatch(actions.annotationDeleteCategoryAction(metadataField));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message

--- a/client/src/components/categorical/category/index.tsx
+++ b/client/src/components/categorical/category/index.tsx
@@ -33,35 +33,47 @@ const LABEL_WIDTH_ANNO = LABEL_WIDTH - ANNO_BUTTON_WIDTH;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state, ownProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const schema = (state as any).annoMatrix?.schema;
   // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type '{... Remove this comment to see the full error message
   const { metadataField } = ownProps;
   const isUserAnno = schema?.annotations?.obsByName[metadataField]?.writable;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const categoricalSelection = (state as any).categoricalSelection?.[
     metadataField
   ];
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     colors: (state as any).colors,
     categoricalSelection,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annotations: (state as any).annotations,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annoMatrix: (state as any).annoMatrix,
     schema,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     crossfilter: (state as any).obsCrossfilter,
     isUserAnno,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     genesets: (state as any).genesets.genesets,
   };
 })
 class Category extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   static getSelectionState(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoricalSelection: any,
     // @ts-expect-error ts-migrate(6133) FIXME: 'metadataField' is declared but its value is never... Remove this comment to see the full error message
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     metadataField: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categorySummary: any
   ) {
     // total number of categories in this dimension
     const totalCatCount = categorySummary.numCategoryValues;
     // number of selected options in this category
     const selectedCatCount = categorySummary.categoryValues.reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (res: any, label: any) =>
         categoricalSelection.get(label) ?? true ? res + 1 : res,
       0
@@ -73,12 +85,14 @@ class Category extends React.PureComponent {
       : "some";
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
 
   createCategorySummaryFromDfCol = memoize(createCategorySummaryFromDfCol);
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getSelectionState(categorySummary: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoricalSelection' does not exist on ... Remove this comment to see the full error message
     const { categoricalSelection, metadataField } = this.props;
@@ -89,6 +103,7 @@ class Category extends React.PureComponent {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleColorChange = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -98,6 +113,7 @@ class Category extends React.PureComponent {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleCategoryClick = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annotations' does not exist on type 'Rea... Remove this comment to see the full error message
     const { annotations, metadataField, onExpansionChange } = this.props;
@@ -109,12 +125,14 @@ class Category extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleCategoryKeyPress = (e: any) => {
     if (e.key === "Enter") {
       this.handleCategoryClick();
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleToggleAllClick = (categorySummary: any) => {
     const isChecked = this.getSelectionState(categorySummary);
     if (isChecked === "all") {
@@ -124,6 +142,7 @@ class Category extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fetchAsyncProps = async (props: any) => {
     const { annoMatrix, metadataField, colors } = props.watchProps;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'crossfilter' does not exist on type 'Rea... Remove this comment to see the full error message
@@ -146,6 +165,7 @@ class Category extends React.PureComponent {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   async fetchData(annoMatrix: any, metadataField: any, colors: any) {
     /*
     fetch our data and the color-by data if appropriate, and then build a summary
@@ -180,6 +200,7 @@ class Category extends React.PureComponent {
     return [categoryData, categorySummary, colorData];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   updateColorTable(colorData: any) {
     // color table, which may be null
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
@@ -199,6 +220,7 @@ class Category extends React.PureComponent {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   toggleNone(categorySummary: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -212,6 +234,7 @@ class Category extends React.PureComponent {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   toggleAll(categorySummary: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField } = this.props;
@@ -225,6 +248,7 @@ class Category extends React.PureComponent {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
@@ -319,6 +343,7 @@ class Category extends React.PureComponent {
 
 export default Category;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const StillLoading = ({ metadataField, checkboxID }: any) => {
   /*
   We are still loading this category, so render a "busy" signal.
@@ -370,6 +395,7 @@ const StillLoading = ({ metadataField, checkboxID }: any) => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const ErrorLoading = ({ metadataField, error }: any) => {
   console.error(error); // log error to console as it is unexpected.
   return (

--- a/client/src/components/categorical/index.tsx
+++ b/client/src/components/categorical/index.tsx
@@ -10,16 +10,22 @@ import LabelInput from "../labelInput";
 import { labelPrompt } from "./labelUtil";
 import actions from "../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
   writableCategoriesEnabled:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).config?.parameters?.annotations ?? false,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   userInfo: (state as any).userInfo,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Categories extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -30,6 +36,7 @@ class Categories extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleCreateUserAnno = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -48,10 +55,12 @@ class Categories extends React.Component<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleEnableAnnoMode = () => {
     this.setState({ createAnnoModeActive: true });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDisableAnnoMode = () => {
     this.setState({
       createAnnoModeActive: false,
@@ -60,10 +69,12 @@ class Categories extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleModalDuplicateCategorySelection = (d: any) => {
     this.setState({ categoryToDuplicate: d });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   categoryNameError = (name: any) => {
     /*
         return false if this is a LEGAL/acceptable category name or NULL/empty string,
@@ -78,6 +89,7 @@ class Categories extends React.Component<{}, State> {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { schema } = this.props;
     const allCategoryNames = schema.annotations.obs.columns.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (c: any) => c.name
     );
     /* check category name syntax */
@@ -93,14 +105,17 @@ class Categories extends React.Component<{}, State> {
     return false;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChange = (name: any) => {
     this.setState({ newCategoryText: name });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleSelect = (name: any) => {
     this.setState({ newCategoryText: name });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   instruction = (name: any) => {
     return labelPrompt(
       this.categoryNameError(name),
@@ -109,6 +124,7 @@ class Categories extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   onExpansionChange = (catName: any) => {
     const { expandedCats } = this.state;
     if (expandedCats.has(catName)) {
@@ -122,6 +138,7 @@ class Categories extends React.Component<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       createAnnoModeActive,
@@ -180,7 +197,6 @@ class Categories extends React.Component<{}, State> {
             />
           }
         />
-
         {writableCategoriesEnabled ? (
           <div style={{ marginBottom: 10 }}>
             <Tooltip
@@ -209,9 +225,9 @@ class Categories extends React.Component<{}, State> {
             </Tooltip>
           </div>
         ) : null}
-
         {/* READ ONLY CATEGORICAL FIELDS */}
         {/* this is duplicative but flat, could be abstracted */}
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS */}
         {allCategoryNames.map((catName: any) =>
           !schema.annotations.obsByName[catName].writable &&
           (schema.annotations.obsByName[catName].categories?.length > 1 ||
@@ -227,6 +243,7 @@ class Categories extends React.Component<{}, State> {
           ) : null
         )}
         {/* WRITEABLE FIELDS */}
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS */}
         {allCategoryNames.map((catName: any) =>
           schema.annotations.obsByName[catName].writable ? (
             <Category

--- a/client/src/components/categorical/labelUtil.tsx
+++ b/client/src/components/categorical/labelUtil.tsx
@@ -3,6 +3,7 @@ import { Colors } from "@blueprintjs/core";
 
 import { AnnotationsHelpers } from "../../util/stateManager";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isLabelErroneous(label: any, metadataField: any, schema: any) {
   /*
     return false if this is a LEGAL/acceptable category name or NULL/empty string,
@@ -35,6 +36,7 @@ const errorMessageMap = {
   "multi-space-run": "Multiple consecutive spaces not allowed",
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function labelPrompt(err: any, prolog: any, epilog: any) {
   let errPrompt = null;
   if (err) {

--- a/client/src/components/categorical/value/index.tsx
+++ b/client/src/components/categorical/value/index.tsx
@@ -30,6 +30,7 @@ const STACKED_BAR_HEIGHT = 11;
 const STACKED_BAR_WIDTH = 100;
 
 /* this is defined outside of the class so we can use it in connect() */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _currentLabelAsString(ownProps: any) {
   const { label } = ownProps;
   // when called as a function, the String() constructor performs type conversion,
@@ -37,6 +38,7 @@ function _currentLabelAsString(ownProps: any) {
   return String(label);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
@@ -54,14 +56,18 @@ type State = any;
   const isSelected = category.get(label) ?? true;
 
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annotations: (state as any).annotations,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema: (state as any).annoMatrix?.schema,
     isDilated,
     isSelected,
     label,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class CategoryValue extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -69,12 +75,15 @@ class CategoryValue extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidUpdate(prevProps: {}) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
     const { metadataField, categoryIndex, categorySummary } = this.props;
     if (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (prevProps as any).metadataField !== metadataField ||
-      (prevProps as any).categoryIndex !== categoryIndex ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      (prevProps as any).categoryIndex !== categoryIndex || // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (prevProps as any).categorySummary !== categorySummary
     ) {
       // eslint-disable-next-line react/no-did-update-set-state --- adequately checked to prevent looping
@@ -85,6 +94,7 @@ class CategoryValue extends React.Component<{}, State> {
   }
 
   // If coloring by and this isn't the colorAccessor and it isn't being edited
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   get shouldRenderStackedBarOrHistogram() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorAccessor' does not exist on type 'R... Remove this comment to see the full error message
     const { colorAccessor, isColorBy, annotations } = this.props;
@@ -92,18 +102,21 @@ class CategoryValue extends React.Component<{}, State> {
     return !!colorAccessor && !isColorBy && !annotations.isEditingLabelName;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDeleteValue = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, label } = this.props;
     dispatch(actions.annotationDeleteLabelFromCategory(metadataField, label));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleAddCurrentSelectionToThisLabel = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, label } = this.props;
     dispatch(actions.annotationLabelCurrentSelection(metadataField, label));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleEditValue = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, label } = this.props;
@@ -119,6 +132,7 @@ class CategoryValue extends React.Component<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleCreateArbitraryLabel = (txt: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, label } = this.props;
@@ -128,6 +142,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   labelNameError = (name: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
     const { metadataField, schema } = this.props;
@@ -135,10 +150,12 @@ class CategoryValue extends React.Component<{}, State> {
     return isLabelErroneous(name, metadataField, schema);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   instruction = (label: any) => {
     return labelPrompt(this.labelNameError(label), "New, unique label", ":");
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   activateEditLabelMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, categoryIndex, label } = this.props;
@@ -150,6 +167,7 @@ class CategoryValue extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   cancelEditMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, categoryIndex, label } = this.props;
@@ -164,6 +182,7 @@ class CategoryValue extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   toggleOff = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -187,6 +206,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   shouldComponentUpdate = (nextProps: any, nextState: any) => {
     /*
     Checks to see if at least one of the following changed:
@@ -212,10 +232,13 @@ class CategoryValue extends React.Component<{}, State> {
     const valueSelectionChange = isSelected !== newIsSelected;
 
     const colorAccessorChange =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (props as any).colorAccessor !== nextProps.colorAccessor;
     const annotationsChange =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (props as any).annotations !== nextProps.annotations;
     const editingLabel = state.editedLabelText !== nextState.editedLabelText;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const dilationChange = (props as any).isDilated !== nextProps.isDilated;
 
     const count = categorySummary.categoryValueCounts[categoryIndex];
@@ -227,6 +250,7 @@ class CategoryValue extends React.Component<{}, State> {
     // if any one changes, but only for the currently colored-by category.
     const colorMightHaveChanged =
       nextProps.colorAccessor === nextProps.metadataField &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (props as any).categorySummary !== nextProps.categorySummary;
 
     return (
@@ -241,6 +265,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   toggleOn = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -264,6 +289,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleMouseEnter = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, categoryIndex, label } = this.props;
@@ -275,6 +301,7 @@ class CategoryValue extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleMouseExit = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, metadataField, categoryIndex, label } = this.props;
@@ -286,23 +313,33 @@ class CategoryValue extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleTextChange = (text: any) => {
     this.setState({ editedLabelText: text });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChoice = (e: any) => {
     /* Blueprint Suggest format */
     this.setState({ editedLabelText: e.target });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createHistogramBins = (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     metadataField: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryData: any,
     // @ts-expect-error ts-migrate(6133) FIXME: 'colorAccessor' is declared but its value is never... Remove this comment to see the full error message
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorAccessor: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorData: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryValue: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     width: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     height: any
   ) => {
     /*
@@ -337,15 +374,24 @@ class CategoryValue extends React.Component<{}, State> {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createStackedGraphBins = (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     metadataField: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryData: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorAccessor: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorData: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryValue: any,
     // @ts-expect-error ts-migrate(6133) FIXME: 'colorTable' is declared but its value is never re... Remove this comment to see the full error message
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorTable: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     schema: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     width: any
   ) => {
     /*
@@ -383,10 +429,12 @@ class CategoryValue extends React.Component<{}, State> {
     return null;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   currentLabelAsString() {
     return _currentLabelAsString(this.props);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isAddCurrentSelectionDisabled(crossfilter: any, category: any, value: any) {
     /*
     disable "add current selection to label", if one of the following is true:
@@ -411,6 +459,7 @@ class CategoryValue extends React.Component<{}, State> {
     return false;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderMiniStackedBar = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorAccessor' does not exist on type 'R... Remove this comment to see the full error message
@@ -470,6 +519,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderMiniHistogram = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorAccessor' does not exist on type 'R... Remove this comment to see the full error message
@@ -528,6 +578,7 @@ class CategoryValue extends React.Component<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message

--- a/client/src/components/categorical/value/occupancy.tsx
+++ b/client/src/components/categorical/value/occupancy.tsx
@@ -10,15 +10,18 @@ import {
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
 }))
 class Occupancy extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   canvas: any;
 
   _WIDTH = 100;
 
   _HEIGHT = 11;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createHistogram = () => {
     /*
           Knowing that colorScale is based off continous data,
@@ -68,6 +71,7 @@ class Occupancy extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createOccupancyStack = () => {
     /*
           Knowing that the color scale is based off of catagorical data,
@@ -126,6 +130,7 @@ class Occupancy extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorAccessor' does not exist on type 'R... Remove this comment to see the full error message
     const { colorAccessor, categoryValue, colorByIsCategorical } = this.props;

--- a/client/src/components/continuous/continuous.tsx
+++ b/client/src/components/continuous/continuous.tsx
@@ -6,9 +6,11 @@ import HistogramBrush from "../brushableHistogram";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
 }))
 class Continuous extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     /* initial value for iterator to simulate index, ranges is an object */
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
@@ -16,12 +18,17 @@ class Continuous extends React.PureComponent {
     if (!schema) return null;
     const obsIndex = schema.annotations.obs.index;
     const allContinuousNames = schema.annotations.obs.columns
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .filter((col: any) => col.type === "int32" || col.type === "float32")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .filter((col: any) => col.name !== obsIndex)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .filter((col: any) => !col.writable) // skip user annotations - they will be treated as categorical
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       .map((col: any) => col.name);
     return (
       <div>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
         {allContinuousNames.map((key: any, zebra: any) => (
           // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
           <HistogramBrush key={key} field={key} isObs zebra={zebra % 2 === 0} />

--- a/client/src/components/continuous/setupParallelCoordinates.ts
+++ b/client/src/components/continuous/setupParallelCoordinates.ts
@@ -5,6 +5,7 @@
 ******************************************/
 import * as d3 from "d3";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const setupParallelCoordinates = (width: any, height: any, margin: any) => {
   const container = d3.select("#parcoords");
 

--- a/client/src/components/continuous/util.ts
+++ b/client/src/components/continuous/util.ts
@@ -12,13 +12,16 @@ export const innerHeight = height - 2;
 
 export const devicePixelRatio = window.devicePixelRatio || 1;
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const createDimensions = (data: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const newArr: any = [];
   each(data, (value, key) => {
     if (value.range) {
       newArr.push({
         key /* room for confusion: lodash calls this key, it's also the name of the property parallel coords code is looking for */,
         type: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           within: (d: any, extent: any, dim: any) =>
             extent[0] <= dim.scale(d) && dim.scale(d) <= extent[1],
         },
@@ -35,13 +38,17 @@ export const createDimensions = (data: any) => {
 // @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 0.
 export const yAxis = d3.axisLeft();
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const brushstart = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   (d3 as any).event.sourceEvent.stopPropagation();
 };
 
 // Unused.
 // export const d3_functor = v => (typeof v === "function" ? v : () => v);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const project = (d: any, dimensions: any, xscale: any) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dimensions.map((p: any, i: any) => {
     // check if data element has property and contains a value
     if (!(p.key in d) || d[p.key] === null) return null;

--- a/client/src/components/continuousLegend/index.tsx
+++ b/client/src/components/continuousLegend/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../util/stateManager/colorHelpers";
 
 // create continuous color legend
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const continuous = (selectorId: any, colorScale: any, colorAccessor: any) => {
   const legendHeight = 200;
   const legendWidth = 80;
@@ -110,11 +111,15 @@ const continuous = (selectorId: any, colorScale: any, colorAccessor: any) => {
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annoMatrix: (state as any).annoMatrix,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colors: (state as any).colors,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets.genesets,
 }))
 class ContinuousLegend extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   async componentDidUpdate(prevProps: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, colors, genesets } = this.props;
@@ -157,6 +162,7 @@ class ContinuousLegend extends React.Component {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     return (
       <div

--- a/client/src/components/embedding/index.tsx
+++ b/client/src/components/embedding/index.tsx
@@ -15,28 +15,36 @@ import * as globals from "../../globals";
 import actions from "../../actions";
 import { getDiscreteCellEmbeddingRowIndex } from "../../util/stateManager/viewStackHelpers";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type EmbeddingState = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     layoutChoice: (state as any).layoutChoice,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema: (state as any).annoMatrix?.schema,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     crossfilter: (state as any).obsCrossfilter,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Embedding extends React.PureComponent<{}, EmbeddingState> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {};
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleLayoutChoiceChange = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     dispatch(actions.layoutChoiceAction(e.currentTarget.value));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'layoutChoice' does not exist on type 'Re... Remove this comment to see the full error message
     const { layoutChoice, schema, crossfilter } = this.props;
@@ -105,8 +113,10 @@ class Embedding extends React.PureComponent<{}, EmbeddingState> {
 
 export default Embedding;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const loadAllEmbeddingCounts = async ({ annoMatrix, available }: any) => {
   const embeddings = await Promise.all(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     available.map((name: any) => annoMatrix.base().fetch("emb", name))
   );
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'name' implicitly has an 'any' type.
@@ -117,6 +127,7 @@ const loadAllEmbeddingCounts = async ({ annoMatrix, available }: any) => {
   }));
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const EmbeddingChoices = ({ onChange, annoMatrix, layoutChoice }: any) => {
   const { available } = layoutChoice;
   const { data, error, isPending } = useAsync({
@@ -133,6 +144,7 @@ const EmbeddingChoices = ({ onChange, annoMatrix, layoutChoice }: any) => {
     /* still loading, or errored out - just omit counts (TODO: spinner?) */
     return (
       <RadioGroup onChange={onChange} selectedValue={layoutChoice.current}>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
         {layoutChoice.available.map((name: any) => (
           <Radio label={`${name}`} value={name} key={name} />
         ))}
@@ -142,6 +154,7 @@ const EmbeddingChoices = ({ onChange, annoMatrix, layoutChoice }: any) => {
   if (data) {
     return (
       <RadioGroup onChange={onChange} selectedValue={layoutChoice.current}>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
         {data.map((summary: any) => {
           const { discreteCellIndex, embeddingName } = summary;
           const sizeHint = `${discreteCellIndex.size()} cells`;

--- a/client/src/components/framework/container.tsx
+++ b/client/src/components/framework/container.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 function Container(props: any) {
   const { children } = props;
   return (

--- a/client/src/components/framework/layout.tsx
+++ b/client/src/components/framework/layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as globals from "../../globals";
 
 class Layout extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   viewportRef: any;
   /*
     Layout - this react component contains all the layout style and logic for the application once it has loaded.
@@ -14,6 +15,7 @@ class Layout extends React.Component {
     should be.
   */
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     /*
       This is a bit of a hack. In order for the graph to size correctly, it needs to know the size of the parent
@@ -22,6 +24,7 @@ class Layout extends React.Component {
     this.forceUpdate();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { children } = this.props;
     // @ts-expect-error ts-migrate(2488) FIXME: Type 'ReactNode' must have a '[Symbol.iterator]()'... Remove this comment to see the full error message

--- a/client/src/components/framework/logo.tsx
+++ b/client/src/components/framework/logo.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as globals from "../../globals";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const Logo = (props: any) => {
   const { size } = props;
   return (

--- a/client/src/components/framework/toasters.ts
+++ b/client/src/components/framework/toasters.ts
@@ -11,6 +11,7 @@ const ToastTopCenter = Toaster.create({
 /*
 A "user" error - eg, bad input
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const postUserErrorToast = (message: any) =>
   ToastTopCenter.show({ message, intent: Intent.WARNING });
 
@@ -18,12 +19,14 @@ export const postUserErrorToast = (message: any) =>
 A toast the user must dismiss manually, because they need to act on its information,
 ie., 8 bulk add genes out of 40 were bad. Manually see which ones and fix.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const keepAroundErrorToast = (message: any) =>
   ToastTopCenter.show({ message, timeout: 0, intent: Intent.WARNING });
 
 /*
 a hard network error
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const postNetworkErrorToast = (message: any, key = undefined) =>
   ToastTopCenter.show(
     {
@@ -37,6 +40,7 @@ export const postNetworkErrorToast = (message: any, key = undefined) =>
 /*
 Async message to user
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const postAsyncSuccessToast = (message: any) =>
   ToastTopCenter.show({
     message,
@@ -44,6 +48,7 @@ export const postAsyncSuccessToast = (message: any) =>
     intent: Intent.SUCCESS,
   });
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const postAsyncFailureToast = (message: any) =>
   ToastTopCenter.show({
     message,

--- a/client/src/components/geneExpression/gene.tsx
+++ b/client/src/components/geneExpression/gene.tsx
@@ -9,6 +9,7 @@ import actions from "../../actions";
 
 const MINI_HISTOGRAM_WIDTH = 110;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
@@ -17,14 +18,19 @@ type State = any;
   const { gene } = ownProps;
 
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     isColorAccessor: (state as any).colors.colorAccessor === gene,
     isScatterplotXXaccessor:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).controls.scatterplotXXaccessor === gene,
     isScatterplotYYaccessor:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).controls.scatterplotYYaccessor === gene,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Gene extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -32,17 +38,20 @@ class Gene extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   onColorChangeClick = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, gene } = this.props;
     dispatch(actions.requestSingleGeneExpressionCountsForColoringPOST(gene));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleGeneExpandClick = () => {
     const { geneIsExpanded } = this.state;
     this.setState({ geneIsExpanded: !geneIsExpanded });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSetGeneAsScatterplotX = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, gene } = this.props;
@@ -52,6 +61,7 @@ class Gene extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSetGeneAsScatterplotY = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, gene } = this.props;
@@ -61,12 +71,14 @@ class Gene extends React.Component<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDeleteGeneFromSet = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, gene, geneset } = this.props;
     dispatch(actions.genesetDeleteGenes(geneset, [gene]));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'gene' does not exist on type 'Readonly<{... Remove this comment to see the full error message

--- a/client/src/components/geneExpression/geneSet.tsx
+++ b/client/src/components/geneExpression/geneSet.tsx
@@ -9,9 +9,12 @@ import HistogramBrush from "../brushableHistogram";
 
 import { diffexpPopNamePrefix1, diffexpPopNamePrefix2 } from "../../globals";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class GeneSet extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -19,11 +22,13 @@ class GeneSet extends React.Component<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   onGenesetMenuClick = () => {
     const { isOpen } = this.state;
     this.setState({ isOpen: !isOpen });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderGenes() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'setName' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { setName, setGenes } = this.props;
@@ -46,6 +51,7 @@ class GeneSet extends React.Component<{}, State> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'setName' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { setName, genesetDescription, setGenes } = this.props;

--- a/client/src/components/geneExpression/index.tsx
+++ b/client/src/components/geneExpression/index.tsx
@@ -7,20 +7,25 @@ import GeneSet from "./geneSet";
 import QuickGene from "./quickGene";
 import CreateGenesetDialogue from "./menus/createGenesetDialogue";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     genesets: (state as any).genesets.genesets,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class GeneExpression extends React.Component<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = { geneSetsExpanded: true };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderGeneSets = () => {
     const sets = [];
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'genesets' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -40,24 +45,29 @@ class GeneExpression extends React.Component<{}, State> {
     return sets;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleActivateCreateGenesetMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     const { geneSetsExpanded } = this.state;
     dispatch({ type: "geneset: activate add new geneset mode" });
     if (!geneSetsExpanded) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       this.setState((state: any) => {
         return { ...state, geneSetsExpanded: true };
       });
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleExpandGeneSets = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.setState((state: any) => {
       return { ...state, geneSetsExpanded: !state.geneSetsExpanded };
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { geneSetsExpanded } = this.state;
     return (

--- a/client/src/components/geneExpression/menus/addGeneToGenesetDialogue.tsx
+++ b/client/src/components/geneExpression/menus/addGeneToGenesetDialogue.tsx
@@ -5,13 +5,17 @@ import LabelInput from "../../labelInput";
 import parseBulkGeneString from "../../../util/parseBulkGeneString";
 import actions from "../../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesetsUI: (state as any).genesetsUI,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class AddGeneToGenesetDialogue extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -19,6 +23,7 @@ class AddGeneToGenesetDialogue extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   disableAddGeneMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -27,10 +32,12 @@ class AddGeneToGenesetDialogue extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleAddGeneToGeneSet = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'geneset' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { geneset, dispatch } = this.props;
     const { genesToAdd } = this.state;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const genesTmpHardcodedFormat: any = [];
     const genesArrayFromString = parseBulkGeneString(genesToAdd);
     genesArrayFromString.forEach((_gene) => {
@@ -45,10 +52,12 @@ class AddGeneToGenesetDialogue extends React.PureComponent<{}, State> {
     if (e) e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChange = (e: any) => {
     this.setState({ genesToAdd: e });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'geneset' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { geneset, genesetsUI } = this.props;

--- a/client/src/components/geneExpression/menus/addGenes.tsx
+++ b/client/src/components/geneExpression/menus/addGenes.tsx
@@ -20,6 +20,7 @@ import {
 import { memoize } from "../../../util/dataframe/util";
 import parseBulkGeneString from "../../../util/parseBulkGeneString";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderGene = (fuzzySortResult: any, { handleClick, modifiers }: any) => {
   if (!modifiers.matchesPredicate) {
     return null;
@@ -33,6 +34,7 @@ const renderGene = (fuzzySortResult: any, { handleClick, modifiers }: any) => {
       disabled={modifiers.disabled}
       data-testid={`suggest-menu-item-${geneName}`}
       key={geneName}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       onClick={(g: any /* this fires when user clicks a menu item */) =>
         handleClick(g)
       }
@@ -41,6 +43,7 @@ const renderGene = (fuzzySortResult: any, { handleClick, modifiers }: any) => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const filterGenes = (query: any, genes: any) =>
   /* fires on load, once, and then for each character typed into the input */
   fuzzysort.go(query, genes, {
@@ -48,17 +51,23 @@ const filterGenes = (query: any, genes: any) =>
     threshold: -10000, // don't return bad results
   });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type AddGenesState = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annoMatrix: (state as any).annoMatrix,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     userDefinedGenes: (state as any).controls.userDefinedGenes,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     userDefinedGenesLoading: (state as any).controls.userDefinedGenesLoading,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class AddGenes extends React.Component<{}, AddGenesState> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -70,15 +79,18 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 0.
     this.updateState();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidUpdate(prevProps: {}) {
     this.updateState(prevProps);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleClick(g: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, userDefinedGenes } = this.props;
@@ -100,6 +112,7 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   _genesToUpper = (listGenes: any) => {
     // Has to be a Map to preserve index
     const upperGenes = new Map();
@@ -110,9 +123,10 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     return upperGenes;
   };
 
-  // eslint-disable-next-line react/sort-comp -- memo requires a defined _genesToUpper
+  // eslint-disable-next-line react/sort-comp, @typescript-eslint/no-explicit-any -- memo requires a defined _genesToUpper
   _memoGenesToUpper = memoize(this._genesToUpper, (arr: any) => arr);
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleBulkAddClick = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, userDefinedGenes } = this.props;
@@ -164,6 +178,7 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     return undefined;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   async updateState(prevProps: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix } = this.props;
@@ -186,6 +201,7 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   placeholderGeneNames() {
     /*
     return a string containing gene name suggestions for use as a user hint.
@@ -215,6 +231,7 @@ class AddGenes extends React.Component<{}, AddGenesState> {
     return "Apod, Cd74, ...";
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'userDefinedGenesLoading' does not exist ... Remove this comment to see the full error message
     const { userDefinedGenesLoading } = this.props;

--- a/client/src/components/geneExpression/menus/createGenesetDialogue.tsx
+++ b/client/src/components/geneExpression/menus/createGenesetDialogue.tsx
@@ -7,17 +7,25 @@ import { Tooltip2 } from "@blueprintjs/popover2";
 import LabelInput from "../../labelInput";
 import actions from "../../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   obsCrossfilter: (state as any).obsCrossfilter,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets.genesets,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesetsUI: (state as any).genesetsUI,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class CreateGenesetDialogue extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -27,6 +35,7 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   disableCreateGenesetMode = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -42,6 +51,7 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
     if (e) e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   createGeneset = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -56,6 +66,7 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
       genesetDescription,
     });
     if (genesToPopulateGeneset) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const genesTmpHardcodedFormat: any = [];
       const genesArrayFromString = pull(
         uniq(genesToPopulateGeneset.split(/[ ,]+/)),
@@ -78,10 +89,12 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   genesetNameError = () => {
     return false;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChange = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'genesets' does not exist on type 'Readon... Remove this comment to see the full error message
     const { genesets } = this.props;
@@ -89,20 +102,24 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
     this.validate(e, genesets);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleGenesetInputChange = (e: any) => {
     this.setState({ genesToPopulateGeneset: e });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleDescriptionInputChange = (e: any) => {
     this.setState({ genesetDescription: e });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   instruction = (genesetName: any, genesets: any) => {
     return genesets.has(genesetName)
       ? "Gene set name must be unique."
       : "New, unique gene set name";
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   validate = (genesetName: any, genesets: any) => {
     if (genesets.has(genesetName)) {
       this.setState({
@@ -127,6 +144,7 @@ class CreateGenesetDialogue extends React.PureComponent<{}, State> {
     return true;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { genesetName, nameErrorMessage } = this.state;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'genesetsUI' does not exist on type 'Read... Remove this comment to see the full error message

--- a/client/src/components/geneExpression/menus/editGenesetNameDialogue.tsx
+++ b/client/src/components/geneExpression/menus/editGenesetNameDialogue.tsx
@@ -3,17 +3,25 @@ import { connect } from "react-redux";
 import AnnoDialog from "../../annoDialog";
 import LabelInput from "../../labelInput";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annotations: (state as any).annotations,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: (state as any).annoMatrix?.schema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   obsCrossfilter: (state as any).obsCrossfilter,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesetsUI: (state as any).genesetsUI,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets.genesets,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class RenameGeneset extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -24,6 +32,7 @@ class RenameGeneset extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   disableEditGenesetNameMode = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -37,6 +46,7 @@ class RenameGeneset extends React.PureComponent<{}, State> {
     if (e) e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   renameGeneset = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, genesetsUI } = this.props;
@@ -55,18 +65,22 @@ class RenameGeneset extends React.PureComponent<{}, State> {
     e.preventDefault();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   genesetNameError = () => {
     return false;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChange = (e: any) => {
     this.setState({ newGenesetName: e });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChangeDescription = (e: any) => {
     this.setState({ newGenesetDescription: e });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   validate = (genesetName: any, genesets: any) => {
     return (
       !genesets.has(genesetName) &&
@@ -76,6 +90,7 @@ class RenameGeneset extends React.PureComponent<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { newGenesetName, newGenesetDescription } = this.state;
     const {

--- a/client/src/components/geneExpression/menus/genesetMenus.tsx
+++ b/client/src/components/geneExpression/menus/genesetMenus.tsx
@@ -17,21 +17,27 @@ import * as globals from "../../../globals";
 import actions from "../../../actions";
 import AddGeneToGenesetDialogue from "./addGeneToGenesetDialogue";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     genesetsUI: (state as any).genesetsUI,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     colorAccessor: (state as any).colors.colorAccessor,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class GenesetMenus extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {};
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   activateAddGeneToGenesetMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, geneset } = this.props;
@@ -41,6 +47,7 @@ class GenesetMenus extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   activateEditGenesetNameMode = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, geneset } = this.props;
@@ -51,6 +58,7 @@ class GenesetMenus extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleColorByEntireGeneset = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, geneset } = this.props;
@@ -61,12 +69,14 @@ class GenesetMenus extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDeleteGeneset = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, geneset } = this.props;
     dispatch(actions.genesetDelete(geneset));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'geneset' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { geneset, genesetsEditable, createText, colorAccessor } = this.props;

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -10,6 +10,7 @@ import Gene from "./gene";
 import { postUserErrorToast } from "../framework/toasters";
 import actions from "../../actions";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const usePrevious = (value: any) => {
   const ref = useRef();
   useEffect(() => {
@@ -18,6 +19,7 @@ const usePrevious = (value: any) => {
   return ref.current;
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 function QuickGene() {
   const dispatch = useDispatch();
 
@@ -28,8 +30,11 @@ function QuickGene() {
   const { annoMatrix, userDefinedGenes, userDefinedGenesLoading } = useSelector(
     (state) => {
       return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         annoMatrix: (state as any).annoMatrix,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         userDefinedGenes: (state as any).controls.userDefinedGenes,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         userDefinedGenesLoading: (state as any).controls
           .userDefinedGenesLoading,
       };
@@ -41,6 +46,7 @@ function QuickGene() {
   // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '() => Promise<void>' is not assi... Remove this comment to see the full error message
   useEffect(async () => {
     if (!annoMatrix) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     if (annoMatrix !== (prevProps as any)?.annoMatrix) {
       const { schema } = annoMatrix;
       const varIndex = schema.annotations.var.index;
@@ -60,7 +66,9 @@ function QuickGene() {
   const handleExpand = () => setIsExpanded(!isExpanded);
 
   const renderGene = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     fuzzySortResult: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     { handleClick, modifiers }: any
   ) => {
     if (!modifiers.matchesPredicate) {
@@ -75,6 +83,7 @@ function QuickGene() {
         disabled={modifiers.disabled}
         data-testid={`suggest-menu-item-${geneName}`}
         key={geneName}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         onClick={(g: any /* this fires when user clicks a menu item */) =>
           handleClick(g)
         }
@@ -83,6 +92,7 @@ function QuickGene() {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const handleClick = (g: any) => {
     if (!g) return;
     const gene = g.target;
@@ -98,6 +108,7 @@ function QuickGene() {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const filterGenes = (query: any, genes: any) =>
     /* fires on load, once, and then for each character typed into the input */
     fuzzysort.go(query, genes, {
@@ -105,11 +116,13 @@ function QuickGene() {
       threshold: -10000, // don't return bad results
     });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const removeGene = (gene: any) => () => {
     dispatch({ type: "clear user defined gene", data: gene });
   };
 
   const QuickGenes = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return userDefinedGenes.map((gene: any) => {
       return (
         <Gene

--- a/client/src/components/graph/drawPointsRegl.ts
+++ b/client/src/components/graph/drawPointsRegl.ts
@@ -1,5 +1,6 @@
 import { glPointFlags, glPointSize } from "../../util/glHelpers";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function drawPointsRegl(regl: any) {
   return regl({
     vert: `

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -34,6 +34,7 @@ Simple 2D transforms control all point painting.  There are three:
   * camera - apply a 2D camera transformation (pan, zoom)
   * projection - apply any transformation required for screen size and layout
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function createProjectionTF(viewportWidth: any, viewportHeight: any) {
   /*
   the projection transform accounts for the screen size & other layout
@@ -68,21 +69,33 @@ function createModelTF() {
   return m;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type GraphState = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annoMatrix: (state as any).annoMatrix,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   crossfilter: (state as any).obsCrossfilter,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   selectionTool: (state as any).graphSelection.tool,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   currentSelection: (state as any).graphSelection.selection,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: (state as any).layoutChoice,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   graphInteractionMode: (state as any).controls.graphInteractionMode,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colors: (state as any).colors,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   pointDilation: (state as any).pointDilation,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets.genesets,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Graph extends React.Component<{}, GraphState> {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static createReglState(canvas: any) {
     /*
         Must be created for each canvas
@@ -108,12 +121,15 @@ class Graph extends React.Component<{}, GraphState> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   cachedAsyncProps: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   reglCanvas: any;
 
   computePointPositions = memoize((X, Y, modelTF) => {
@@ -214,6 +230,7 @@ class Graph extends React.Component<{}, GraphState> {
     }
   );
 
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     const viewport = this.getViewportDimensions();
@@ -255,10 +272,12 @@ class Graph extends React.Component<{}, GraphState> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     window.addEventListener("resize", this.handleResize);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidUpdate(prevProps: {}, prevState: GraphState) {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'selectionTool' does not exist on type 'R... Remove this comment to see the full error message
@@ -312,10 +331,12 @@ class Graph extends React.Component<{}, GraphState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleResize = () => {
     const { state } = this.state;
     const viewport = this.getViewportDimensions();
@@ -327,17 +348,20 @@ class Graph extends React.Component<{}, GraphState> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleCanvasEvent = (e: any) => {
     const { camera, projectionTF } = this.state;
     if (e.type !== "wheel") e.preventDefault();
     if (camera.handleEvent(e, projectionTF)) {
       this.renderCanvas();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       this.setState((state: any) => {
         return { ...state, updateOverlay: !state.updateOverlay };
       });
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleBrushDragAction() {
     /*
           event describing brush position:
@@ -369,6 +393,7 @@ class Graph extends React.Component<{}, GraphState> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleBrushStartAction() {
     // Ignore programatically generated events.
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'event' does not exist on type 'typeof im... Remove this comment to see the full error message
@@ -378,6 +403,7 @@ class Graph extends React.Component<{}, GraphState> {
     dispatch(actions.graphBrushStartAction());
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleBrushEndAction() {
     // Ignore programatically generated events.
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'event' does not exist on type 'typeof im... Remove this comment to see the full error message
@@ -410,12 +436,14 @@ class Graph extends React.Component<{}, GraphState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleBrushDeselectAction() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, layoutChoice } = this.props;
     dispatch(actions.graphBrushDeselectAction(layoutChoice.current));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleLassoStart() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, layoutChoice } = this.props;
@@ -424,6 +452,7 @@ class Graph extends React.Component<{}, GraphState> {
   }
 
   // when a lasso is completed, filter to the points within the lasso polygon
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleLassoEnd(polygon: any) {
     const minimumPolygonArea = 10;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -438,24 +467,28 @@ class Graph extends React.Component<{}, GraphState> {
       dispatch(
         actions.graphLassoEndAction(
           layoutChoice.current,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           polygon.map((xy: any) => this.mapScreenToPoint(xy))
         )
       );
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleLassoCancel() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, layoutChoice } = this.props;
     dispatch(actions.graphLassoCancelAction(layoutChoice.current));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleLassoDeselectAction() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, layoutChoice } = this.props;
     dispatch(actions.graphLassoDeselectAction(layoutChoice.current));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleDeselectAction() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'selectionTool' does not exist on type 'R... Remove this comment to see the full error message
     const { selectionTool } = this.props;
@@ -463,6 +496,7 @@ class Graph extends React.Component<{}, GraphState> {
     if (selectionTool === "lasso") this.handleLassoDeselectAction();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleOpacityRangeChange(e: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -472,6 +506,7 @@ class Graph extends React.Component<{}, GraphState> {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   setReglCanvas = (canvas: any) => {
     this.reglCanvas = canvas;
     this.setState({
@@ -479,6 +514,7 @@ class Graph extends React.Component<{}, GraphState> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getViewportDimensions = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'viewportRef' does not exist on type 'Rea... Remove this comment to see the full error message
     const { viewportRef } = this.props;
@@ -488,6 +524,7 @@ class Graph extends React.Component<{}, GraphState> {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   createToolSVG = () => {
     /*
         Called from componentDidUpdate. Create the tool SVG, and return any
@@ -531,6 +568,7 @@ class Graph extends React.Component<{}, GraphState> {
     return { toolSVG: newToolSVG, tool, container };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fetchAsyncProps = async (props: any) => {
     const {
       annoMatrix,
@@ -578,10 +616,15 @@ class Graph extends React.Component<{}, GraphState> {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async fetchData(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     annoMatrix: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     layoutChoice: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colors: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointDilation: any
   ) {
     /*
@@ -610,6 +653,7 @@ class Graph extends React.Component<{}, GraphState> {
     return Promise.all(promises);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   brushToolUpdate(tool: any, container: any) {
     /*
         this is called from componentDidUpdate(), so be very careful using
@@ -653,6 +697,7 @@ class Graph extends React.Component<{}, GraphState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   lassoToolUpdate(tool: any) {
     /*
         this is called from componentDidUpdate(), so be very careful using
@@ -664,6 +709,7 @@ class Graph extends React.Component<{}, GraphState> {
       /*
             if there is a current selection, make sure the lasso tool matches
             */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const polygon = currentSelection.polygon.map((p: any) =>
         this.mapPointToScreen(p)
       );
@@ -673,6 +719,7 @@ class Graph extends React.Component<{}, GraphState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectionToolUpdate(tool: any, container: any) {
     /*
         this is called from componentDidUpdate(), so be very careful using
@@ -694,6 +741,7 @@ class Graph extends React.Component<{}, GraphState> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   mapScreenToPoint(pin: any) {
     /*
         Map an XY coordinates from screen domain to cell/point range,
@@ -712,6 +760,7 @@ class Graph extends React.Component<{}, GraphState> {
     return xy;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   mapPointToScreen(xyCell: any) {
     /*
         Map an XY coordinate from cell/point domain to screen range.  Inverse
@@ -749,6 +798,7 @@ class Graph extends React.Component<{}, GraphState> {
     );
   });
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   updateReglAndRender(asyncProps: any, prevAsyncProps: any) {
     const { positions, colors, flags, height, width } = asyncProps;
     this.cachedAsyncProps = asyncProps;
@@ -772,6 +822,7 @@ class Graph extends React.Component<{}, GraphState> {
     if (needToRenderCanvas) this.renderCanvas();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   updateColorTable(colors: any, colorDf: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix } = this.props;
@@ -796,6 +847,7 @@ class Graph extends React.Component<{}, GraphState> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   createColorByQuery(colors: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, genesets } = this.props;
@@ -804,13 +856,21 @@ class Graph extends React.Component<{}, GraphState> {
     return createColorQuery(colorMode, colorAccessor, schema, genesets);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderPoints(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     regl: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     drawPoints: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     flagBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     camera: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     projectionTF: any
   ) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
@@ -838,6 +898,7 @@ class Graph extends React.Component<{}, GraphState> {
     regl._gl.flush();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'graphInteractionMode' does not exist on ... Remove this comment to see the full error message
@@ -957,6 +1018,7 @@ class Graph extends React.Component<{}, GraphState> {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const ErrorLoading = ({ displayName, error, width, height }: any) => {
   console.log(error); // log to console as this is an unepected error
   return (
@@ -973,6 +1035,7 @@ const ErrorLoading = ({ displayName, error, width, height }: any) => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const StillLoading = ({ displayName, width, height }: any) => {
   /*
   Render a busy/loading indicator

--- a/client/src/components/graph/overlays/centroidLabels.tsx
+++ b/client/src/components/graph/overlays/centroidLabels.tsx
@@ -8,19 +8,28 @@ import { createColorQuery } from "../../../util/stateManager/colorHelpers";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   annoMatrix: (state as any).annoMatrix,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colors: (state as any).colors,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: (state as any).layoutChoice,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dilatedValue: (state as any).pointDilation.categoryField,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoricalSelection: (state as any).categoricalSelection,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   showLabels: (state as any).centroidLabels?.showLabels,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   genesets: (state as any).genesets.genesets,
 }))
 export default class CentroidLabels extends PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fetchAsyncProps = async (props: any) => {
     const {
       annoMatrix,
@@ -55,6 +64,7 @@ export default class CentroidLabels extends PureComponent {
   };
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleMouseEnter = (e: any, colorAccessor: any, label: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -66,6 +76,7 @@ export default class CentroidLabels extends PureComponent {
   };
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleMouseOut = (e: any, colorAccessor: any, label: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -76,6 +87,7 @@ export default class CentroidLabels extends PureComponent {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   colorByQuery() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, colors, genesets } = this.props;
@@ -84,6 +96,7 @@ export default class CentroidLabels extends PureComponent {
     return createColorQuery(colorMode, colorAccessor, schema, genesets);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async fetchData() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, layoutChoice } = this.props;
@@ -101,6 +114,7 @@ export default class CentroidLabels extends PureComponent {
     return Promise.all(promises);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'inverseTransform' does not exist on type... Remove this comment to see the full error message
@@ -134,10 +148,12 @@ export default class CentroidLabels extends PureComponent {
         <Async.Fulfilled>
           {(asyncProps) => {
             if (!showLabels) return null;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             const labelSVGS: any = [];
             const deselectOpacity = 0.375;
             // @ts-expect-error ts-migrate(2339) FIXME: Property 'category' does not exist on type 'unknow... Remove this comment to see the full error message
             const { category, colorAccessor, labels } = asyncProps;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
             labels.forEach((coords: any, label: any) => {
               const selected = category.get(label) ?? true;
               // Mirror LSB middle truncation
@@ -181,7 +197,7 @@ const Label = ({
   colorAccessor,
   displayLabel,
   onMouseEnter,
-  onMouseOut,
+  onMouseOut, // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 }: any) => {
   /*
   Render a label at a given coordinate.

--- a/client/src/components/graph/overlays/graphOverlayLayer.tsx
+++ b/client/src/components/graph/overlays/graphOverlayLayer.tsx
@@ -3,8 +3,10 @@ import React, { PureComponent, cloneElement } from "react";
 // @ts-expect-error ts-migrate(2307) FIXME: Cannot find module '../graph.css' or its correspon... Remove this comment to see the full error message
 import styles from "../graph.css";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 export default class GraphOverlayLayer extends PureComponent<{}, State> {
   /*
     This component takes its children (assumed in the data coordinate space ([0, 1] range, origin in bottom left corner))
@@ -12,6 +14,7 @@ export default class GraphOverlayLayer extends PureComponent<{}, State> {
 
     Children are assigned in the graph component and must implement onDisplayChange()
    */
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -19,6 +22,7 @@ export default class GraphOverlayLayer extends PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   matrixToTransformString = (m: any) => {
     /* 
       Translates the gl-matrix mat3 to SVG matrix transform style
@@ -31,17 +35,21 @@ export default class GraphOverlayLayer extends PureComponent<{}, State> {
     return `matrix(${m[0]} ${m[1]} ${m[3]} ${m[4]} ${m[6]} ${m[7]})`;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   reverseMatrixScaleTransformString = (m: any) => {
     return `matrix(${1 / m[0]} 0 0 ${1 / m[4]} 0 0)`;
   };
 
   // This is passed to all children, should be called when an overlay's display state is toggled along with the overlay name and its new display state in boolean form
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   overlaySetShowing = (overlay: any, displaying: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.setState((state: any) => {
       return { ...state, display: { ...state.display, [overlay]: displaying } };
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'cameraTF' does not exist on type 'Readon... Remove this comment to see the full error message

--- a/client/src/components/graph/setupLasso.ts
+++ b/client/src/components/graph/setupLasso.ts
@@ -1,18 +1,27 @@
 import * as d3 from "d3";
 import { Colors } from "@blueprintjs/core";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Lasso = () => {
   const dispatch = d3.dispatch("start", "end", "cancel");
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const lasso = (svg: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let lassoPolygon: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let lassoPath: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let closePath: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     let lassoInProgress: any;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const polygonToPath = (polygon: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       `M${polygon.map((d: any) => d.join(",")).join("L")}`;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const distance = (pt1: any, pt2: any) =>
       Math.sqrt((pt2[0] - pt1[0]) ** 2 + (pt2[1] - pt1[1]) ** 2);
 
@@ -21,6 +30,7 @@ const Lasso = () => {
     const lassoPathColor = Colors.BLUE5;
 
     const handleDragStart = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       lassoPolygon = [(d3 as any).mouse(svg.node())]; // current x y of mouse within element
 
       if (lassoPath) {
@@ -56,6 +66,7 @@ const Lasso = () => {
     };
 
     const handleDrag = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const point = (d3 as any).mouse(svg.node());
       lassoPolygon.push(point);
       lassoPath.attr("d", polygonToPath(lassoPolygon));
@@ -126,6 +137,7 @@ const Lasso = () => {
 
     area.call(drag);
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (lasso as any).reset = () => {
       if (lassoPath) {
         lassoPath.remove();
@@ -138,6 +150,7 @@ const Lasso = () => {
       }
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (lasso as any).move = (polygon: any) => {
       if (polygon !== lassoPolygon || polygon.length !== lassoPolygon.length) {
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'reset' does not exist on type '(svg: any... Remove this comment to see the full error message
@@ -155,6 +168,7 @@ const Lasso = () => {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   lasso.on = (type: any, callback: any) => {
     dispatch.on(type, callback);
     return lasso;

--- a/client/src/components/graph/setupSVGandBrush.ts
+++ b/client/src/components/graph/setupSVGandBrush.ts
@@ -7,12 +7,19 @@ import Lasso from "./setupLasso";
 *******************************************
 ******************************************/
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export default (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectionToolType: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleStartAction: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleDragAction: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleEndAction: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleCancelAction: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   viewport: any
 ) => {
   const svg = d3.select("#graph-wrapper").select("#lasso-layer");
@@ -39,6 +46,7 @@ export default (
   }
 
   if (selectionToolType === "lasso") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const lasso = (Lasso() as any)
       .on("end", handleEndAction)
       // FYI, Lasso doesn't generate drag

--- a/client/src/components/infoDrawer/infoDrawer.tsx
+++ b/client/src/components/infoDrawer/infoDrawer.tsx
@@ -8,14 +8,20 @@ import { selectableCategoryNames } from "../../util/stateManager/controlsHelpers
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema: (state as any).annoMatrix.schema,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     datasetTitle: (state as any).config?.displayNames?.dataset ?? "",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     aboutURL: (state as any).config?.links?.["about-dataset"],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     isOpen: (state as any).controls.datasetDrawer,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     dataPortalProps: (state as any).config?.corpora_props,
   };
 })
 class InfoDrawer extends PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleClose = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -23,6 +29,7 @@ class InfoDrawer extends PureComponent {
     dispatch({ type: "toggle dataset drawer" });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'position' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -43,6 +50,7 @@ class InfoDrawer extends PureComponent {
     const allCategoryNames = selectableCategoryNames(schema).sort();
     const singleValueCategories = new Map();
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     allCategoryNames.forEach((catName: any) => {
       const isUserAnno = schema?.annotations?.obsByName[catName]?.writable;
       const colSchema = schema.annotations.obsByName[catName];

--- a/client/src/components/infoDrawer/infoFormat.tsx
+++ b/client/src/components/infoDrawer/infoFormat.tsx
@@ -1,6 +1,7 @@
 import { H3, H1, UL, HTMLTable, Classes } from "@blueprintjs/core";
 import React from "react";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderContributors = (contributors: any, affiliations: any) => {
   // eslint-disable-next-line no-constant-condition --  Temp removed contributor section to avoid publishing PII
   if (!contributors || contributors.length === 0 || true) return null;
@@ -8,6 +9,7 @@ const renderContributors = (contributors: any, affiliations: any) => {
     <>
       <H3>Contributors</H3>
       <p>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
         {contributors.map((contributor: any) => {
           const { email, name, institution } = contributor;
 
@@ -27,6 +29,7 @@ const renderContributors = (contributors: any, affiliations: any) => {
 
 // generates a list of unique institutions by order of appearance in contributors
 const buildAffiliations = (contributors = []) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const affiliations: any = [];
   contributors.forEach((contributor) => {
     const { institution } = contributor;
@@ -37,12 +40,14 @@ const buildAffiliations = (contributors = []) => {
   return affiliations;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderAffiliations = (affiliations: any) => {
   if (affiliations.length === 0) return null;
   return (
     <>
       <H3>Affiliations</H3>
       <UL>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
         {affiliations.map((item: any, index: any) => (
           <div key={item}>
             <sup>{index + 1}</sup>
@@ -55,6 +60,7 @@ const renderAffiliations = (affiliations: any) => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderDOILink = (type: any, doi: any) => {
   if (!doi) return null;
   return (
@@ -72,7 +78,9 @@ const renderDOILink = (type: any, doi: any) => {
 const ONTOLOGY_KEY = "ontology_term_id";
 // Render list of metadata attributes found in categorical field
 const renderDatasetMetadata = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   singleValueCategories: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   corporaMetadata: any
 ) => {
   if (singleValueCategories.size === 0) return null;
@@ -110,15 +118,18 @@ const renderDatasetMetadata = (
 
             // If this category is a ontology term, let's add its value to the previous node
             if (String(category).includes(ONTOLOGY_KEY)) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
               const prevElem = (elems as any).pop();
               const newChildren = [...prevElem.props.children];
               newChildren.splice(2, 1, [<td key="ontology">{value}</td>]);
               // Props aren't extensible so we must clone and alter the component to append the new child
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
               (elems as any).push(
                 React.cloneElement(prevElem, prevElem.props, newChildren)
               );
             } else {
               // Create the list item
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
               (elems as any).push(
                 <tr key={category}>
                   <td>{`${category}:`}</td>
@@ -137,6 +148,7 @@ const renderDatasetMetadata = (
 
 // Renders any links found in the config where link_type is not "SUMMARY"
 // If there are no links in the config, render the aboutURL
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderLinks = (projectLinks: any, aboutURL: any) => {
   if (!projectLinks && !aboutURL) return null;
   if (projectLinks)
@@ -144,6 +156,7 @@ const renderLinks = (projectLinks: any, aboutURL: any) => {
       <>
         <H3>Project Links</H3>
         <UL>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS. */}
           {projectLinks.map((link: any) => {
             if (link.link_type === "SUMMARY") return null;
             return (

--- a/client/src/components/labelInput.tsx
+++ b/client/src/components/labelInput.tsx
@@ -3,8 +3,10 @@ import { InputGroup, MenuItem, Keys } from "@blueprintjs/core";
 import { Suggest } from "@blueprintjs/select";
 import fuzzysort from "fuzzysort";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 export default class LabelInput extends React.PureComponent<{}, State> {
   /*
   Input widget for text labels, which acts like an InputGroup, but will also 
@@ -28,6 +30,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
   /* maxinum number of suggestions */
   static QueryResultLimit = 100;
 
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
 
@@ -41,6 +44,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleQueryChange = (query: any, event: any) => {
     // https://github.com/palantir/blueprint/issues/2983
     if (!event) return;
@@ -56,6 +60,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     if (onChange) onChange(query, event);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleItemSelect = (item: any, event: any) => {
     /* only report the select if not already reported via onChange() */
     const { target } = item;
@@ -65,6 +70,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     if (target !== query && onSelect) onSelect(target, event);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleKeyDown = (e: any) => {
     /* 
     prevent these events from propagating to containing form/dialog
@@ -80,14 +86,18 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleChange = (e: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'onChange' does not exist on type 'Readon... Remove this comment to see the full error message
     const { onChange } = this.props;
     if (onChange) onChange(e.target.value);
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderLabelSuggestion = (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     queryResult: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     { handleClick, modifiers }: any
   ) => {
     if (queryResult.newLabel) {
@@ -116,6 +126,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     );
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   filterLabels(query: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'labelSuggestions' does not exist on type... Remove this comment to see the full error message
     const { labelSuggestions } = this.props;
@@ -123,12 +134,15 @@ export default class LabelInput extends React.PureComponent<{}, State> {
 
     /* empty query is wildcard */
     if (query === "") {
-      return labelSuggestions
-        .slice(0, LabelInput.QueryResultLimit)
-        .map((l: any) => ({
-          target: l,
-          score: -10000,
-        }));
+      return (
+        labelSuggestions
+          .slice(0, LabelInput.QueryResultLimit)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+          .map((l: any) => ({
+            target: l,
+            score: -10000,
+          }))
+      );
     }
 
     /* else, do a fuzzy query */
@@ -145,6 +159,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
     return queryResults;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { props } = this;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'labelSuggestions' does not exist on type... Remove this comment to see the full error message
@@ -155,6 +170,7 @@ export default class LabelInput extends React.PureComponent<{}, State> {
       return (
         <InputGroup
           autoFocus={autoFocus}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           {...(props as any).inputProps} // eslint-disable-line react/jsx-props-no-spreading --- Allows for modularity
           value={label}
           onChange={this.handleChange}
@@ -164,9 +180,11 @@ export default class LabelInput extends React.PureComponent<{}, State> {
 
     const popoverProps = {
       minimal: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       ...(props as any).popoverProps,
     };
     const inputProps = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       ...(props as any).inputProps,
       autoFocus: false,
     };

--- a/client/src/components/leftSidebar/index.tsx
+++ b/client/src/components/leftSidebar/index.tsx
@@ -8,10 +8,13 @@ import Continuous from "../continuous/continuous";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   scatterplotXXaccessor: (state as any).controls.scatterplotXXaccessor,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   scatterplotYYaccessor: (state as any).controls.scatterplotYYaccessor,
 }))
 class LeftSideBar extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'scatterplotXXaccessor' does not exist on... Remove this comment to see the full error message
     const { scatterplotXXaccessor, scatterplotYYaccessor } = this.props;

--- a/client/src/components/leftSidebar/topLeftLogoAndTitle.tsx
+++ b/client/src/components/leftSidebar/topLeftLogoAndTitle.tsx
@@ -12,26 +12,34 @@ const DATASET_TITLE_FONT_SIZE = 14;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const { corpora_props: corporaProps } = (state as any).config;
   const correctVersion =
     ["1.0.0", "1.1.0"].indexOf(corporaProps?.version?.corpora_schema_version) >
     -1;
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     datasetTitle: (state as any).config?.displayNames?.dataset ?? "",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     libraryVersions: (state as any).config?.library_versions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     aboutLink: (state as any).config?.links?.["about-dataset"],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     tosURL: (state as any).config?.parameters?.about_legal_tos,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     privacyURL: (state as any).config?.parameters?.about_legal_privacy,
     title: correctVersion ? corporaProps?.title : undefined,
   };
 })
 class LeftSideBar extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleClick = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     dispatch({ type: "toggle dataset drawer" });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'datasetTitle' does not exist on type 'Re... Remove this comment to see the full error message

--- a/client/src/components/menubar/authButtons.tsx
+++ b/client/src/components/menubar/authButtons.tsx
@@ -37,6 +37,7 @@ const Auth = React.memo((props) => {
 
   const isAuthenticated = userInfo && userInfo.is_authenticated;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   (window as any).userInfo = userInfo;
 
   const randomInt = Math.random() * 15;
@@ -131,6 +132,7 @@ const Auth = React.memo((props) => {
   }
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function PromptContent({ setIsPromptOpen }: any) {
   const [isChecked, setIsChecked] = useState(false);
 

--- a/client/src/components/menubar/cellSetButtons.tsx
+++ b/client/src/components/menubar/cellSetButtons.tsx
@@ -6,15 +6,18 @@ import actions from "../../actions";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   differential: (state as any).differential,
 }))
 class CellSetButton extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   set() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, eitherCellSetOneOrTwo } = this.props;
     dispatch(actions.setCellSetFromSelection(eitherCellSetOneOrTwo));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'differential' does not exist on type 'Re... Remove this comment to see the full error message
     const { differential, eitherCellSetOneOrTwo } = this.props;

--- a/client/src/components/menubar/clip.tsx
+++ b/client/src/components/menubar/clip.tsx
@@ -45,7 +45,8 @@ const Clip = React.memo((props) => {
     pendingClipPercentiles?.clipPercentileMax ?? clipPercentileMax;
   const intent =
     clipPercentileMin > 0 || clipPercentileMax < 100
-      ? (Intent as any).INTENT_WARNING
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+        (Intent as any).INTENT_WARNING
       : Intent.NONE;
 
   return (

--- a/client/src/components/menubar/diffexpButtons.tsx
+++ b/client/src/components/menubar/diffexpButtons.tsx
@@ -9,12 +9,16 @@ import CellSetButton from "./cellSetButtons";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   differential: (state as any).differential,
   diffexpMayBeSlow:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (state as any).config?.parameters?.["diffexp-may-be-slow"] ?? false,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   diffexpCellcountMax: (state as any).config?.limits?.diffexp_cellcount_max,
 }))
 class DiffexpButtons extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   computeDiffExp = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, differential } = this.props;
@@ -28,6 +32,7 @@ class DiffexpButtons extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     /* diffexp-related buttons may be disabled */
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'differential' does not exist on type 'Re... Remove this comment to see the full error message

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -14,12 +14,14 @@ import UndoRedoReset from "./undoRedo";
 import DiffexpButtons from "./diffexpButtons";
 import { getEmbSubsetView } from "../../util/stateManager/viewStackHelpers";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => {
   // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Defa... Remove this comment to see the full error message
   const { annoMatrix } = state;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const crossfilter = (state as any).obsCrossfilter;
   const selectedCount = crossfilter.countSelected();
 
@@ -33,32 +35,49 @@ type State = any;
   return {
     subsetPossible,
     subsetResetPossible,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     graphInteractionMode: (state as any).controls.graphInteractionMode,
     clipPercentileMin: Math.round(100 * (annoMatrix?.clipRange?.[0] ?? 0)),
     clipPercentileMax: Math.round(100 * (annoMatrix?.clipRange?.[1] ?? 1)),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     userDefinedGenes: (state as any).controls.userDefinedGenes,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     colorAccessor: (state as any).colors.colorAccessor,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     scatterplotXXaccessor: (state as any).controls.scatterplotXXaccessor,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     scatterplotYYaccessor: (state as any).controls.scatterplotYYaccessor,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     libraryVersions: (state as any).config?.library_versions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     auth: (state as any).config?.authentication,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     userInfo: (state as any).userInfo,
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     undoDisabled: state["@@undoable/past"].length === 0,
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     redoDisabled: state["@@undoable/future"].length === 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     aboutLink: (state as any).config?.links?.["about-dataset"],
     disableDiffexp:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).config?.parameters?.["disable-diffexp"] ?? false,
     diffexpMayBeSlow:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (state as any).config?.parameters?.["diffexp-may-be-slow"] ?? false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     showCentroidLabels: (state as any).centroidLabels.showLabels,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     tosURL: (state as any).config?.parameters?.about_legal_tos,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     privacyURL: (state as any).config?.parameters?.about_legal_privacy,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     categoricalSelection: (state as any).categoricalSelection,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class MenuBar extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static isValidDigitKeyEvent(e: any) {
     /*
     Return true if this event is necessary to enter a percent number input.
@@ -83,6 +102,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     return key >= 0 && key <= 9;
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -90,6 +110,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   isClipDisabled = () => {
     /*
     return true if clip button should be disabled.
@@ -114,6 +135,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     return isDisabled;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleClipOnKeyPress = (e: any) => {
     /*
     allow only numbers, plus other critical keys which
@@ -124,6 +146,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleClipPercentileMinValueChange = (v: any) => {
     /*
     Ignore anything that isn't a legit number
@@ -144,6 +167,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   handleClipPercentileMaxValueChange = (v: any) => {
     /*
     Ignore anything that isn't a legit number
@@ -165,6 +189,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleClipCommit = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
@@ -175,6 +200,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     dispatch(actions.clipAction(min, max));
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleClipOpening = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'clipPercentileMin' does not exist on typ... Remove this comment to see the full error message
     const { clipPercentileMin, clipPercentileMax } = this.props;
@@ -183,10 +209,12 @@ class MenuBar extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleClipClosing = () => {
     this.setState({ pendingClipPercentiles: null });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleCentroidChange = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, showCentroidLabels } = this.props;
@@ -197,18 +225,21 @@ class MenuBar extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSubset = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     dispatch(actions.subsetAction());
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleSubsetReset = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch } = this.props;
     dispatch(actions.resetSubsetAction());
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message

--- a/client/src/components/miniHistogram/index.tsx
+++ b/client/src/components/miniHistogram/index.tsx
@@ -7,13 +7,16 @@ import {
 } from "@blueprintjs/core";
 
 export default class MiniHistogram extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   canvasRef: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(props: any) {
     super(props);
     this.canvasRef = React.createRef();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   drawHistogram = () => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'xScale' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { xScale, yScale, bins, width, height } = this.props;
@@ -38,10 +41,12 @@ export default class MiniHistogram extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount = () => {
     this.drawHistogram();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   componentDidUpdate = (prevProps: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'obsOrVarContinuousFieldDisplayName' does... Remove this comment to see the full error message
     const { obsOrVarContinuousFieldDisplayName, bins } = this.props;
@@ -53,6 +58,7 @@ export default class MiniHistogram extends React.PureComponent {
       this.drawHistogram();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'domainLabel' does not exist on type 'Rea... Remove this comment to see the full error message

--- a/client/src/components/miniStackedBar/index.tsx
+++ b/client/src/components/miniStackedBar/index.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 
 export default class MiniStackedBar extends React.PureComponent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   canvasRef: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(props: any) {
     super(props);
     this.canvasRef = React.createRef();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   drawStacks = () => {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'domainValues' does not exist on type 'Re... Remove this comment to see the full error message
@@ -51,16 +54,19 @@ export default class MiniStackedBar extends React.PureComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   componentDidUpdate = (prevProps: any) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'occupancy' does not exist on type 'Reado... Remove this comment to see the full error message
     const { occupancy } = this.props;
     if (occupancy !== prevProps.occupancy) this.drawStacks();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount = () => {
     this.drawStacks();
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'width' does not exist on type 'Readonly<... Remove this comment to see the full error message
     const { width, height } = this.props;

--- a/client/src/components/rightSidebar/index.tsx
+++ b/client/src/components/rightSidebar/index.tsx
@@ -5,10 +5,13 @@ import * as globals from "../../globals";
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   scatterplotXXaccessor: (state as any).controls.scatterplotXXaccessor,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   scatterplotYYaccessor: (state as any).controls.scatterplotYYaccessor,
 }))
 class RightSidebar extends React.Component {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     return (
       <div

--- a/client/src/components/scatterplot/drawPointsRegl.ts
+++ b/client/src/components/scatterplot/drawPointsRegl.ts
@@ -1,5 +1,6 @@
 import { glPointFlags, glPointSize } from "../../util/glHelpers";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function drawPointsRegl(regl: any) {
   return regl({
     vert: `

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -23,6 +23,7 @@ import {
   flagHighlight,
 } from "../../util/glHelpers";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function createProjectionTF(viewportWidth: any, viewportHeight: any) {
   /*
   the projection transform accounts for the screen size & other layout
@@ -31,6 +32,7 @@ function createProjectionTF(viewportWidth: any, viewportHeight: any) {
   return mat3.projection(m, viewportWidth, viewportHeight);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function getScale(col: any, rangeMin: any, rangeMax: any) {
   if (!col) return null;
   const { min, max } = col.summarize();
@@ -39,6 +41,7 @@ function getScale(col: any, rangeMin: any, rangeMax: any) {
 const getXScale = memoize(getScale);
 const getYScale = memoize(getScale);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
@@ -48,20 +51,27 @@ type State = any;
   const {
     scatterplotXXaccessor,
     scatterplotYYaccessor,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   } = (state as any).controls;
 
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     annoMatrix: (state as any).annoMatrix,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     colors: (state as any).colors,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     pointDilation: (state as any).pointDilation,
     // Accessors are var/gene names (strings)
     scatterplotXXaccessor,
     scatterplotYYaccessor,
     crossfilter,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     genesets: (state as any).genesets.genesets,
   };
 })
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class Scatterplot extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static createReglState(canvas: any) {
     /*
     Must be created for each canvas
@@ -92,14 +102,18 @@ class Scatterplot extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   axes: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   reglCanvas: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   renderCache: any;
 
   computePointPositions = memoize((X, Y, xScale, yScale) => {
@@ -198,6 +212,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     }
   );
 
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     const viewport = this.getViewportDimensions();
@@ -213,15 +228,18 @@ class Scatterplot extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     // this affect point render size for the scatterplot
     window.addEventListener("resize", this.handleResize);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   setReglCanvas = (canvas: any) => {
     this.reglCanvas = canvas;
     if (canvas) {
@@ -232,6 +250,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   getViewportDimensions = () => {
     return {
       height: window.innerHeight,
@@ -239,6 +258,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleResize = () => {
     const { state } = this.state;
     const viewport = this.getViewportDimensions();
@@ -248,6 +268,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fetchAsyncProps = async (props: any) => {
     const {
       scatterplotXXaccessor,
@@ -310,6 +331,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     };
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   createXQuery(geneName: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix } = this.props;
@@ -328,6 +350,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     ];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   createColorByQuery(colors: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, genesets } = this.props;
@@ -336,6 +359,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     return createColorQuery(colorMode, colorAccessor, schema, genesets);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   updateColorTable(colors: any, colorDf: any) {
     /* update color table state */
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
@@ -351,10 +375,15 @@ class Scatterplot extends React.PureComponent<{}, State> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   async fetchData(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     scatterplotXXaccessor: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     scatterplotYYaccessor: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colors: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointDilation: any
   ) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
@@ -408,6 +437,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     );
   });
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   updateReglAndRender(newRenderCache: any) {
     const { positions, colors, flags } = newRenderCache;
     this.renderCache = newRenderCache;
@@ -418,12 +448,19 @@ class Scatterplot extends React.PureComponent<{}, State> {
     this.renderCanvas();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderPoints(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     regl: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     drawPoints: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     flagBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointBuffer: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     projectionTF: any
   ) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
@@ -452,6 +489,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     regl._gl.flush();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
@@ -564,7 +602,9 @@ class Scatterplot extends React.PureComponent<{}, State> {
                     minimized={minimized}
                     scatterplotYYaccessor={scatterplotYYaccessor}
                     scatterplotXXaccessor={scatterplotXXaccessor}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     xScale={(asyncProps as any).xScale}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
                     yScale={(asyncProps as any).yScale}
                   />
                 );

--- a/client/src/components/termsPrompt/index.tsx
+++ b/client/src/components/termsPrompt/index.tsx
@@ -10,16 +10,22 @@ import {
 } from "@blueprintjs/core";
 import { storageGet, storageSet, KEYS } from "../util/localStorage";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   tosURL: (state as any).config?.parameters?.about_legal_tos,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   privacyURL: (state as any).config?.parameters?.about_legal_privacy,
 }))
+// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
 class TermsPrompt extends React.PureComponent<{}, State> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   drawerClose: any;
 
+  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
   constructor(props: {}) {
     super(props);
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'tosURL' does not exist on type 'Readonly... Remove this comment to see the full error message
@@ -33,6 +39,7 @@ class TermsPrompt extends React.PureComponent<{}, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     const { hasDecided, isEnabled } = this.state;
     if (isEnabled && !hasDecided) {
@@ -40,6 +47,7 @@ class TermsPrompt extends React.PureComponent<{}, State> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleOK = () => {
     this.setState({ isOpen: false });
     storageSet(KEYS.COOKIE_DECISION, "yes");
@@ -54,11 +62,13 @@ class TermsPrompt extends React.PureComponent<{}, State> {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   handleNo = () => {
     this.setState({ isOpen: false });
     storageSet(KEYS.COOKIE_DECISION, "no");
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderTos() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'tosURL' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { tosURL } = this.props;
@@ -83,6 +93,7 @@ class TermsPrompt extends React.PureComponent<{}, State> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   renderPrivacy() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'privacyURL' does not exist on type 'Read... Remove this comment to see the full error message
     const { privacyURL } = this.props;
@@ -106,6 +117,7 @@ class TermsPrompt extends React.PureComponent<{}, State> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
     const { isOpen, isEnabled } = this.state;
     if (!isEnabled || !isOpen) return null;

--- a/client/src/components/util/localStorage.ts
+++ b/client/src/components/util/localStorage.ts
@@ -3,6 +3,7 @@ export const KEYS = {
   LOGIN_PROMPT: "cxg.LOGIN_PROMPT",
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function storageGet(key: any, defaultValue = null) {
   try {
     const val = window.localStorage.getItem(key);
@@ -13,6 +14,7 @@ export function storageGet(key: any, defaultValue = null) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function storageSet(key: any, value: any) {
   try {
     window.localStorage.setItem(key, value);

--- a/client/src/components/util/truncate.tsx
+++ b/client/src/components/util/truncate.tsx
@@ -32,6 +32,7 @@ const SECOND_HALF_INNER_STYLE = {
   right: 0,
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default (props: any) => {
   const { children, tooltipAddendum = "" } = props;
   // Truncate only support a single child with a text child

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -91,7 +91,9 @@ const CXG_SERVER_PORT =
 
 let _API;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 if ((window as any).CELLXGENE && (window as any).CELLXGENE.API) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   _API = (window as any).CELLXGENE.API;
 } else {
   if (CXG_SERVER_PORT === undefined) {

--- a/client/src/reducers/annoMatrix.ts
+++ b/client/src/reducers/annoMatrix.ts
@@ -2,6 +2,7 @@
 Reducer for the annoMatrix
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const AnnoMatrix = (state = null, action: any) => {
   if (action.annoMatrix) {
     return action.annoMatrix;

--- a/client/src/reducers/annotations.ts
+++ b/client/src/reducers/annotations.ts
@@ -1,6 +1,7 @@
 /*
 Reducers for annotation UI-state.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Annotations = (
   state = {
     /*
@@ -28,6 +29,7 @@ const Annotations = (
     labelEditable: { category: null, label: null },
     promptForFilename: true,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/autosave.ts
+++ b/client/src/reducers/autosave.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Autosave = (
   state = {
     // cell labels
@@ -11,7 +12,9 @@ const Autosave = (
     // error state
     error: false,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   nextSharedState: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/cascade.ts
+++ b/client/src/reducers/cascade.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function cascadeReducers(arg: any) {
   /*
   Combine a set of cascading reducers into a single reducer.  Cascading
@@ -23,6 +24,7 @@ export default function cascadeReducers(arg: any) {
   */
   const reducers = arg instanceof Map ? arg : new Map(arg);
   const reducerKeys = [...reducers.keys()];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return (prevState: any, action: any) => {
     const nextState = {};
     let stateChange = false;

--- a/client/src/reducers/categoricalSelection.ts
+++ b/client/src/reducers/categoricalSelection.ts
@@ -11,9 +11,13 @@ Label state default (if missing) is up to the component, but typically true.
   ...
 }
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const CategoricalSelection = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   state: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   nextSharedState: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/centroidLabels.ts
+++ b/client/src/reducers/centroidLabels.ts
@@ -2,9 +2,12 @@ const initialState = {
   showLabels: false,
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const centroidLabels = (
   state = initialState,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   sharedNextState: any
 ) => {
   const {

--- a/client/src/reducers/colors.ts
+++ b/client/src/reducers/colors.ts
@@ -2,11 +2,13 @@
 Color By UI state
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const ColorsReducer = (
   state = {
     colorMode: null /* by continuous, by expression */,
     colorAccessor: null /* tissue, Apod */,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/config.ts
+++ b/client/src/reducers/config.ts
@@ -1,9 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Config = (
   state = {
     displayNames: null,
     features: null,
     parameters: null,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/continuousSelection.ts
+++ b/client/src/reducers/continuousSelection.ts
@@ -1,5 +1,6 @@
 import { makeContinuousDimensionName } from "../util/nameCreators";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const ContinuousSelection = (state = {}, action: any) => {
   switch (action.type) {
     case "reset subset":

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -1,6 +1,7 @@
 import uniq from "lodash.uniq";
 import filter from "lodash.filter";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Controls = (
   state = {
     // data loading flag
@@ -20,6 +21,7 @@ const Controls = (
 
     datasetDrawer: false,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   /*

--- a/client/src/reducers/differential.ts
+++ b/client/src/reducers/differential.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const Differential = (
   state = {
     loading: null,
@@ -5,6 +6,7 @@ const Differential = (
     celllist1: null,
     celllist2: null,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/genesets.ts
+++ b/client/src/reducers/genesets.ts
@@ -24,12 +24,14 @@
  */
 import { diffexpPopNamePrefix1, diffexpPopNamePrefix2 } from "../globals";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const GeneSets = (
   state = {
     initialized: false,
     lastTid: undefined,
     genesets: new Map(),
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {
@@ -375,6 +377,7 @@ const GeneSets = (
       const diffExpGeneSets = [];
       for (const polarity of Object.keys(genesetNames)) {
         const genes = new Map(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
           data[polarity].map((diffExpGene: any) => [
             diffExpGene[0],
             {

--- a/client/src/reducers/genesetsUI.ts
+++ b/client/src/reducers/genesetsUI.ts
@@ -1,12 +1,14 @@
 /*
 Reducers for geneset UI-state.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const GeneSetsUI = (
   state = {
     createGenesetModeActive: false,
     isEditingGenesetName: false,
     isAddingGenesToGeneset: false,
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/graphSelection.ts
+++ b/client/src/reducers/graphSelection.ts
@@ -1,8 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const GraphSelection = (
   state = {
     tool: "lasso", // what selection tool mode (lasso, brush, ...)
     selection: { mode: "all" }, // current selection, which is tool specific
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/layoutChoice.ts
+++ b/client/src/reducers/layoutChoice.ts
@@ -7,6 +7,7 @@ about commonly used names.  Preferentially, pick in the following order:
   3. "pca"
   4. give up, use the first available
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function bestDefaultLayout(layouts: any) {
   const preferredNames = ["umap", "tsne", "pca"];
   const idx = preferredNames.findIndex((name) => layouts.indexOf(name) !== -1);
@@ -14,20 +15,25 @@ function bestDefaultLayout(layouts: any) {
   return layouts[0];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function setToDefaultLayout(schema: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const available = schema.layout.obs.map((v: any) => v.name).sort();
   const current = bestDefaultLayout(available);
   const currentDimNames = schema.layout.obsByName[current].dims;
   return { available, current, currentDimNames };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const LayoutChoice = (
   state = {
     available: [], // all available choices
     current: undefined, // name of the current layout, eg, 'umap'
     currentDimNames: [], // dimension name
   },
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   action: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   nextSharedState: any
 ) => {
   switch (action.type) {

--- a/client/src/reducers/obsCrossfilter.ts
+++ b/client/src/reducers/obsCrossfilter.ts
@@ -2,6 +2,7 @@
 Reducer for the obsCrossfilter
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const ObsCrossfilter = (state = null, action: any) => {
   if (action.obsCrossfilter) {
     return action.obsCrossfilter;

--- a/client/src/reducers/pointDilation.ts
+++ b/client/src/reducers/pointDilation.ts
@@ -3,6 +3,7 @@ const initialState = {
   categoryField: "",
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const pointDialation = (state = initialState, action: any) => {
   const { metadataField, label: categoryField } = action;
 

--- a/client/src/reducers/undoable.ts
+++ b/client/src/reducers/undoable.ts
@@ -61,6 +61,7 @@ const filterActionKey = `${historyKeyPrefix}filterAction`;
 const pendingKey = `${historyKeyPrefix}pending`;
 const defaultHistoryLimit = -100;
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   // @ts-expect-error ts-migrate(2339) FIXME: Property 'debug' does not exist on type '{}'.
   const { debug } = options;
@@ -69,6 +70,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   if (!historyLimit) historyLimit = defaultHistoryLimit;
   if (historyLimit > 0) historyLimit = -historyLimit;
   const actionFilter =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (options as any).actionFilter || (() => ({ [filterActionKey]: "save" }));
 
   if (!Array.isArray(undoableKeys) || undoableKeys.length === 0)
@@ -78,6 +80,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Undo the current to previous history
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function undo(currentState: any) {
     const past = currentState[pastKey];
     const future = currentState[futureKey];
@@ -101,6 +104,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Replay future, previously undone.
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function redo(currentState: any) {
     const past = currentState[pastKey] || [];
     const future = currentState[futureKey] || [];
@@ -124,6 +128,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Clear the history state.  No side-effects on current state.
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function clear(currentState: any) {
     return {
       ...currentState,
@@ -137,6 +142,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Reduce current action, with no history side-effects
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function skip(currentState: any, action: any, filterState: any) {
     const past = currentState[pastKey] || [];
     const future = currentState[futureKey] || [];
@@ -154,6 +160,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Save current state in the history, then reduce action.
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function save(currentState: any, action: any, filterState: any) {
     const past = currentState[pastKey] || [];
     const currentUndoableState = Object.entries(currentState).filter((kv) =>
@@ -174,6 +181,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Save current state as pending history change.  No other side effects.
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function stashPending(currentState: any) {
     const currentUndoableState = Object.entries(currentState).filter((kv) =>
       undoableKeysSet.has(kv[0])
@@ -187,6 +195,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Cancel pending history state change.  No other side effects.
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function cancelPending(currentState: any) {
     return {
       ...currentState,
@@ -197,6 +206,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   /*
   Push pending state onto the history stack
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   function applyPending(currentState: any) {
     const past = currentState[pastKey] || [];
     const pendingState = currentState[pendingKey];
@@ -217,6 +227,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
       [filterStateKey]: {},
       [pendingKey]: null,
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     action: any
   ) => {
     if (debug > 1) console.log("---- ACTION", action.type);
@@ -277,6 +288,7 @@ const Undoable = (reducer: any, undoableKeys: any, options = {}) => {
   };
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function push(arr: any, val: any, limit = undefined) {
   /*
   functional array push, with a max length limit to the new array.

--- a/client/src/reducers/undoableConfig.ts
+++ b/client/src/reducers/undoableConfig.ts
@@ -125,6 +125,7 @@ See graph definition for the transitions that use each.
 
 Signature:  (fsm, transition, reducerState, reducerAction) => undoableAction
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const stashPending = (fsm: any) => ({
   [actionKey]: "stashPending",
   [stateKey]: { fsm },
@@ -155,6 +156,7 @@ StateMachine when it doesn't know what to do.
 
 Signature:  (fsm, event, from) => undoableAction
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const onFsmError = (fsm: any, event: any, from: any) => {
   console.error(`FSM error [event: "${event}", state: "${from}"]`, fsm);
   // In production, try to recover gracefully if we have unexpected state
@@ -183,9 +185,13 @@ Basic approach:
   * only implement complex state machines where absolutely required (eg,
     multi-event selection and the like)
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const actionFilter = (debug: any) => (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   state: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   action: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   prevFilterState: any
 ) => {
   const actionType = action.type;
@@ -233,6 +239,7 @@ return true if objA and objB are ===, OR if:
   - have same own properties
   - all values are strict equal (===)
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function shallowObjectEq(objA: any, objB: any) {
   if (objA === objB) return true;
   if (!objA || !objB) return false;
@@ -245,6 +252,7 @@ function shallowObjectEq(objA: any, objB: any) {
 return true if arrA and arrB contain the same strict-equal values,
 in the same order.
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function shallowArrayEq(arrA: any, arrB: any) {
   if (arrA.length !== arrB.length) return false;
   for (let i = 0, l = arrA.length; i < l; i += 1) {

--- a/client/src/reducers/undoableFsm.ts
+++ b/client/src/reducers/undoableFsm.ts
@@ -18,13 +18,20 @@ b) compound actions that should be collapsed into a single history change.
 
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const createFsmTransitions = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   stashPending: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   cancelPending: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   applyPending: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   skip: any,
   // @ts-expect-error ts-migrate(6133) FIXME: 'clear' is declared but its value is never read.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   clear: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   save: any
 ) => {
   return [
@@ -47,6 +54,7 @@ const createFsmTransitions = (
       to: "done",
       /* if current selection is all, cancelPending.  Else, applyPending */
       // @ts-expect-error ts-migrate(6133) FIXME: 'fsm' is declared but its value is never read.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       action: (fsm: any, transition: any, data: any) =>
         data.state.graphSelection.selection.mode === "all"
           ? cancelPending()
@@ -78,6 +86,7 @@ const createFsmTransitions = (
       to: "done",
       /* if current selection is all, cancelPending.  Else, applyPending */
       // @ts-expect-error ts-migrate(6133) FIXME: 'fsm' is declared but its value is never read.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       action: (fsm: any, transition: any, data: any) =>
         data.state.graphSelection.selection.mode === "all"
           ? cancelPending()

--- a/client/src/reducers/userInfo.ts
+++ b/client/src/reducers/userInfo.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const UserInfo = (state = {}, action: any) => {
   switch (action.type) {
     case "initial data load start":

--- a/client/src/util/actionHelpers.ts
+++ b/client/src/util/actionHelpers.ts
@@ -6,7 +6,9 @@ import { postNetworkErrorToast } from "../components/framework/toasters";
 dispatch an action error to the user.   Currently we use
 async toasts.
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 let networkErrorToastKey: any = null;
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const dispatchNetworkErrorMessageToUser = (message: any) => {
   if (!networkErrorToastKey) {
     networkErrorToastKey = postNetworkErrorToast(message);
@@ -18,8 +20,11 @@ export const dispatchNetworkErrorMessageToUser = (message: any) => {
 /*
 Catch unexpected errors and make sure we don't lose them!
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function catchErrorsWrap(fn: any, dispatchToUser = false) {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   return (dispatch: any, getState: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     fn(dispatch, getState).catch((error: any) => {
       console.error(error);
       if (dispatchToUser) {
@@ -34,6 +39,7 @@ export function catchErrorsWrap(fn: any, dispatchToUser = false) {
  * Wrapper to perform async fetch with some modest error handling
  * and decoding.  Arguments are identical to standard fetch.
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const doFetch = async (url: any, init = {}) => {
   try {
     // add defaults to the fetch init param.
@@ -42,6 +48,7 @@ export const doFetch = async (url: any, init = {}) => {
       credentials: "include",
       ...init,
     };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const acceptType = (init as any).headers?.get("Accept");
     const res = await fetch(url, init);
     if (
@@ -67,6 +74,7 @@ export const doFetch = async (url: any, init = {}) => {
 /*
 Wrapper to perform an async fetch and JSON decode response.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const doJsonRequest = async (url: any, init = {}) => {
   const res = await doFetch(url, {
     ...init,
@@ -78,6 +86,7 @@ export const doJsonRequest = async (url: any, init = {}) => {
 /*
 Wrapper to perform an async fetch for binary data.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const doBinaryRequest = async (url: any, init = {}) => {
   const res = await doFetch(url, {
     ...init,
@@ -101,7 +110,9 @@ Parameters:
 
 So [1, 2, 3, 4, 10, 11, 14] -> [ [1, 4], [10, 11], 14]
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const rangeEncodeIndices = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   indices: any,
   minRangeLength = 3,
   sorted = false

--- a/client/src/util/camera.ts
+++ b/client/src/util/camera.ts
@@ -11,19 +11,25 @@ const panBound = 0.8;
 const scratch0 = new Float32Array(16);
 const scratch1 = new Float32Array(16);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function clamp(val: any, rng: any) {
   return Math.max(Math.min(val, rng[1]), rng[0]);
 }
 
 class Camera {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   canvas: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   prevEvent: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   viewMatrix: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   viewMatrixInv: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   constructor(canvas: any) {
     this.prevEvent = {
       clientX: 0,
@@ -47,6 +53,7 @@ class Camera {
     return this.viewMatrix[0];
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   pan(dx: any, dy: any) {
     const m = this.viewMatrix;
     const dyRange = [
@@ -67,6 +74,7 @@ class Camera {
     mat3.invert(this.viewMatrixInv, m);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   zoomAt(d: any, x = 0, y = 0) {
     /*
     Camera zoom at [x,y]
@@ -90,12 +98,14 @@ class Camera {
   Event handling
   */
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   flush(e: any) {
     this.prevEvent.type = e.type;
     this.prevEvent.clientX = e.clientX;
     this.prevEvent.clientY = e.clientY;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   localPosition(target: any, canvasX: any, canvasY: any, projectionInvTF: any) {
     /*
     Convert mouse position to local
@@ -116,6 +126,7 @@ class Camera {
     return pos;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   mousePan(e: any, projectionTF: any) {
     const projectionInvTF = mat3.invert(scratch0, projectionTF);
     const pos = this.localPosition(
@@ -136,6 +147,7 @@ class Camera {
     return true;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   wheelZoom(e: any, projectionTF: any) {
     const { height } = this.canvas;
     const { deltaY, deltaMode, clientX, clientY } = e;
@@ -152,6 +164,7 @@ class Camera {
     return true;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   handleEvent(e: any, projectionTF: any) {
     /*
     process the event, and return true if camera view changed
@@ -181,6 +194,7 @@ class Camera {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 function attachCamera(canvas: any) {
   return new Camera(canvas);
 }

--- a/client/src/util/catLabelSort.ts
+++ b/client/src/util/catLabelSort.ts
@@ -11,19 +11,25 @@ TL;DR: sort order is:
 import isNumber from "is-number";
 import * as globals from "../globals";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function caseInsensitiveCompare(a: any, b: any) {
   const textA = String(a).toUpperCase();
   const textB = String(b).toUpperCase();
   return textA < textB ? -1 : textA > textB ? 1 : 0;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 const catLabelSort = (isUserAnno: any, values: any) => {
   /* this sort could be memoized for perf */
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const strings: any = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const ints: any = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const unassignedOrNaN: any = [];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   values.forEach((v: any) => {
     if (isUserAnno && v === globals.unassignedCategoryLabel) {
       unassignedOrNaN.push(v);

--- a/client/src/util/centroid.ts
+++ b/client/src/util/centroid.ts
@@ -23,10 +23,15 @@ label -> {
 }
 */
 const getCoordinatesByLabel = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryDf: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutDf: any
 ) => {
   const coordsByCategoryLabel = new Map();
@@ -105,10 +110,15 @@ const getCoordinatesByLabel = (
 */
 
 const calcMedianCentroid = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryDf: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutDf: any
 ) => {
   // generate a map describing the coordinates for each label within the given category
@@ -145,10 +155,15 @@ const calcMedianCentroid = (
 // A simple function to hash the parameters
 const hashMedianCentroid = (
   // @ts-expect-error ts-migrate(6133) FIXME: 'schema' is declared but its value is never read.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryDf: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutDf: any
 ) => {
   const category = categoryDf.col(categoryName);

--- a/client/src/util/clamp.ts
+++ b/client/src/util/clamp.ts
@@ -8,6 +8,7 @@
  * @returns a number
  */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function clamp(val: any, rng: any) {
   return Math.max(Math.min(val, rng[1]), rng[0]);
 }

--- a/client/src/util/clip.ts
+++ b/client/src/util/clip.ts
@@ -10,6 +10,7 @@ If `setTo` is not undefined, values outside the [lower, upper] range will be set
 `setTo`.
 
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function clip(arr: any, lower: any, upper: any, setTo: any) {
   const lowerSet = setTo === undefined ? lower : setTo;
   const upperSet = setTo === undefined ? upper : setTo;

--- a/client/src/util/dataframe/cache.ts
+++ b/client/src/util/dataframe/cache.ts
@@ -11,15 +11,19 @@ objects.
 
 import { memoize } from "./util";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function hashDataframe(df: any) {
   if (df.isEmpty()) return "";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return df.__columnsAccessor.map((c: any) => c.__id).join(",");
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function noop(df: any) {
   return df;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 const dataframeMemo = (capacity = 100) =>
   memoize(noop, hashDataframe, capacity);
 

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -73,25 +73,34 @@ Dataframe
 **/
 
 class Dataframe {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   __columns: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   __columnsAccessor: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   __id: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colIndex: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dims: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   length: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   rowIndex: any;
   /**
   Constructors & factories
   **/
 
   constructor(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     dims: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     columnarData: any,
     rowIndex = null,
     colIndex = null,
@@ -137,10 +146,15 @@ class Dataframe {
     Object.freeze(this);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   static __errorChecks(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     dims: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     columnarData: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     rowIndex: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colIndex: any
   ) {
     const [nRows, nCols] = dims;
@@ -180,6 +194,7 @@ class Dataframe {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static __compileColumn(column: any, getRowByOffset: any, getRowByLabel: any) {
     /*
       Each column accessor is a function which will lookup data by
@@ -215,11 +230,13 @@ class Dataframe {
     const __id = __getMemoId();
 
     /* get value by row label */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const get = function get(rlabel: any) {
       return column[getRowByOffset(rlabel)];
     };
 
     /* get value by row offset */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const iget = function iget(roffset: any) {
       return column[roffset];
     };
@@ -230,11 +247,13 @@ class Dataframe {
     };
 
     /* test for row label inclusion in column */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const has = function has(rlabel: any) {
       const offset = getRowByOffset(rlabel);
       return offset >= 0 && offset < length;
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const ihas = function ihas(offset: any) {
       return offset >= 0 && offset < length;
     };
@@ -246,6 +265,7 @@ class Dataframe {
     NOTE: not found return is DIFFERENT than the default Array.indexOf as
     -1 is a plausible Dataframe row/col label.
     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const indexOf = function indexOf(value: any) {
       const offset = column.indexOf(value);
       if (offset === -1) {
@@ -270,10 +290,12 @@ class Dataframe {
     Create histogram bins for this column.  Memoized.
     */
     const _memoHistoCat = memoize(_histogramCategorical, hashCategorical);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const histogramCategorical = (by: any) => _memoHistoCat(get, by);
     let histogram = null;
     if (isTypedArray(column)) {
       const mFn = memoize(histogramContinuous, hashContinuous);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       histogram = (bins: any, domain: any, by: any) =>
         mFn(get, bins, domain, by);
     } else {
@@ -295,6 +317,7 @@ class Dataframe {
     return get;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   __compile(accessors: any) {
     /*
     Compile data accessors for each column.
@@ -303,6 +326,7 @@ class Dataframe {
     */
     const getRowByOffset = this.rowIndex.getOffset.bind(this.rowIndex);
     const getRowByLabel = this.rowIndex.getLabel.bind(this.rowIndex);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.__columnsAccessor = this.__columns.map((column: any, idx: any) => {
       if (accessors[idx]) {
         return accessors[idx];
@@ -312,6 +336,7 @@ class Dataframe {
     Object.freeze(this.__columnsAccessor);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   clone() {
     /*
     Clone this dataframe
@@ -326,6 +351,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withCol(label: any, colData: any, withRowIndex = null) {
     /*
     Create a new DF, which is `this` plus the new column. Example:
@@ -369,6 +395,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withColsFrom(dataframe: any, labels: any) {
     /*
     return a new dataframe containing all columns from both `this` and the
@@ -433,6 +460,7 @@ class Dataframe {
 
     // otherwise, bulid a new dataframe combining columns from both
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const srcOffsets = srcLabels.map((l: any) =>
       dataframe.colIndex.getOffset(l)
     );
@@ -447,11 +475,13 @@ class Dataframe {
     const { rowIndex } = this;
     const columns = [
       ...this.__columns,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       ...srcOffsets.map((i: any) => dataframe.__columns[i]),
     ];
     const colIndex = this.colIndex.withLabels(dstLabels);
     const columnsAccessor = [
       ...this.__columnsAccessor,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       ...srcOffsets.map((i: any) => dataframe.__columnsAccessor[i]),
     ];
 
@@ -465,12 +495,14 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   withColsFromAll(dataframes = []) {
     dataframes = Array.isArray(dataframes) ? dataframes : [dataframes];
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
     return dataframes.reduce((acc, df) => acc.withColsFrom(df), this);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dropCol(label: any) {
     /*
     Create a new dataframe, omitting one columns.
@@ -507,6 +539,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   renameCol(oldLabel: any, newLabel: any) {
     /*
     Accelerator for dropping a column and then adding it again with a new label
@@ -532,6 +565,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   replaceColData(label: any, newColData: any) {
     /*
     Accelerator for dropping a column then adding it again with same
@@ -553,6 +587,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   static empty(rowIndex = null, colIndex = null) {
     const dims = [
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -564,6 +599,7 @@ class Dataframe {
     return new Dataframe(dims, new Array(dims[1]), rowIndex, colIndex);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static create(dims: any, columnarData: any) {
     /*
     Create a dataframe from raw columnar data.  All column arrays
@@ -575,6 +611,7 @@ class Dataframe {
     return new Dataframe(dims, columnarData, null, null);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   __subset(newRowIndex: any, newColIndex: any) {
     const dims = [...this.dims];
 
@@ -595,6 +632,7 @@ class Dataframe {
     let { rowIndex } = this;
     if (newRowIndex) {
       const rowOffsets = this.rowIndex.getOffsets(newRowIndex.labels());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       __columns = __columns.map((col: any) => {
         const newCol = new col.constructor(rowOffsets.length);
         for (let i = 0, l = rowOffsets.length; i < l; i += 1) {
@@ -617,6 +655,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   subset(rowLabels: any, colLabels = null, withRowIndex = null) {
     /*
     Subset by row/col labels.
@@ -639,6 +678,7 @@ class Dataframe {
     return this.__subset(rowIndex, colIndex);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubset(rowOffsets: any, colOffsets = null, withRowIndex = null) {
     /*
     Subset by row/col offset.
@@ -663,6 +703,7 @@ class Dataframe {
     return this.__subset(rowIndex, colIndex);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubsetMask(rowMask: any, colMask = null, withRowIndex = null) {
     /*
     Subset on row/column based upon a truthy/falsey array (a mask).
@@ -682,6 +723,7 @@ class Dataframe {
     }
 
     /* convert masks to lists - method wastes space, but is fast */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const toList = (mask: any, maxSize: any) => {
       if (!mask) {
         return null;
@@ -706,11 +748,13 @@ class Dataframe {
   Data access with row/col.
   **/
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   columns() {
     /* return all column accessors as an array, in offset order */
     return [...this.__columnsAccessor];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   col(columnLabel: any) {
     /*
     Return accessor bound to a column.  Allows random row access
@@ -731,6 +775,7 @@ class Dataframe {
     return this.__columnsAccessor[coff];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   icol(columnOffset: any) {
     /*
     Return column accessor by offset.
@@ -740,6 +785,7 @@ class Dataframe {
       : undefined;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   at(r: any, c: any) {
     /*
     Access a single value, for a row/col label pair.
@@ -757,6 +803,7 @@ class Dataframe {
     return this.__columns[coff][roff];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   iat(r: any, c: any) {
     /*
     Access a single value, for a row/col offset (integer) position.
@@ -770,6 +817,7 @@ class Dataframe {
     return this.__columns[c][r];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   has(r: any, c: any) {
     /*
     Test if row/col labels exist in the dataframe - returns true/false
@@ -780,6 +828,7 @@ class Dataframe {
     return coff >= 0 && coff < nCols && roff >= 0 && roff < nRows;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   ihas(r: any, c: any) {
     /*
     Test if row/col offset (integer) position exists in the
@@ -796,6 +845,7 @@ class Dataframe {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   hasCol(c: any) {
     /*
     Test if col label exists - return true/false
@@ -803,6 +853,7 @@ class Dataframe {
     return !!this.col(c);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   isEmpty() {
     /*
     Return true if this is an empty dataframe, ie, has dimensions [0,0]
@@ -818,6 +869,7 @@ class Dataframe {
   add these as useful.
   ****/
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   mapColumns(callback: any) {
     /*
     map all columns in the dataframe, returning a new dataframe comprised of the
@@ -825,9 +877,11 @@ class Dataframe {
 
     callback MUST not modify the column, but instead return a mutated copy.
     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const columns = this.__columns.map((colData: any, colIdx: any) =>
       callback(colData, colIdx, this)
     );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const columnsAccessor = columns.map((c: any, idx: any) =>
       this.__columns[idx] === c ? this.__columnsAccessor[idx] : undefined
     );

--- a/client/src/util/dataframe/histogram.ts
+++ b/client/src/util/dataframe/histogram.ts
@@ -3,6 +3,7 @@ Dataframe histogram
 */
 import { isTypedArray } from "./util";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _histogramContinuous(column: any, bins: any, min: any, max: any) {
   const valBins = new Array(bins).fill(0);
   if (!column) {
@@ -22,10 +23,15 @@ function _histogramContinuous(column: any, bins: any, min: any, max: any) {
 }
 
 function _histogramContinuousBy(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   column: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   bins: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   min: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   max: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   by: any
 ) {
   const byMap = new Map();
@@ -52,6 +58,7 @@ function _histogramContinuousBy(
   return byMap;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _histogramCategorical(column: any) {
   const valMap = new Map();
   if (!column) {
@@ -69,6 +76,7 @@ function _histogramCategorical(column: any) {
   return valMap;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _histogramCategoricalBy(column: any, by: any) {
   const byMap = new Map();
   if (!column || !by) {
@@ -96,6 +104,7 @@ function _histogramCategoricalBy(column: any, by: any) {
 /*
 Count category occupancy.  Optional group-by category.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function histogramCategorical(column: any, by: any) {
   if (by && isTypedArray(by)) {
     throw new Error("Group by column must be categorical");
@@ -108,6 +117,7 @@ export function histogramCategorical(column: any, by: any) {
 /*
 Memoization hash for histogramCategorical()
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function hashCategorical(column: any, by: any) {
   if (by) {
     return `${column.__id}:${by.__id}`;
@@ -119,10 +129,13 @@ export function hashCategorical(column: any, by: any) {
 Bin counts for continuous/scalar values, with optional group-by category.
 Values outside domain are ignored.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function histogramContinuous(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   column: any,
   bins = 40,
   domain = [0, 1],
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   by: any
 ) {
   if (by && isTypedArray(by)) {
@@ -137,10 +150,13 @@ export function histogramContinuous(
 /*
 Memoization hash for histogramContinuous
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function hashContinuous(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   column: any,
   bins = "",
   domain = [0, 0],
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   by: any
 ) {
   const [min, max] = domain;

--- a/client/src/util/dataframe/labelIndex.ts
+++ b/client/src/util/dataframe/labelIndex.ts
@@ -10,6 +10,7 @@ import { __getMemoId } from "./util";
 /*
 Private utility functions
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function extent(tarr: any) {
   let min = 0x7fffffff;
   let max = ~min; // eslint-disable-line no-bitwise -- Establishes 0 of same size
@@ -26,19 +27,23 @@ function extent(tarr: any) {
 }
 
 class IdentityInt32Index {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   maxOffset: any;
 
   /*
   identity/noop index, with small assumptions that labels are int32
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(maxOffset: any) {
     this.maxOffset = maxOffset;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   get __id() {
     return `IdentityInt32Index_${this.maxOffset}`;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   labels() {
     // memoize
     const k = fillRange(new Int32Array(this.maxOffset));
@@ -48,30 +53,38 @@ class IdentityInt32Index {
     return k;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getOffset(i: any) {
     // label to offset
     return Number.isInteger(i) && i >= 0 && i < this.maxOffset ? i : undefined;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getOffsets(arr: any) {
     // labels to offsets
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return arr.map((i: any) => this.getOffset(i));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getLabel(i: any) {
     // offset to label
     return Number.isInteger(i) && i >= 0 && i < this.maxOffset ? i : undefined;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   getLabels(arr: any) {
     // offsets to labels
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return arr.map((i: any) => this.getLabel(i));
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   size() {
     return this.maxOffset;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   __promote(labelArray: any) {
     /*
     time/space decision - based on the resulting density
@@ -90,6 +103,7 @@ class IdentityInt32Index {
     return new DenseInt32Index(labelArray, [minLabel, maxLabel]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   subset(labels: any) {
     /* validate subset */
     const { maxOffset } = this;
@@ -102,11 +116,13 @@ class IdentityInt32Index {
   }
 
   /* identity index - labels are offsets */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubset(offsets: any) {
     return this.subset(offsets);
   }
 
   /* identity index - labels are offsets */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubsetMask(mask: any) {
     let count = 0;
     if (mask.length !== this.maxOffset) {
@@ -123,6 +139,7 @@ class IdentityInt32Index {
     return this.subset(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabel(label: any) {
     if (label === this.maxOffset) {
       return new IdentityInt32Index(label + 1);
@@ -130,10 +147,12 @@ class IdentityInt32Index {
     return this.__promote([...this.labels(), label]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabels(labels: any) {
     return this.__promote([...this.labels(), ...labels]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dropLabel(label: any) {
     if (label === this.maxOffset - 1) {
       return new IdentityInt32Index(label);
@@ -145,20 +164,28 @@ class IdentityInt32Index {
 }
 
 class DenseInt32Index {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   __id: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getLabel: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getLabels: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getOffset: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getOffsets: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   index: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   minLabel: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   rindex: any;
 
   /*
@@ -167,6 +194,7 @@ class DenseInt32Index {
   of the forward index labels must be known a priori (so that the index
   array can be pre-allocated).
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(labels: any, labelRange = null) {
     if (labels.constructor !== Int32Array) {
       labels = new Int32Array(labels);
@@ -192,35 +220,45 @@ class DenseInt32Index {
     this.__compile();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   __compile() {
     const { minLabel, index, rindex } = this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getOffset = function getOffset(l: any) {
       if (!Number.isInteger(l)) return undefined;
       const offset = index[l - minLabel];
       return offset === -1 ? undefined : offset;
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getOffsets = function getOffsets(arr: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return arr.map((i: any) => this.getOffset(i));
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getLabel = function getLabel(i: any) {
       return Number.isInteger(i) ? rindex[i] : undefined;
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getLabels = function getLabels(arr: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return arr.map((i: any) => this.getLabel(i));
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   labels() {
     return this.rindex;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   size() {
     return this.rindex.length;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   __promote(labelArray: any) {
     /*
     time/space decision - if we are going to use less than 10% of the
@@ -238,6 +276,7 @@ class DenseInt32Index {
     return new DenseInt32Index(labelArray, [minLabel, maxLabel]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   subset(labels: any) {
     /* validate subset */
     for (let i = 0, l = labels.length; i < l; i += 1) {
@@ -249,6 +288,7 @@ class DenseInt32Index {
     return this.__promote(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubset(offsets: any) {
     /* validate subset */
     const { rindex } = this;
@@ -263,6 +303,7 @@ class DenseInt32Index {
     return this.__promote(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubsetMask(mask: any) {
     const { rindex } = this;
     if (mask.length !== rindex.length)
@@ -279,14 +320,17 @@ class DenseInt32Index {
     return this.__promote(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabel(label: any) {
     return this.__promote([...this.labels(), label]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabels(labels: any) {
     return this.__promote([...this.labels(), ...labels]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dropLabel(label: any) {
     const labelArray = [...this.labels()];
     labelArray.splice(labelArray.indexOf(label), 1);
@@ -295,30 +339,39 @@ class DenseInt32Index {
 }
 
 class KeyIndex {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   __id: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getLabel: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getLabels: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getOffset: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   getOffsets: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   index: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   rindex: any;
 
   /*
   KeyIndex indexes arbitrary JS primitive types, and uses a Map()
   as its core data structure.
   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(labels: any) {
     const index = new Map();
     if (labels === undefined) {
       labels = [];
     }
     const rindex = labels;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     labels.forEach((v: any, i: any) => {
       index.set(v, i);
     });
@@ -334,33 +387,43 @@ class KeyIndex {
     this.__compile();
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   __compile() {
     const { index, rindex } = this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getOffset = function getOffset(k: any) {
       return index.get(k);
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getOffsets = function getOffsets(arr: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return arr.map((l: any) => this.getOffset(l));
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getLabel = function getLabel(i: any) {
       return Number.isInteger(i) ? rindex[i] : undefined;
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.getLabels = function getLabels(arr: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       return arr.map((i: any) => this.getLabel(i));
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   labels() {
     return this.rindex;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   size() {
     return this.rindex.length;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   subset(labels: any) {
     /* validate subset */
     for (let i = 0, l = labels.length; i < l; i += 1) {
@@ -374,6 +437,7 @@ class KeyIndex {
     return new KeyIndex(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubset(offsets: any) {
     const { rindex } = this;
     const maxOffset = rindex.length;
@@ -388,6 +452,7 @@ class KeyIndex {
     return new KeyIndex(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isubsetMask(mask: any) {
     const { rindex } = this;
     if (mask.length !== rindex.length)
@@ -404,14 +469,17 @@ class KeyIndex {
     return new KeyIndex(labels);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabel(label: any) {
     return new KeyIndex([...this.rindex, label]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   withLabels(labels: any) {
     return new KeyIndex([...this.rindex, ...labels]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   dropLabel(label: any) {
     const idx = this.rindex.indexOf(label);
     const labelArray = [...this.rindex];
@@ -420,6 +488,7 @@ class KeyIndex {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 function isLabelIndex(i: any) {
   return (
     i instanceof IdentityInt32Index ||

--- a/client/src/util/dataframe/summarize.ts
+++ b/client/src/util/dataframe/summarize.ts
@@ -13,6 +13,7 @@ import { sortArray } from "../typedCrossfilter/sort";
 // @ts-expect-error ts-migrate(6133) FIXME: 'v' is declared but its value is never read.
 const centileNames = new Array(101).fill(0).map((v, idx) => idx / 100);
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function summarizeContinuous(col: any) {
   let min;
   let max;
@@ -64,6 +65,7 @@ export function summarizeContinuous(col: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function summarizeCategorical(col: any) {
   const categoryCounts = new Map();
   if (col) {

--- a/client/src/util/dataframe/util.ts
+++ b/client/src/util/dataframe/util.ts
@@ -4,13 +4,16 @@ Private utility code for dataframe
 
 export { isTypedArray, isArrayOrTypedArray } from "../typeHelpers";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function callOnceLazy(f: any) {
   /*
   call function once, and save the result, regardless of arguments (this is not
   the same as typical memoization).
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let value: any;
   let calledOnce = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const result = function result(...args: any[]) {
     if (!calledOnce) {
       value = f(...args);
@@ -21,6 +24,7 @@ export function callOnceLazy(f: any) {
   return result;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
   /* 
   function memoization, with user-provided hash.  hashFn must return a
@@ -29,6 +33,7 @@ export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Key_equality
   */
   const cache = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const wrap = function wrap(...args: any[]) {
     const key = hashFn(...args);
     if (cache.has(key)) {
@@ -57,6 +62,7 @@ export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
 memoization helpers - just a global counter.
 **/
 let __DataframeMemoId__ = 0;
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function __getMemoId() {
   const id = __DataframeMemoId__;
   __DataframeMemoId__ += 1;

--- a/client/src/util/finiteExtent.ts
+++ b/client/src/util/finiteExtent.ts
@@ -6,6 +6,7 @@ If undefined or empty array, or array contains only non-finite numbers,
 will return [undefined, undefined]
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 function finiteExtent(tarr: any) {
   let min;
   let max;

--- a/client/src/util/fromEntries.ts
+++ b/client/src/util/fromEntries.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function fromEntries(arr: any) {
   /*
 	Similar to Object.fromEntries, but only handles array.

--- a/client/src/util/maybeScientific.ts
+++ b/client/src/util/maybeScientific.ts
@@ -10,10 +10,12 @@ import significantDigits from "./significantDigits";
  * @returns - the number formatted as scientific, if it's big enough
  */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function maybeScientific(x: any) {
   let format = ",";
   const _ticks = x.ticks(4);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   if (x.domain().some((n: any) => Math.abs(n) >= 10000)) {
     /* 
           heuristic: if the last tick d3 wants to render has one significant

--- a/client/src/util/nameCreators.ts
+++ b/client/src/util/nameCreators.ts
@@ -13,16 +13,22 @@ anno matrix namespaces. It is still used by the component tier.
 
 */
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const makeDimensionName = (namespace: any, key: any) => `${namespace}_${key}`;
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const layoutDimensionName = (key: any) =>
   makeDimensionName("layout", key);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const obsAnnoDimensionName = (key: any) =>
   makeDimensionName("obsAnno", key);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const diffexpDimensionName = (key: any) =>
   makeDimensionName("varData_diffexp", key);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const userDefinedDimensionName = (key: any) =>
   makeDimensionName("varData_userDefined", key);
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const geneSetSummaryDimensionName = (key: any) =>
   makeDimensionName("geneSetSummary", key);
 
@@ -37,8 +43,11 @@ export const geneSetSummaryDimensionName = (key: any) =>
   ie., makeContinuousDimensionName(continuousNamespace = {isObs: true}, "total_reads")
   see: histogram brush, as it doesn't know what type of continuous it was with only field
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const makeContinuousDimensionName = (
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   continuousNamespace: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   key: any
 ) => {
   let name;

--- a/client/src/util/parseBulkGeneString.ts
+++ b/client/src/util/parseBulkGeneString.ts
@@ -6,6 +6,7 @@
 import pull from "lodash.pull";
 import uniq from "lodash.uniq";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function parseBulkGeneString(geneString: any) {
   return pull(uniq(geneString.split(/[ ,]+/)), "");
 }

--- a/client/src/util/parseRGB.ts
+++ b/client/src/util/parseRGB.ts
@@ -6,6 +6,7 @@ import scaleRGB from "./scaleRGB";
 //
 const colorCache = {};
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function parseColorName(c: any) {
   if (c[0] !== "#") {
     const _c = c.replace(/[^\d,.]/g, "").split(",");
@@ -22,6 +23,7 @@ function parseColorName(c: any) {
   ];
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default (c: any) => {
   // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   let cv = colorCache[c];

--- a/client/src/util/promiseLimit.ts
+++ b/client/src/util/promiseLimit.ts
@@ -37,13 +37,18 @@ function compare(a, b) {
 
 export default class PromiseLimit {
   constructor(maxConcurrency = 5) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).queue = new TinyQueue([], compare);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).maxConcurrency = maxConcurrency;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).pending = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).insertCounter = 0;
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'p' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   priorityAdd(p, fn, ...args) {
     // p - numermic priority (lower first)
     // fn - must return a promise
@@ -52,6 +57,7 @@ export default class PromiseLimit {
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'fn' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   add(fn, ...args) {
     // fn - must return a promise
     // args - will be passed to fn
@@ -63,23 +69,33 @@ export default class PromiseLimit {
   **/
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'priority' implicitly has an 'any' type.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _push(priority, fn, args) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const order = (this as any).insertCount;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (this as any).insertCount += 1;
     return new Promise((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).queue.push({ priority, order, fn, args, resolve, reject });
       this._resolveNext(false);
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _resolveNext = (completed = true) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     if (completed) (this as any).pending -= 1;
 
     while (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).queue.length > 0 &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).pending < (this as any).maxConcurrency
     ) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       const task = (this as any).queue.pop(); // order of insertion
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       (this as any).pending += 1;
       const { resolve, reject, fn, args } = task;
 

--- a/client/src/util/quantile.ts
+++ b/client/src/util/quantile.ts
@@ -15,6 +15,7 @@ Arguments:
 import { sortArray } from "./typedCrossfilter/sort";
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'quantArr' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export default function quantile(quantArr, tarr, sorted = false) {
   /*
 	start with the naive (sort) implementation.  Later, use a faster partition

--- a/client/src/util/range.ts
+++ b/client/src/util/range.ts
@@ -31,11 +31,13 @@ function _doFill(arr, start, step, count) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'arr' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function rangeFill(arr, start = 0, step = 1) {
   return _doFill(arr, start, step, arr.length);
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'start' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function range(start, stop, step) {
   if (start === undefined) return [];
   if (stop === undefined) {
@@ -48,6 +50,7 @@ export function range(start, stop, step) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'start' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function linspace(start, stop, nsteps) {
   // @ts-expect-error ts-migrate(2363) FIXME: The right-hand side of an arithmetic operation mus... Remove this comment to see the full error message
   const delta = (stop - start) / (nsteps - 1).toFixed();

--- a/client/src/util/renderThrottle.ts
+++ b/client/src/util/renderThrottle.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default function renderThrottle(callback: any) {
   /*
   This wraps a call to requestAnimationFrame(), enforcing a single
@@ -5,9 +6,12 @@ export default function renderThrottle(callback: any) {
   of times, and it will coallesce multiple inter-frame calls into a
   single render).
   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let rafCurrentlyInProgress: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return function f(this: any) {
     if (rafCurrentlyInProgress) return;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias --- FIXME: disabled temporarily on migrate to TS.
     const context = this;
     rafCurrentlyInProgress = window.requestAnimationFrame(() => {
       callback.apply(context);

--- a/client/src/util/scaleLinear.ts
+++ b/client/src/util/scaleLinear.ts
@@ -6,14 +6,17 @@
 //     myScale(0) === -1
 // this is is equivalent to d3.scaleLinear().domain([0,1]).range([-1,1])
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default (domain: any, range: any) => {
   const domainStart = domain[0];
   const scale = (range[1] - range[0]) / (domain[1] - domain[0]);
   const invScale = 1 / scale;
   const rangeStart = range[0];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const f = (value: any) => (value - domainStart) * scale + rangeStart;
 
   // inverter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   f.invert = (value: any) => (value - rangeStart) * invScale + domainStart;
 
   return f;

--- a/client/src/util/scaleRGB.ts
+++ b/client/src/util/scaleRGB.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default (input: any) => {
   const outputMax = 1;
   const outputMin = 0;

--- a/client/src/util/significantDigits.ts
+++ b/client/src/util/significantDigits.ts
@@ -2,6 +2,7 @@
     via https://github.com/nodef/extra-number/blob/master/scripts/significantDigits.js
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export default (n: any) => {
   return n
     .toExponential()

--- a/client/src/util/stateManager/annotationsHelpers.ts
+++ b/client/src/util/stateManager/annotationsHelpers.ts
@@ -18,6 +18,7 @@ categorical annotations to be writable.
 */
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'schema' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function isCategoricalAnnotation(schema, name) {
   /* 
   we treat any string, categorical or boolean as a categorical.
@@ -30,6 +31,7 @@ export function isCategoricalAnnotation(schema, name) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'schema' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function isContinuousAnnotation(schema, name) {
   /*
   Return true/false/undefined
@@ -46,11 +48,13 @@ function _isUserAnnotation(schema, name) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function isUserAnnotation(annoMatrix, name) {
   return _isUserAnnotation(annoMatrix.schema, name);
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'df' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function allHaveLabelByMask(df, colName, label, mask) {
   // return true if all rows as indicated by mask have the colname set to label.
   // False if not.
@@ -69,6 +73,7 @@ export function allHaveLabelByMask(df, colName, label, mask) {
 
 const legalCharacters = /^(\w|[ .()-])+$/;
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'name' implicitly has an 'any' type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function annotationNameIsErroneous(name) {
   /*
 	Validate the name - return:

--- a/client/src/util/stateManager/colorHelpers.ts
+++ b/client/src/util/stateManager/colorHelpers.ts
@@ -12,10 +12,15 @@ import { range } from "../range";
 given a color mode & accessor, generate an annoMatrix query that will
 fulfill it
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function createColorQuery(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   colorMode: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   colorByAccessor: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   schema: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   genesets: any
 ) {
   if (!colorMode || !colorByAccessor || !schema || !genesets) return null;
@@ -66,6 +71,7 @@ export function createColorQuery(
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _defaultColors(nObs: any) {
   const defaultCellColor = parseRGB(globals.defaultCellColor);
   return {
@@ -89,9 +95,13 @@ Returns:
   }
 */
 function _createColorTable(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colorMode: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colorByAccessor: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colorByData: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
   userColors = null
 ) {
@@ -132,6 +142,7 @@ export const createColorTable = memoize(_createColorTable);
  *    - scale: function which given label returns d3 color scale for label
  * Order doesn't matter - everything is keyed by label value.
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function loadUserColorConfig(userColors: any) {
   const convertedUserColors = {};
   Object.keys(userColors).forEach((category) => {
@@ -147,6 +158,7 @@ export function loadUserColorConfig(userColors: any) {
       [{}, {}]
     );
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const scale = (label: any) => scaleMap[label];
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     convertedUserColors[category] = { colors, scale };
@@ -155,9 +167,13 @@ export function loadUserColorConfig(userColors: any) {
 }
 
 function _createUserColors(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   data: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colorAccessor: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   userColors: any
 ) {
   const { colors, scale: scaleByLabel } = userColors[colorAccessor];
@@ -167,7 +183,9 @@ function _createUserColors(
   // See createColorsByCategoricalMetadata() for another example.
   const { categories } = schema.annotations.obsByName[colorAccessor];
   const categoryMap = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categories.forEach((label: any, idx: any) => categoryMap.set(idx, label));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const scale = (idx: any) => scaleByLabel(categoryMap.get(idx));
 
   return { rgb, scale };
@@ -175,8 +193,11 @@ function _createUserColors(
 const createUserColors = memoize(_createUserColors);
 
 function _createColorsByCategoricalMetadata(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   data: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   colorAccessor: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any
 ) {
   const { categories } = schema.annotations.obsByName[colorAccessor];
@@ -186,6 +207,7 @@ function _createColorsByCategoricalMetadata(
     .domain([0, categories.length]);
 
   /* pre-create colors - much faster than doing it for each obs */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const colors = categories.reduce((acc: any, cat: any, idx: any) => {
     acc[cat] = parseRGB(scale(idx));
     return acc;
@@ -198,6 +220,7 @@ const createColorsByCategoricalMetadata = memoize(
   _createColorsByCategoricalMetadata
 );
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function createRgbArray(data: any, colors: any) {
   const rgb = new Array(data.length);
   for (let i = 0, len = data.length; i < len; i += 1) {
@@ -207,6 +230,7 @@ function createRgbArray(data: any, colors: any) {
   return rgb;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _createColorsByContinuousMetadata(data: any, min: any, max: any) {
   const colorBins = 100;
   const scale = d3

--- a/client/src/util/stateManager/controlsHelpers.ts
+++ b/client/src/util/stateManager/controlsHelpers.ts
@@ -35,10 +35,12 @@ Remember that option values can be ANY js type, except undefined/null.
     }
   }
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function topNCategories(colSchema: any, summary: any, N: any) {
   /* return top N categories by occurrences in the data */
   const { categories: allCategories } = colSchema;
   const counts = allCategories.map(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (cat: any) => summary.categoryCounts.get(cat) ?? 0
   );
 
@@ -47,6 +49,7 @@ function topNCategories(colSchema: any, summary: any, N: any) {
   }
 
   const sortIndex = fillRange(new Array(allCategories.length)).sort(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (a: any, b: any) => counts[b] - counts[a]
   );
   const topNindices = new Set(sortIndex.slice(0, N));
@@ -62,6 +65,7 @@ function topNCategories(colSchema: any, summary: any, N: any) {
   return [allCategories, _topNCategories, topNCounts];
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isSelectableCategoryName(schema: any, name: any) {
   const { index } = schema.annotations.obs;
   const colSchema = schema.annotations.obsByName[name];
@@ -72,6 +76,7 @@ export function isSelectableCategoryName(schema: any, name: any) {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function selectableCategoryNames(schema: any, names: any) {
   /*
   return all obs annotation names that are categorical AND have a
@@ -80,10 +85,13 @@ export function selectableCategoryNames(schema: any, names: any) {
   If the initial name list not provided, use everything in the schema.
   */
   if (!schema) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   if (!names) names = schema.annotations.obs.columns.map((c: any) => c.name);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return names.filter((name: any) => isSelectableCategoryName(schema, name));
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function createCategorySummaryFromDfCol(dfCol: any, colSchema: any) {
   const N = globals.maxCategoricalOptionsToDisplay;
   const { writable: isUserAnno } = colSchema;
@@ -100,6 +108,7 @@ export function createCategorySummaryFromDfCol(dfCol: any, colSchema: any) {
     categoryValueCounts,
   ] = topNCategories(colSchema, summary, N);
   const categoryValueIndices = new Map(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     categoryValues.map((v: any, i: any) => [v, i])
   );
   const numCategoryValues = categoryValueIndices.size;
@@ -116,10 +125,13 @@ export function createCategorySummaryFromDfCol(dfCol: any, colSchema: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function createCategoricalSelection(names: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return fromEntries(names.map((name: any) => [name, new Map()]));
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function pruneVarDataCache(varData: any, needed: any) {
   /*
   Remove any unneeded columns from the varData dataframe.  Will only

--- a/client/src/util/stateManager/matrix.ts
+++ b/client/src/util/stateManager/matrix.ts
@@ -17,12 +17,14 @@ Matrix flatbuffer decoding support.   See fbs/matrix.fbs
 /*
 Decode NetEncoding.TypedArray
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function decodeTypedArray(uType: any, uValF: any, inplace = false) {
   if (uType === NetEncoding.TypedArray.NONE) {
     return null;
   }
 
   // Convert to a JS class that supports this type
+  // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
   const TypeClass = NetEncoding[NetEncoding.TypedArray[uType]];
   // Create a TypedArray that references the underlying buffer
   let arr = uValF(new TypeClass()).dataArray();
@@ -48,6 +50,7 @@ Returns: object containing decoded Matrix:
   colIdx: []|null
 }
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function decodeMatrixFBS(arrayBuffer: any, inplace = false) {
   const bb = new flatbuffers.ByteBuffer(new Uint8Array(arrayBuffer));
   const matrix = NetEncoding.Matrix.getRootAsMatrix(bb);
@@ -79,8 +82,11 @@ export function decodeMatrixFBS(arrayBuffer: any, inplace = false) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function encodeTypedArray(builder: any, uType: any, uData: any) {
+  // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
   const uTypeName = NetEncoding.TypedArray[uType];
+  // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
   const ArrayType = NetEncoding[uTypeName];
   const dv = ArrayType.createDataVector(builder, uData);
   builder.startObject(1);
@@ -88,6 +94,7 @@ function encodeTypedArray(builder: any, uType: any, uData: any) {
   return builder.endObject();
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function encodeMatrixFBS(df: any) {
   /*
   encode the dataframe as an FBS Matrix
@@ -108,12 +115,15 @@ export function encodeMatrixFBS(df: any) {
   let encColumns;
 
   if (shape[0] > 0 && shape[1] > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const columns = df.columns().map((col: any) => col.asArray());
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     const cols = columns.map((carr: any) => {
       let uType;
       let tarr;
       if (isTypedArray(carr)) {
+        // @ts-expect-error --- FIXME: Element implicitly has an 'any' type.
         uType = NetEncoding.TypedArray[carr.constructor.name];
         tarr = encodeTypedArray(builder, uType, carr);
       } else {
@@ -169,6 +179,7 @@ export function encodeMatrixFBS(df: any) {
   return builder.asUint8Array();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function promoteTypedArray(o: any) {
   /*
   Decide what internal data type to use for the data returned from
@@ -201,6 +212,7 @@ function promoteTypedArray(o: any) {
   return new TypedArrayCtor(o);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function matrixFBSToDataframe(arrayBuffers: any) {
   /*
   Convert array of Matrix FBS to a Dataframe.
@@ -217,18 +229,22 @@ export function matrixFBSToDataframe(arrayBuffers: any) {
     arrayBuffers = [arrayBuffers];
   }
   if (arrayBuffers.length === 0) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     return (Dataframe as any).Dataframe.empty();
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const fbs = arrayBuffers.map((ab: any) => decodeMatrixFBS(ab, true)); // leave in place
   /* check that all FBS have same row dimensionality */
   const { nRows } = fbs[0];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   fbs.forEach((b: any) => {
     if (b.nRows !== nRows)
       throw new Error("FBS with inconsistent dimensionality");
   });
-  const columns = fbs
+  const columns = fbs // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     .map((fb: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       fb.columns.map((c: any) => {
         if (isFpTypedArray(c) || Array.isArray(c)) return c;
         return promoteTypedArray(c);
@@ -236,7 +252,7 @@ export function matrixFBSToDataframe(arrayBuffers: any) {
     )
     .flat();
   // colIdx may be TypedArray or Array
-  const colIdx = fbs
+  const colIdx = fbs // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     .map((b: any) =>
       Array.isArray(b.colIdx) ? b.colIdx : Array.from(b.colIdx)
     )

--- a/client/src/util/stateManager/schemaHelpers.ts
+++ b/client/src/util/stateManager/schemaHelpers.ts
@@ -15,24 +15,30 @@ System wide schema assumptions:
   - schema will be internally self-consistent (eg, index matches columns)
 */
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function indexEntireSchema(schema: any) {
   /* Index schema for ease of use */
   schema.annotations.obsByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.annotations?.obs?.columns?.map((v: any) => [v.name, v]) ?? []
   );
   schema.annotations.varByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.annotations?.var?.columns?.map((v: any) => [v.name, v]) ?? []
   );
   schema.layout.obsByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.layout?.obs?.map((v: any) => [v.name, v]) ?? []
   );
   schema.layout.varByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.layout?.var?.map((v: any) => [v.name, v]) ?? []
   );
 
   return schema;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _copyObsAnno(schema: any) {
   /* redux copy conventions - WARNING, only for modifying obs annotations */
   return {
@@ -44,6 +50,7 @@ function _copyObsAnno(schema: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _copyObsLayout(schema: any) {
   return {
     ...schema,
@@ -54,36 +61,44 @@ function _copyObsLayout(schema: any) {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _reindexObsAnno(schema: any) {
   /* reindex obs annotations ONLY */
   schema.annotations.obsByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.annotations.obs.columns.map((v: any) => [v.name, v])
   );
   return schema;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function _reindexObsLayout(schema: any) {
   schema.layout.obsByName = fromEntries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     schema.layout.obs.map((v: any) => [v.name, v])
   );
   return schema;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function removeObsAnnoColumn(schema: any, name: any) {
   const newSchema = _copyObsAnno(schema);
   newSchema.annotations.obs.columns = schema.annotations.obs.columns.filter(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     (v: any) => v.name !== name
   );
   return _reindexObsAnno(newSchema);
 }
 
 // @ts-expect-error ts-migrate(6133) FIXME: 'name' is declared but its value is never read.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function addObsAnnoColumn(schema: any, name: any, defn: any) {
   const newSchema = _copyObsAnno(schema);
   newSchema.annotations.obs.columns.push(defn);
   return _reindexObsAnno(newSchema);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function removeObsAnnoCategory(schema: any, name: any, category: any) {
   /* remove a category from a categorical annotation */
   const categories = schema.annotations.obsByName[name]?.categories;
@@ -100,6 +115,7 @@ export function removeObsAnnoCategory(schema: any, name: any, category: any) {
   return newSchema;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function addObsAnnoCategory(schema: any, name: any, category: any) {
   /* add a category to a categorical annotation */
   const categories = schema.annotations.obsByName[name]?.categories;
@@ -120,6 +136,7 @@ export function addObsAnnoCategory(schema: any, name: any, category: any) {
   return newSchema;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function addObsLayout(schema: any, layout: any) {
   /* add or replace a layout */
   const newSchema = _copyObsLayout(schema);
@@ -127,9 +144,11 @@ export function addObsLayout(schema: any, layout: any) {
   return _reindexObsLayout(newSchema);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function removeObsLayout(schema: any, name: any) {
   /* remove a layout */
   const newSchema = _copyObsLayout(schema);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   newSchema.layout.obs = schema.layout.obs.filter((v: any) => v.name !== name);
   return _reindexObsLayout(newSchema);
 }

--- a/client/src/util/stateManager/viewStackHelpers.ts
+++ b/client/src/util/stateManager/viewStackHelpers.ts
@@ -39,6 +39,7 @@ import { clip, isubsetMask, isubset } from "../../annoMatrix";
 import { memoize } from "../dataframe/util";
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _clipAnnoMatrix(annoMatrix, min, max) {
   /*
   clip the annoMatrix.
@@ -49,6 +50,7 @@ export function _clipAnnoMatrix(annoMatrix, min, max) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _userSubsetAnnoMatrix(annoMatrix, mask) {
   /*
   user-requested row subset of annoMatrix, to be added on top of any 
@@ -71,6 +73,7 @@ export function _userSubsetAnnoMatrix(annoMatrix, mask) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _userResetSubsetAnnoMatrix(annoMatrix) {
   /*
   Reset/remove all user-requested subsets.  Do not remove clip or embedding subset.
@@ -97,6 +100,7 @@ export function _userResetSubsetAnnoMatrix(annoMatrix) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _setEmbeddingSubset(annoMatrix, embeddingDf) {
   /*
   Set the embedding subset view.  Only create a subset view for the embedding
@@ -164,6 +168,7 @@ function _getEmbeddingRowOffsets(baseRowIndex, embeddingDf) {
 }
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'embeddingDf' implicitly has an 'any' ty... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function _getDiscreteCellEmbeddingRowIndex(embeddingDf) {
   const idx = _getEmbeddingRowOffsets(embeddingDf.rowIndex, embeddingDf);
   if (idx === null) return embeddingDf.rowIndex;
@@ -176,6 +181,7 @@ export const getDiscreteCellEmbeddingRowIndex = memoize(
 );
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function getEmbSubsetView(annoMatrix) {
   /* if there is an embedding subset in the view stack, return it.  Falsish if not. */
   while (annoMatrix.isView) {

--- a/client/src/util/statemachine/index.ts
+++ b/client/src/util/statemachine/index.ts
@@ -43,22 +43,29 @@ Example:
 
 */
 export default class StateMachine {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   events: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   graph: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   onError: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   state: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   states: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(initState: any, transitions: any, onError: any) {
     this.onError = onError || (() => undefined);
     this.state = initState;
 
     // all states
     this.states = new Set(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       transitions.reduce((names: any, tsn: any) => {
         names.push(tsn.from);
         names.push(tsn.to);
@@ -67,10 +74,12 @@ export default class StateMachine {
     );
 
     // all transition names (aka events)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.events = new Set(transitions.map((tsn: any) => tsn.event));
 
     // the transition graph.
     // graph[event][from] -> transition
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     this.graph = transitions.reduce((graph: any, tsn: any) => {
       const { event, from } = tsn;
       if (!graph.has(event)) graph.set(event, new Map());
@@ -80,6 +89,7 @@ export default class StateMachine {
     }, new Map());
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   clone(initState: any) {
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.
     const fsm = new StateMachine(initState, []);
@@ -90,6 +100,7 @@ export default class StateMachine {
     return fsm;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   next(event: any, data: any) {
     const { graph, state } = this;
     const tsnMap = graph.get(event);

--- a/client/src/util/typeHelpers.ts
+++ b/client/src/util/typeHelpers.ts
@@ -5,6 +5,7 @@ Various type and schema related helper functions.
 /*
 Utility function to test for a typed array
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isTypedArray(x: any) {
   return (
     ArrayBuffer.isView(x) &&
@@ -15,6 +16,7 @@ export function isTypedArray(x: any) {
 /*
 Test for float typed array, ie, Float32TypedArray or Float64TypedArray
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isFpTypedArray(x: any) {
   let constructor;
   const isFloatArray =
@@ -24,6 +26,7 @@ export function isFpTypedArray(x: any) {
   return isFloatArray;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function isArrayOrTypedArray(x: any) {
   return Array.isArray(x) || isTypedArray(x);
 }

--- a/client/src/util/typedCrossfilter/bitArray.ts
+++ b/client/src/util/typedCrossfilter/bitArray.ts
@@ -17,16 +17,22 @@
 // The underlying data structure uses TypedArrays for performance.
 //
 class BitArray {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   bitarray: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   bitmask: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dimensionCount: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   length: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   width: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(length: any) {
     // Initially allocate a 32 bit wide array.  allocDimension() will expand
     // as necessary.
@@ -50,12 +56,14 @@ class BitArray {
   // Return the number of records that are selected, ie, have a one bit in
   // all allocated dimensions.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   selectionCount() {
     return this.countAllOnes();
   }
 
   // Count all records that have a 'one' bit in allocated dimensions.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   countAllOnes() {
     let count = 0;
     const { bitarray, length, width } = this;
@@ -86,6 +94,7 @@ class BitArray {
 
   // count trailing zeros - hard to do fast in JS!
   // https://en.wikipedia.org/wiki/Find_first_set#CTZ
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static ctz(av: any) {
     let c = 32;
     let v = av;
@@ -100,6 +109,7 @@ class BitArray {
   }
 
   // find a free dimension.  Return undefined if none
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _findFreeDimension() {
     let dim;
     for (let col = 0; col < this.width; col += 1) {
@@ -115,6 +125,7 @@ class BitArray {
 
   // allocate and return the dimension ID (bit position)
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allocDimension() {
     let dim = this._findFreeDimension();
 
@@ -140,6 +151,7 @@ class BitArray {
   // free a dimension for later use.  MUST deselect the dimension, as other
   // code assume the column will be zero valued.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   freeDimension(dim: any) {
     // all selection tests assume unallocated dimensions are zero valued.
     this.deselectAll(dim);
@@ -150,6 +162,7 @@ class BitArray {
 
   // return true if this index is selected in ALL dimensions.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isSelected(index: any) {
     const { width, length, bitarray } = this;
 
@@ -162,6 +175,7 @@ class BitArray {
 
   // return true if this index is selected in ALL dimensions IGNORING dim
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isSelectedIgnoringDim(index: any, dim: any) {
     const ignoreOffset = dim >>> 5;
     const ignoreMask = ~(1 << dim % 32);
@@ -186,6 +200,7 @@ class BitArray {
 
   // select index on dimension
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectOne(dim: any, index: any) {
     const col = dim >>> 5;
     const before = this.bitarray[col * this.length + index];
@@ -195,6 +210,7 @@ class BitArray {
 
   // deselect index on dimension
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   deselectOne(dim: any, index: any) {
     const col = dim >>> 5;
     const before = this.bitarray[col * this.length + index];
@@ -204,6 +220,7 @@ class BitArray {
 
   // select all indices on dimension.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectAll(dim: any) {
     const col = dim >> 5;
     const one = 1 << dim % 32;
@@ -214,6 +231,7 @@ class BitArray {
 
   // deselect all indices on dimension
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   deselectAll(dim: any) {
     const col = dim >> 5;
     const zero = ~(1 << dim % 32);
@@ -224,6 +242,7 @@ class BitArray {
 
   // select range of indices on a dimension
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectFromRange(dim: any, range: any) {
     const col = dim >>> 5;
     const first = range[0];
@@ -238,6 +257,7 @@ class BitArray {
   // select range of indices on a dimension, indirect through a sort map.
   // Indirect functions are used to map between sort and natural order.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectIndirectFromRange(dim: any, indirect: any, range: any) {
     const col = dim >>> 5;
     const first = range[0];
@@ -251,6 +271,7 @@ class BitArray {
 
   // deselect range of indices on a dimension
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   deselectFromRange(dim: any, range: any) {
     const col = dim >>> 5;
     const first = range[0];
@@ -264,6 +285,7 @@ class BitArray {
 
   // deselect range of indices on a dimension, indirect through a sort map.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   deselectIndirectFromRange(dim: any, indirect: any, range: any) {
     const col = dim >>> 5;
     const first = range[0];
@@ -278,6 +300,7 @@ class BitArray {
   // Fill the array with selected|deselected value based upon the
   // current selection state.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fillBySelection(result: any, selectedValue: any, deselectedValue: any) {
     // special case (width === 1) for performance
     if (this.width === 1) {

--- a/client/src/util/typedCrossfilter/crossfilter.ts
+++ b/client/src/util/typedCrossfilter/crossfilter.ts
@@ -11,6 +11,7 @@ import {
 import { makeSortIndex } from "./util";
 
 class NotImplementedError extends Error {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   constructor(...params: any[]) {
     super(...params);
 
@@ -22,12 +23,16 @@ class NotImplementedError extends Error {
 }
 
 export default class ImmutableTypedCrossfilter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   data: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   dimensions: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   selectionCache: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(data: any, dimensions = {}, selectionCache = {}) {
     /*
     Typically, parameter 'data' is one of:
@@ -57,14 +62,17 @@ export default class ImmutableTypedCrossfilter {
     Object.preventExtensions(this);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   size() {
     return this.data.length;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   all() {
     return this.data;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   setData(data: any) {
     if (this.data === data) return this;
     // please leave, WIP
@@ -72,15 +80,18 @@ export default class ImmutableTypedCrossfilter {
     return new ImmutableTypedCrossfilter(data, this.dimensions);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   dimensionNames() {
     /* return array of all dimensions (by name) */
     return Object.keys(this.dimensions);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   hasDimension(name: any) {
     return !!this.dimensions[name];
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   addDimension(name: any, type: any, ...rest: any[]) {
     /*
     Add a new dimension to this crossfilter, of type DimensionType.
@@ -119,6 +130,7 @@ export default class ImmutableTypedCrossfilter {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   delDimension(name: any) {
     const { data } = this;
     const { bitArray } = this.selectionCache;
@@ -139,6 +151,7 @@ export default class ImmutableTypedCrossfilter {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   renameDimension(oldName: any, newName: any) {
     const { [oldName]: dim, ...dimensions } = this.dimensions;
     const { data, selectionCache } = this;
@@ -153,6 +166,7 @@ export default class ImmutableTypedCrossfilter {
     return new ImmutableTypedCrossfilter(data, newDimensions, selectionCache);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   select(name: any, spec: any) {
     /*
     select on named dimension, as indicated by `spec`.   Spec is an object
@@ -181,10 +195,15 @@ export default class ImmutableTypedCrossfilter {
     return new ImmutableTypedCrossfilter(data, dimensions, newSelectionCache);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   static _dimSelnHasUpdated(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     selectionCache: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     id: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     newSeln: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     oldSeln: any
   ) {
     /*
@@ -220,24 +239,29 @@ export default class ImmutableTypedCrossfilter {
       If sort index exists in the dimension, assume sort ordered ranges.
       */
     if (oldSeln.index) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       dels.forEach((interval: any) =>
         bitArray.deselectIndirectFromRange(id, oldSeln.index, interval)
       );
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       dels.forEach((interval: any) => bitArray.deselectFromRange(id, interval));
     }
 
     if (newSeln.index) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       adds.forEach((interval: any) =>
         bitArray.selectIndirectFromRange(id, newSeln.index, interval)
       );
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       adds.forEach((interval: any) => bitArray.selectFromRange(id, interval));
     }
 
     return { bitArray };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _getSelectionCache() {
     if (!this.selectionCache) this.selectionCache = {};
 
@@ -249,6 +273,7 @@ export default class ImmutableTypedCrossfilter {
         const id = bitArray.allocDimension();
         this.dimensions[name].id = id;
         const { ranges, index } = selection;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         ranges.forEach((range: any) => {
           if (index) {
             bitArray.selectIndirectFromRange(id, index, range);
@@ -262,16 +287,19 @@ export default class ImmutableTypedCrossfilter {
     return this.selectionCache;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _clearSelectionCache() {
     this.selectionCache = {};
     return this.selectionCache;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   _setSelectionCache(vals = {}) {
     Object.assign(this.selectionCache, vals);
     return this.selectionCache;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allSelected() {
     /*
     return array of all records currently selected by all dimensions
@@ -292,6 +320,7 @@ export default class ImmutableTypedCrossfilter {
     return data.isubsetMask(this.allSelectedMask());
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   allSelectedMask() {
     /*
     return Uint8Array containing selection state (truthy/falsey) for each record.
@@ -310,6 +339,7 @@ export default class ImmutableTypedCrossfilter {
     return allSelectedMask;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   countSelected() {
     /*
     return number of records selected on all dimensions
@@ -324,6 +354,7 @@ export default class ImmutableTypedCrossfilter {
     return countSelected;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   isElementSelected(i: any) {
     /*
     return truthy/falsey if this record is selected on all dimensions
@@ -332,6 +363,7 @@ export default class ImmutableTypedCrossfilter {
     return selectionCache.bitArray.isSelected(i);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   fillByIsSelected(array: any, selectedValue: any, deselectedValue: any) {
     /*
     fill array with one of two values, based upon selection state.
@@ -357,8 +389,10 @@ for a dimension:
   - name - the dimension name/label.
 */
 class _ImmutableBaseDimension {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   name: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   constructor(name: any) {
     this.name = name;
   }
@@ -367,12 +401,14 @@ class _ImmutableBaseDimension {
     return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   rename(name: any) {
     const d = this.clone();
     d.name = name;
     return d;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   select(spec: any) {
     const { mode } = spec;
     if (mode === undefined) {
@@ -385,10 +421,13 @@ class _ImmutableBaseDimension {
 }
 
 class ImmutableScalarDimension extends _ImmutableBaseDimension {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   index: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(name: any, data: any, value: any, ValueArrayType: any) {
     super(name);
 
@@ -416,6 +455,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
       // only by enumerated dimensions
       array = this._createValueArray(
         data,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
         (i: any) => value[i],
         new ValueArrayType(data.length)
       );
@@ -430,7 +470,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
     this.index = makeSortIndex(array);
   }
 
-  // eslint-disable-next-line class-methods-use-this -- needed for polymorphism
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- needed for polymorphism
   _createValueArray(data: any, mapf: any, array: any) {
     // create dimension value array
     const len = data.length;
@@ -441,6 +481,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
     return larray;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   select(spec: any) {
     const { mode } = spec;
     const { index } = this;
@@ -458,6 +499,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectExact(spec: any) {
     const { value, index } = this;
     let { values } = spec;
@@ -477,6 +519,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
     return { ranges, index };
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectRange(spec: any) {
     const { value, index } = this;
     /* 
@@ -496,10 +539,12 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
 }
 
 class ImmutableEnumDimension extends ImmutableScalarDimension {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(name: any, data: any, value: any) {
     super(name, data, value, Uint32Array);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   _createValueArray(data: any, mapf: any, array: any) {
     const len = data.length;
     const larray = array;
@@ -524,6 +569,7 @@ class ImmutableEnumDimension extends ImmutableScalarDimension {
     return larray;
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectExact(spec: any) {
     // @ts-expect-error FIXME Adding enumIndex as member variable results in "undefined" enumIndex value
     const { enumIndex } = this;
@@ -533,6 +579,7 @@ class ImmutableEnumDimension extends ImmutableScalarDimension {
     }
     return super.selectExact({
       mode: spec.mode,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
       values: values.map((v: any) =>
         binarySearch(enumIndex, v, 0, enumIndex.length)
       ),
@@ -540,21 +587,26 @@ class ImmutableEnumDimension extends ImmutableScalarDimension {
   }
 
   // @ts-expect-error ts-migrate(2416) FIXME: Property 'selectRange' in type 'ImmutableEnumDimen... Remove this comment to see the full error message
-  // eslint-disable-next-line class-methods-use-this -- enables polymorphism
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types -- enables polymorphism
   selectRange() {
     throw new Error("range selection unsupported on Enumerated dimension");
   }
 }
 
 class ImmutableSpatialDimension extends _ImmutableBaseDimension {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   X: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   Xindex: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   Y: any;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   Yindex: any;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   constructor(name: any, data: any, X: any, Y: any) {
     super(name);
 
@@ -570,6 +622,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     this.Yindex = makeSortIndex(Y);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   select(spec: any) {
     const { mode } = spec;
     switch (mode) {
@@ -586,6 +639,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectWithinRect(spec: any) {
     /*
       { mode: "within-rect", minX: 1, minY: 0, maxX: 3, maxY: 9 }
@@ -619,6 +673,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     * then the polygon test is applied
   */
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   selectWithinPolygon(spec: any) {
     /*
       { mode: "within-polygon", polygon: [ [x0, y0], ... ] }
@@ -674,6 +729,7 @@ export const DimTypes = {
   spatial: ImmutableSpatialDimension,
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function isArrayOrTypedArray(x: any) {
   return (
     Array.isArray(x) ||
@@ -683,6 +739,7 @@ function isArrayOrTypedArray(x: any) {
 }
 
 /* return bounding box of the polygon */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function polygonBoundingBox(polygon: any) {
   let minX = Number.MAX_VALUE;
   let minY = Number.MAX_VALUE;
@@ -707,6 +764,7 @@ function polygonBoundingBox(polygon: any) {
  *  @param {float} y - point y coordinate
  *  @type {boolean}
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function withinPolygon(polygon: any, x: any, y: any) {
   const n = polygon.length;
   let p = polygon[n - 1];

--- a/client/src/util/typedCrossfilter/positiveIntervals.ts
+++ b/client/src/util/typedCrossfilter/positiveIntervals.ts
@@ -16,9 +16,11 @@ class PositiveIntervals {
   //  1. no overlapping intervals
   //  2. sorted in order of interval min.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static canonicalize(A: any) {
     if (A.length <= 1) return A;
     const copy = A.slice();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     copy.sort((a: any, b: any) => a[0] - b[0]);
     const res = [];
     res.push(copy[0]);
@@ -38,10 +40,12 @@ class PositiveIntervals {
   // Return interval with values belonging to both A and B. Essentially
   // a set union operation.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static union(A: any, B: any) {
     return PositiveIntervals.canonicalize([...A, ...B]);
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static _flatten(A: any, B: any) {
     const points = []; /* point, A, start */
     for (let a = 0; a < A.length; a += 1) {
@@ -60,6 +64,7 @@ class PositiveIntervals {
   // A - B, ie, the interval with all values in A that are not in B.  Essentially
   // a set difference operation.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static difference(A: any, B: any) {
     // Corner cases
     if (A.length === 0 || B.length === 0) {
@@ -96,6 +101,7 @@ class PositiveIntervals {
   // Return interval with values belonging to A or B.  Essentially a set
   // intersection.
   //
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static intersection(A: any, B: any) {
     if (A.length === 0 || B.length === 0) {
       return [];

--- a/client/src/util/typedCrossfilter/sort.ts
+++ b/client/src/util/typedCrossfilter/sort.ts
@@ -10,11 +10,13 @@ import { isTypedArray, isFpTypedArray } from "../typeHelpers";
 /*
 Comparators for float sort.   -Infinity < finite < Infinity < NaN
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function lt(a: any, b: any) {
   if (Number.isNaN(b)) return !Number.isNaN(a);
   return a < b;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function gt(a: any, b: any) {
   if (Number.isNaN(a)) return !Number.isNaN(b);
   return a > b;
@@ -24,6 +26,7 @@ function gt(a: any, b: any) {
 insertion sort, used for small arrays (controlled by SMALL_ARRAY constant)
 */
 const SMALL_ARRAY = 32;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function insertionsort(a: any, lo: any, hi: any) {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
@@ -36,6 +39,7 @@ function insertionsort(a: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function insertionsortFloats(a: any, lo: any, hi: any) {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
@@ -48,6 +52,7 @@ function insertionsortFloats(a: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function insertionsortIndirect(a: any, s: any, lo: any, hi: any) {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
@@ -61,6 +66,7 @@ function insertionsortIndirect(a: any, s: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function insertionsortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
@@ -77,6 +83,7 @@ function insertionsortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
 /*
 Quicksort - used for larger arrays
 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function quicksort(a: any, lo: any, hi: any) {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsort(a, lo, hi);
@@ -107,6 +114,7 @@ function quicksort(a: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function quicksortFloats(a: any, lo: any, hi: any) {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortFloats(a, lo, hi);
@@ -137,6 +145,7 @@ function quicksortFloats(a: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function quicksortIndirect(a: any, s: any, lo: any, hi: any) {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortIndirect(a, s, lo, hi);
@@ -168,6 +177,7 @@ function quicksortIndirect(a: any, s: any, lo: any, hi: any) {
   return a;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function quicksortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortFloatsIndirect(a, s, lo, hi);
@@ -203,6 +213,7 @@ function quicksortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
 Convenience wrappers, handling optimization paths and default
 handlers for NaN comparisons.  Sorts in place.
 */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function sortArray(arr: any) {
   if (Array.isArray(arr)) {
     return quicksort(arr, 0, arr.length - 1);
@@ -217,6 +228,7 @@ export function sortArray(arr: any) {
   throw new Error("sortArray received unsupported object type");
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function sortIndex(index: any, source: any) {
   if (isFpTypedArray(source))
     return quicksortFloatsIndirect(index, source, 0, index.length - 1);
@@ -235,9 +247,13 @@ export function sortIndex(index: any, source: any) {
 //    Python: bisect.bisect_left()
 //
 function lowerBoundNonFloat(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -259,6 +275,7 @@ function lowerBoundNonFloat(
 // If the underlying array is a Float32Array or Float64Array, will enforce
 // the ordering -Infinity < finite < Infinity < NaN.
 //
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function lowerBoundFloat(valueArray: any, value: any, first: any, last: any) {
   let lfirst = first;
   let llast = last;
@@ -274,6 +291,7 @@ function lowerBoundFloat(valueArray: any, value: any, first: any, last: any) {
   return lfirst;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function lowerBound(valueArray: any, value: any, first: any, last: any) {
   if (isFpTypedArray(valueArray)) {
     return lowerBoundFloat(valueArray, value, first, last);
@@ -284,10 +302,15 @@ export function lowerBound(valueArray: any, value: any, first: any, last: any) {
 // Inlined performance optimization - used to indirect through a sort map.
 //
 function lowerBoundNonFloatIndirect(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -305,10 +328,15 @@ function lowerBoundNonFloatIndirect(
 }
 
 function lowerBoundFloatIndirect(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -325,11 +353,17 @@ function lowerBoundFloatIndirect(
   return lfirst;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function lowerBoundIndirect(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   if (isFpTypedArray(valueArray)) {
@@ -350,9 +384,13 @@ export function lowerBoundIndirect(
 //    Python: bisect.bisect_right()
 //
 function upperBoundNonFloat(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -369,6 +407,7 @@ function upperBoundNonFloat(
   return lfirst;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function upperBoundFloat(valueArray: any, value: any, first: any, last: any) {
   let lfirst = first;
   let llast = last;
@@ -384,6 +423,7 @@ function upperBoundFloat(valueArray: any, value: any, first: any, last: any) {
   return lfirst;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function upperBound(valueArray: any, value: any, first: any, last: any) {
   if (isFpTypedArray(valueArray)) {
     return upperBoundFloat(valueArray, value, first, last);
@@ -394,10 +434,15 @@ export function upperBound(valueArray: any, value: any, first: any, last: any) {
 // Inline performance optimization
 //
 function upperBoundNonFloatIndirect(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -415,10 +460,15 @@ function upperBoundNonFloatIndirect(
 }
 
 function upperBoundFloatIndirect(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   let lfirst = first;
@@ -435,11 +485,17 @@ function upperBoundFloatIndirect(
   return lfirst;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function upperBoundIndirect(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   indexArray: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   if (isFpTypedArray(valueArray)) {
@@ -455,10 +511,15 @@ export function upperBoundIndirect(
 // The same semantics/behavior as:
 //    C++: binary_search()
 //
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function binarySearch(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   valueArray: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   value: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   first: any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   last: any
 ) {
   const index = lowerBound(valueArray, value, first, last);

--- a/client/src/util/typedCrossfilter/util.ts
+++ b/client/src/util/typedCrossfilter/util.ts
@@ -7,6 +7,7 @@ import { rangeFill as fillRange } from "../range";
 
 // slice out of one array into another, using an index array
 //
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function sliceByIndex(src: any, index: any) {
   if (index === undefined || index === null) {
     return src;
@@ -18,6 +19,7 @@ export function sliceByIndex(src: any, index: any) {
   return dst;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function makeSortIndex(src: any) {
   const index = fillRange(new Uint32Array(src.length));
   sortIndex(index, src);


### PR DESCRIPTION
#### Reviewers
**Functional:**
@tihuan

---

## Changes
* Added @typescript-eslint/recommended config.
* Ran `suppress-eslint-errors` codemod  to add the corresponding error/warning suppressions.

## Background
1. Modified `suppress-eslint-errors` codemod to suppress errors/warnings in the format expected by our `eslint.js`.
2. Ran `suppress-eslint-errors` on the `__tests__`, `configuration` and `src` directories individually (with separate commits for each).
3. Manually fixed files mangled `suppress-eslint-errors`
4. Manually added rules skipped by `suppress-eslint-errors`.
