### PR TITLE
fix: disable FE auth testing on compatibility tests

### DIFF
--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   JEST_ENV: prod
+  CXG_AUTH_TYPE: none
 
 jobs:
   docker-build:

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,11 +1,13 @@
 include ../common.mk
 
 ANNOTATIONS := $(if $(ANNOTATIONS),$(ANNOTATIONS),../backend/test/fixtures/pbmc3k-annotations.csv)
-GENE_SETS := $(if $(GENE_SETS),$(GENE_SETS),../backend/test/fixtures/pbmc3k-genesets.csv) 
+GENE_SETS := $(if $(GENE_SETS),$(GENE_SETS),../backend/test/fixtures/pbmc3k-genesets.csv)
 ANNOTATIONS_FILENAME := $(shell basename $(ANNOTATIONS))
 GENE_SETS_FILENAME := $(shell basename $(GENE_SETS))
 
 CXG_CONFIG := $(if $(CXG_CONFIG), $(CXG_CONFIG), ./__tests__/e2e/test_config.yaml)
+
+CXG_AUTH_TYPE := $(if $(CXG_AUTH_TYPE), $(CXG_AUTH_TYPE), "test")
 
 
 # Packaging
@@ -38,7 +40,7 @@ smoke-test:
 	start_server_and_test \
 		'CXG_OPTIONS="--config-file $(CXG_CONFIG)" $(MAKE) start-server' \
 		$(CXG_SERVER_PORT) \
-		'CXG_URL_BASE="http://localhost:$(CXG_SERVER_PORT)" CXG_AUTH_TYPE="test" npm run e2e -- --verbose false'
+		'CXG_URL_BASE="http://localhost:$(CXG_SERVER_PORT)" CXG_AUTH_TYPE=$(CXG_AUTH_TYPE) npm run e2e -- --verbose false'
 
 # start an instance of cellxgene and run the end-to-end annotations tests
 .PHONY: smoke-test-annotations

--- a/client/Makefile
+++ b/client/Makefile
@@ -5,9 +5,9 @@ GENE_SETS := $(if $(GENE_SETS),$(GENE_SETS),../backend/test/fixtures/pbmc3k-gene
 ANNOTATIONS_FILENAME := $(shell basename $(ANNOTATIONS))
 GENE_SETS_FILENAME := $(shell basename $(GENE_SETS))
 
-CXG_CONFIG := $(if $(CXG_CONFIG), $(CXG_CONFIG), ./__tests__/e2e/test_config.yaml)
+CXG_CONFIG := $(if $(CXG_CONFIG), $(CXG_CONFIG),./__tests__/e2e/test_config.yaml)
 
-CXG_AUTH_TYPE := $(if $(CXG_AUTH_TYPE), $(CXG_AUTH_TYPE), "test")
+CXG_AUTH_TYPE := $(if $(CXG_AUTH_TYPE), $(CXG_AUTH_TYPE),"test")
 
 
 # Packaging


### PR DESCRIPTION
Disable the frontend auth testing for compatibility tests as they are breaking, and we don't run auth on explorer anymore.