### PR TITLE
chore: Add global type file

### DIFF
--- a/client/src/common/types/entities.ts
+++ b/client/src/common/types/entities.ts
@@ -1,0 +1,1 @@
+// If a globally shared type or interface doesn't have a clear owner, put it here


### PR DESCRIPTION
Hey all! Adding this new folder and starter file for hosting global types and interfaces that don't have a clear owner file. When it makes sense to create a new file under `/common/types/*` we should do so!

Thank you 😄 

closes #2364