### PR TITLE
fix: thuang-fix-tsconfig-path

### DIFF
--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -37,7 +37,10 @@ module.exports = {
       jsx: true,
       generators: true,
     },
-    project: "./tsconfig.json",
+    // (thuang): Pairing with `tsconfigRootDir`, which points to the directory
+    // of eslint.js
+    project: "../../tsconfig.json",
+    tsconfigRootDir: __dirname,
   },
   rules: {
     "react/jsx-no-target-blank": "off",


### PR DESCRIPTION
Bruce was having issue with VS Code thinking the `tsconfig.json` file is one level up from the `client` folder, so explicitly setting the project path relative to `eslint.js` lives seems more reliable and works for both me and Bruce

@MillenniumFalconMechanic or @seve please help test your VS Code to see if you still get eslint's type hints 🙏 

Thanks so much!