### PR TITLE
TS typing for Dataframe

### DIFF
--- a/client/__tests__/util/annoMatrix/annoMatrix.test.ts
+++ b/client/__tests__/util/annoMatrix/annoMatrix.test.ts
@@ -218,7 +218,7 @@ describe("AnnoMatrix", () => {
       );
       expect(base.getMatrixColumns("obs")).not.toContain("foo");
       expect(am1.getMatrixColumns("obs")).toContain("foo");
-      const foo = await am1.fetch("obs", "foo");
+      const foo: Dataframe = await am1.fetch("obs", "foo");
       expect(foo).toBeDefined();
       expect(foo).toBeInstanceOf(Dataframe);
       expect(foo).toHaveLength(am1.nObs);

--- a/client/__tests__/util/annoMatrix/annoMatrix.test.ts
+++ b/client/__tests__/util/annoMatrix/annoMatrix.test.ts
@@ -188,8 +188,10 @@ describe("AnnoMatrix", () => {
       (fetch as any)
         .once(serverMocks.annotationsObs(["n_genes"]))
         .once(serverMocks.annotationsObs(["n_genes"]));
-      const ng1 = await am1.fetch("obs", "n_genes");
-      const ng2 = await am2.fetch("obs", "n_genes");
+      const ng1 = (await am1.fetch("obs", "n_genes")) as Dataframe;
+      const ng2 = (await am2.fetch("obs", "n_genes")) as Dataframe;
+      expect(ng1).toBeDefined();
+      expect(ng2).toBeDefined();
       expect(ng1).toHaveLength(ng2.length);
       expect(ng1.colIndex.labels()).toEqual(ng2.colIndex.labels());
       expect(ng1.col("n_genes").asArray()).toEqual(

--- a/client/__tests__/util/annoMatrix/crossfilter.test.ts
+++ b/client/__tests__/util/annoMatrix/crossfilter.test.ts
@@ -133,7 +133,7 @@ describe("AnnoMatrixCrossfilter", () => {
         )
       );
 
-      const df = await annoMatrix.fetch("obs", "louvain");
+      const df: Dataframe = await annoMatrix.fetch("obs", "louvain");
       const values = df.col("louvain").asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
@@ -266,9 +266,12 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(xfltr).toBeDefined();
       expect(xfltr.countSelected()).toEqual(240);
 
-      const df = await annoMatrixSubset.fetch("obs", "louvain");
+      const df: Dataframe = (await annoMatrixSubset.fetch(
+        "obs",
+        "louvain"
+      )) as Dataframe;
       expect(df).toBeDefined();
-      const values = (df as Dataframe).col("louvain").asArray();
+      const values = df.col("louvain").asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
@@ -356,7 +359,7 @@ describe("AnnoMatrixCrossfilter", () => {
       ).toHaveLength(1);
 
       // check data update.
-      const df = await xfltr.annoMatrix.fetch("obs", "foo");
+      const df: Dataframe = await xfltr.annoMatrix.fetch("obs", "foo");
       expect(
         df
           .col("foo")

--- a/client/__tests__/util/annoMatrix/crossfilter.test.ts
+++ b/client/__tests__/util/annoMatrix/crossfilter.test.ts
@@ -12,6 +12,7 @@ import {
   AnnoMatrixObsCrossfilter,
   isubsetMask,
 } from "../../../src/annoMatrix";
+import { Dataframe } from "../../../src/util/dataframe";
 import { rangeFill } from "../../../src/util/range";
 
 enableFetchMocks();
@@ -266,7 +267,8 @@ describe("AnnoMatrixCrossfilter", () => {
       expect(xfltr.countSelected()).toEqual(240);
 
       const df = await annoMatrixSubset.fetch("obs", "louvain");
-      const values = df.col("louvain").asArray();
+      expect(df).toBeDefined();
+      const values = (df as Dataframe).col("louvain").asArray();
       const selected = xfltr.allSelectedMask();
       values.every(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
@@ -649,7 +651,7 @@ describe("AnnoMatrixCrossfilter", () => {
         values: ["purple"],
       });
       expect(xfltr2.countSelected()).toEqual(2);
-      expect(xfltr2.allSelectedLabels()).toEqual(Int32Array.from([0, 10]));
+      expect(xfltr2.allSelectedLabels()).toEqual(Array.from([0, 10]));
     });
 
     test("resetObsColumnValues", async () => {

--- a/client/__tests__/util/annoMatrix/serverMocks/routes.ts
+++ b/client/__tests__/util/annoMatrix/serverMocks/routes.ts
@@ -43,7 +43,6 @@ function getEncodedDataframe(colNames: any, length: any, colSchemas: any) {
   const colIndex = new KeyIndex(colNames);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   const columns = colSchemas.map((s: any) => makeMockColumn(s, length));
-  // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
   const df = new Dataframe([length, colNames.length], columns, null, colIndex);
   const body = encodeMatrixFBS(df);
   return body;
@@ -56,7 +55,6 @@ export function dataframeResponse(colNames: any, columns: any) {
     [columns[0].length, colNames.length],
     columns,
     null,
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
     colIndex
   );
   const body = encodeMatrixFBS(df);

--- a/client/__tests__/util/centroid.test.ts
+++ b/client/__tests__/util/centroid.test.ts
@@ -1,19 +1,19 @@
 import cloneDeep from "lodash.clonedeep";
 
+import { NumberArray } from "../../src/common/types/arraytypes";
 import calcCentroid from "../../src/util/centroid";
 import quantile from "../../src/util/quantile";
 import { matrixFBSToDataframe } from "../../src/util/stateManager/matrix";
 import * as REST from "./stateManager/sampleResponses";
 import { indexEntireSchema } from "../../src/util/stateManager/schemaHelpers";
 import { normalizeWritableCategoricalSchema } from "../../src/annoMatrix/normalize";
+import { Dataframe } from "../../src/util/dataframe";
 
 describe("centroid", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   let schema: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  let obsAnnotations: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  let obsLayout: any;
+  let obsAnnotations: Dataframe;
+  let obsLayout: Dataframe;
 
   beforeAll(() => {
     schema = indexEntireSchema(cloneDeep(REST.schema.schema));
@@ -43,8 +43,8 @@ describe("centroid", () => {
 
     // This expected result assumes that all cells belong in all categorical values inside of sample response
     const expectedResult = [
-      quantile([0.5], obsLayout.col("umap_0").asArray())[0],
-      quantile([0.5], obsLayout.col("umap_1").asArray())[0],
+      quantile([0.5], obsLayout.col("umap_0").asArray() as NumberArray)[0],
+      quantile([0.5], obsLayout.col("umap_1").asArray() as NumberArray)[0],
     ];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
@@ -68,8 +68,8 @@ describe("centroid", () => {
 
     // This expected result assumes that all cells belong in all categorical values inside of sample response
     const expectedResult = [
-      quantile([0.5], obsLayout.col("umap_0").asArray())[0],
-      quantile([0.5], obsLayout.col("umap_1").asArray())[0],
+      quantile([0.5], obsLayout.col("umap_0").asArray() as NumberArray)[0],
+      quantile([0.5], obsLayout.col("umap_1").asArray() as NumberArray)[0],
     ];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.

--- a/client/__tests__/util/dataframe/histogram.test.ts
+++ b/client/__tests__/util/dataframe/histogram.test.ts
@@ -6,11 +6,10 @@ describe("Dataframe column histogram", () => {
       [3, 3],
       [["n1", "n2", "n3"], ["c1", "c2", "c3"], new Int32Array([0, 1, 2])],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex(["name", "cat", "value"])
     );
 
-    const h1 = df.col("cat").histogram(df.col("name"));
+    const h1 = df.col("cat").histogramCategoricalBy(df.col("name"));
     expect(h1).toMatchObject(
       new Map([
         ["n1", new Map([["c1", 1]])],
@@ -19,7 +18,9 @@ describe("Dataframe column histogram", () => {
       ])
     );
     // memoized?
-    expect(df.col("cat").histogram(df.col("name"))).toMatchObject(h1);
+    expect(df.col("cat").histogramCategoricalBy(df.col("name"))).toMatchObject(
+      h1
+    );
   });
 
   test("continuous by categorical", () => {
@@ -27,11 +28,10 @@ describe("Dataframe column histogram", () => {
       [3, 3],
       [["n1", "n2", "n3"], ["c1", "c2", "c3"], new Int32Array([0, 1, 2])],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex(["name", "cat", "value"])
     );
 
-    const h1 = df.col("value").histogram(3, [0, 2], df.col("name"));
+    const h1 = df.col("value").histogramContinuousBy(3, [0, 2], df.col("name"));
     expect(h1).toMatchObject(
       new Map([
         ["n1", [1, 0, 0]],
@@ -40,9 +40,9 @@ describe("Dataframe column histogram", () => {
       ])
     );
     // memoized?
-    expect(df.col("value").histogram(3, [0, 2], df.col("name"))).toMatchObject(
-      h1
-    );
+    expect(
+      df.col("value").histogramContinuousBy(3, [0, 2], df.col("name"))
+    ).toMatchObject(h1);
   });
 
   test("categorical", () => {
@@ -50,11 +50,10 @@ describe("Dataframe column histogram", () => {
       [3, 3],
       [["n1", "n2", "n3"], ["c1", "c2", "c3"], new Int32Array([0, 1, 2])],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex(["name", "cat", "value"])
     );
 
-    const h1 = df.col("cat").histogram();
+    const h1 = df.col("cat").histogramCategorical();
     expect(h1).toMatchObject(
       new Map([
         ["c1", 1],
@@ -63,7 +62,7 @@ describe("Dataframe column histogram", () => {
       ])
     );
     // memoized?
-    expect(df.col("value").histogram(3, [0, 2])).toMatchObject(h1);
+    expect(df.col("cat").histogramCategorical()).toMatchObject(h1);
   });
 
   test("continuous", () => {
@@ -71,14 +70,13 @@ describe("Dataframe column histogram", () => {
       [3, 3],
       [["n1", "n2", "n3"], ["c1", "c2", "c3"], new Int32Array([0, 1, 2])],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex(["name", "cat", "value"])
     );
 
-    const h1 = df.col("value").histogram(3, [0, 2]);
+    const h1 = df.col("value").histogramContinuous(3, [0, 2]);
     expect(h1).toMatchObject([1, 1, 1]);
     // memoized?
-    expect(df.col("value").histogram(3, [0, 2])).toMatchObject(h1);
+    expect(df.col("value").histogramContinuous(3, [0, 2])).toMatchObject(h1);
   });
 
   test("continuous thesholds correct", () => {
@@ -88,20 +86,11 @@ describe("Dataframe column histogram", () => {
       [new Int32Array(vals), new Float32Array(vals)]
     );
 
-    expect(df.col(0).histogram(5, [0, 100])).toEqual([5, 1, 0, 0, 2]);
-    expect(df.col(1).histogram(5, [0, 100])).toEqual([5, 1, 0, 0, 2]);
-    expect(df.col(0).histogram(2, [0, 10])).toEqual([2, 2]);
-    expect(df.col(0).histogram(10, [0, 100])).toEqual([
-      3,
-      2,
-      1,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      2,
+    expect(df.col(0).histogramContinuous(5, [0, 100])).toEqual([5, 1, 0, 0, 2]);
+    expect(df.col(1).histogramContinuous(5, [0, 100])).toEqual([5, 1, 0, 0, 2]);
+    expect(df.col(0).histogramContinuous(2, [0, 10])).toEqual([2, 2]);
+    expect(df.col(0).histogramContinuous(10, [0, 100])).toEqual([
+      3, 2, 1, 0, 0, 0, 0, 0, 0, 2,
     ]);
   });
 });

--- a/client/__tests__/util/dataframe/summarize.test.ts
+++ b/client/__tests__/util/dataframe/summarize.test.ts
@@ -8,7 +8,7 @@ function float32Conversion(f: any) {
 describe("Dataframe column summary", () => {
   test("empty column test", () => {
     const df = Dataframe.Dataframe.create([0, 1], [[]]);
-    const summary = df.icol(0).summarize();
+    const summary = df.icol(0).summarizeCategorical();
     expect(summary).toEqual(
       expect.objectContaining({
         categorical: true,
@@ -31,7 +31,6 @@ describe("Dataframe column summary", () => {
         [1],
       ],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex([
         "name",
         "nameString",
@@ -42,7 +41,7 @@ describe("Dataframe column summary", () => {
       ])
     );
 
-    expect(df.icol(0).summarize()).toEqual(
+    expect(df.icol(0).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: ["n1"],
@@ -50,7 +49,7 @@ describe("Dataframe column summary", () => {
         numCategories: 1,
       })
     );
-    expect(df.icol(1).summarize()).toEqual(
+    expect(df.icol(1).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: ["hi"],
@@ -58,7 +57,7 @@ describe("Dataframe column summary", () => {
         numCategories: 1,
       })
     );
-    expect(df.icol(2).summarize()).toEqual(
+    expect(df.icol(2).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: [true],
@@ -66,7 +65,7 @@ describe("Dataframe column summary", () => {
         numCategories: 1,
       })
     );
-    expect(df.icol(3).summarize()).toEqual(
+    expect(df.icol(3).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: float32Conversion(39.3),
@@ -76,7 +75,7 @@ describe("Dataframe column summary", () => {
         pinf: 0,
       })
     );
-    expect(df.icol(4).summarize()).toEqual(
+    expect(df.icol(4).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: 99,
@@ -86,7 +85,7 @@ describe("Dataframe column summary", () => {
         pinf: 0,
       })
     );
-    expect(df.icol(5).summarize()).toEqual(
+    expect(df.icol(5).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: [1],
@@ -108,7 +107,6 @@ describe("Dataframe column summary", () => {
         [1, false, "0"],
       ],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex([
         "name",
         "nameString",
@@ -119,7 +117,7 @@ describe("Dataframe column summary", () => {
       ])
     );
 
-    expect(df.icol(0).summarize()).toEqual(
+    expect(df.icol(0).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining(["n0", "n1", "n2"]),
@@ -131,7 +129,7 @@ describe("Dataframe column summary", () => {
         numCategories: 3,
       })
     );
-    expect(df.icol(1).summarize()).toEqual(
+    expect(df.icol(1).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining(["hi", "bye"]),
@@ -142,7 +140,7 @@ describe("Dataframe column summary", () => {
         numCategories: 2,
       })
     );
-    expect(df.icol(2).summarize()).toEqual(
+    expect(df.icol(2).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining([true, false]),
@@ -153,7 +151,7 @@ describe("Dataframe column summary", () => {
         numCategories: 2,
       })
     );
-    expect(df.icol(3).summarize()).toEqual(
+    expect(df.icol(3).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: 0,
@@ -163,7 +161,7 @@ describe("Dataframe column summary", () => {
         pinf: 0,
       })
     );
-    expect(df.icol(4).summarize()).toEqual(
+    expect(df.icol(4).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: 99,
@@ -173,7 +171,7 @@ describe("Dataframe column summary", () => {
         pinf: 0,
       })
     );
-    expect(df.icol(5).summarize()).toEqual(
+    expect(df.icol(5).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining([1, false, "0"]),
@@ -205,7 +203,6 @@ describe("Dataframe column summary", () => {
         [1, false, "0", "0"],
       ],
       null,
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
       new Dataframe.KeyIndex([
         "name",
         "nameString",
@@ -216,7 +213,7 @@ describe("Dataframe column summary", () => {
       ])
     );
 
-    expect(df.icol(0).summarize()).toEqual(
+    expect(df.icol(0).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining(["n0", "n1", "n2"]),
@@ -228,7 +225,7 @@ describe("Dataframe column summary", () => {
         numCategories: 3,
       })
     );
-    expect(df.icol(1).summarize()).toEqual(
+    expect(df.icol(1).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining(["hi", "bye"]),
@@ -239,7 +236,7 @@ describe("Dataframe column summary", () => {
         numCategories: 2,
       })
     );
-    expect(df.icol(2).summarize()).toEqual(
+    expect(df.icol(2).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining([true, false]),
@@ -250,7 +247,7 @@ describe("Dataframe column summary", () => {
         numCategories: 2,
       })
     );
-    expect(df.icol(3).summarize()).toEqual(
+    expect(df.icol(3).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: float32Conversion(39.3),
@@ -260,7 +257,7 @@ describe("Dataframe column summary", () => {
         pinf: 1,
       })
     );
-    expect(df.icol(4).summarize()).toEqual(
+    expect(df.icol(4).summarizeContinuous()).toEqual(
       expect.objectContaining({
         categorical: false,
         min: 99,
@@ -270,7 +267,7 @@ describe("Dataframe column summary", () => {
         pinf: 0,
       })
     );
-    expect(df.icol(5).summarize()).toEqual(
+    expect(df.icol(5).summarizeCategorical()).toEqual(
       expect.objectContaining({
         categorical: true,
         categories: expect.arrayContaining([1, false, "0"]),

--- a/client/__tests__/util/stateManager/colorHelpers.test.ts
+++ b/client/__tests__/util/stateManager/colorHelpers.test.ts
@@ -81,7 +81,6 @@ describe("categorical color helpers", () => {
         ),
     ],
     null,
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
     new Dataframe.KeyIndex(["continuousColumn", "categoricalColumn"])
   );
 

--- a/client/__tests__/util/stateManager/fbs.test.ts
+++ b/client/__tests__/util/stateManager/fbs.test.ts
@@ -24,7 +24,6 @@ describe("encode/decode", () => {
     expect(dfA.columns).toEqual(columns);
 
     const colIndex = new KeyIndex(["a", "b", "c", "d"]);
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'KeyIndex' is not assignable to p... Remove this comment to see the full error message
     const dfWithColIdx = new Dataframe([3, 4], columns, null, colIndex);
     const dfB = decodeMatrixFBS(encodeMatrixFBS(dfWithColIdx));
     expect([dfB.nRows, dfB.nCols]).toEqual(dfWithColIdx.dims);

--- a/client/src/actions/geneset.ts
+++ b/client/src/actions/geneset.ts
@@ -21,90 +21,90 @@ The behavior manifest in these action creators:
 Note that crossfilter indices are lazy created, as needed.
 */
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export const genesetDelete = (genesetName: any) => (
+import { Dataframe } from "../util/dataframe";
+
+export const genesetDelete =
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  const state = getState();
-  const { genesets } = state;
-  const gs = genesets?.genesets?.get(genesetName) ?? {};
-  const geneSymbols = Array.from(gs.genes.keys());
-  const obsCrossfilter = dropGeneset(dispatch, state, genesetName, geneSymbols);
-  if (genesetName === state.colors.colorAccessor) {
+  (genesetName: any) => (dispatch: any, getState: any) => {
+    const state = getState();
+    const { genesets } = state;
+    const gs = genesets?.genesets?.get(genesetName) ?? {};
+    const geneSymbols = Array.from(gs.genes.keys());
+    const obsCrossfilter = dropGeneset(
+      dispatch,
+      state,
+      genesetName,
+      geneSymbols
+    );
+    if (genesetName === state.colors.colorAccessor) {
+      dispatch({
+        type: "reset colorscale",
+      });
+    }
     dispatch({
-      type: "reset colorscale",
+      type: "geneset: delete",
+      genesetName,
+      obsCrossfilter,
+      annoMatrix: obsCrossfilter.annoMatrix,
     });
-  }
-  dispatch({
-    type: "geneset: delete",
-    genesetName,
-    obsCrossfilter,
-    annoMatrix: obsCrossfilter.annoMatrix,
-  });
-};
+  };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export const genesetAddGenes = (genesetName: any, genes: any) => async (
+export const genesetAddGenes =
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  const state = getState();
-  const { obsCrossfilter: prevObsCrossfilter, annoMatrix } = state;
-  const { schema } = annoMatrix;
-  const varIndex = schema.annotations.var.index;
-  const df = await annoMatrix.fetch("var", varIndex);
-  const geneNames = df.col(varIndex).asArray();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  genes = genes.reduce((acc: any, gene: any) => {
-    if (geneNames.indexOf(gene.geneSymbol) === -1) {
-      postUserErrorToast(
-        `${gene.geneSymbol} doesn't appear to be a valid gene name.`
-      );
-    } else acc.push(gene);
-    return acc;
-  }, []);
+  (genesetName: any, genes: any) => async (dispatch: any, getState: any) => {
+    const state = getState();
+    const { obsCrossfilter: prevObsCrossfilter, annoMatrix } = state;
+    const { schema } = annoMatrix;
+    const varIndex = schema.annotations.var.index;
+    const df: Dataframe = await annoMatrix.fetch("var", varIndex);
+    const geneNames = df.col(varIndex).asArray();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+    genes = genes.reduce((acc: any, gene: any) => {
+      if (geneNames.indexOf(gene.geneSymbol) === -1) {
+        postUserErrorToast(
+          `${gene.geneSymbol} doesn't appear to be a valid gene name.`
+        );
+      } else acc.push(gene);
+      return acc;
+    }, []);
 
-  const obsCrossfilter = dropGenesetSummaryDimension(
-    prevObsCrossfilter,
-    state,
-    genesetName
-  );
-  dispatch({
-    type: "continuous metadata histogram cancel",
-    continuousNamespace: { isGeneSetSummary: true },
-    selection: genesetName,
-  });
-  return dispatch({
-    type: "geneset: add genes",
-    genesetName,
-    genes,
-    obsCrossfilter,
-    annoMatrix: obsCrossfilter.annoMatrix,
-  });
-};
+    const obsCrossfilter = dropGenesetSummaryDimension(
+      prevObsCrossfilter,
+      state,
+      genesetName
+    );
+    dispatch({
+      type: "continuous metadata histogram cancel",
+      continuousNamespace: { isGeneSetSummary: true },
+      selection: genesetName,
+    });
+    return dispatch({
+      type: "geneset: add genes",
+      genesetName,
+      genes,
+      obsCrossfilter,
+      annoMatrix: obsCrossfilter.annoMatrix,
+    });
+  };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export const genesetDeleteGenes = (genesetName: any, geneSymbols: any) => (
+export const genesetDeleteGenes =
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  const state = getState();
-  const obsCrossfilter = dropGeneset(dispatch, state, genesetName, geneSymbols);
-  return dispatch({
-    type: "geneset: delete genes",
-    genesetName,
-    geneSymbols,
-    obsCrossfilter,
-    annoMatrix: obsCrossfilter.annoMatrix,
-  });
-};
+  (genesetName: any, geneSymbols: any) => (dispatch: any, getState: any) => {
+    const state = getState();
+    const obsCrossfilter = dropGeneset(
+      dispatch,
+      state,
+      genesetName,
+      geneSymbols
+    );
+    return dispatch({
+      type: "geneset: delete genes",
+      genesetName,
+      geneSymbols,
+      obsCrossfilter,
+      annoMatrix: obsCrossfilter.annoMatrix,
+    });
+  };
 
 /*
 Private

--- a/client/src/annoMatrix/annoMatrix.ts
+++ b/client/src/annoMatrix/annoMatrix.ts
@@ -248,7 +248,7 @@ export default class AnnoMatrix {
     1. Fetch the "n_genes" column the "obs":
 
 			const df = await fetch("obs", "n_genes")
-      console.log("Largest number of genes is: ", df.summarize().max);
+      console.log("Largest number of genes is: ", df.summarizeContinuous().max);
 
     2. Fetch two separate columns from obs.  Returns a single dataframe containing
        the columns:

--- a/client/src/annoMatrix/annoMatrix.ts
+++ b/client/src/annoMatrix/annoMatrix.ts
@@ -219,7 +219,7 @@ export default class AnnoMatrix {
    **/
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  fetch(field, q) {
+  fetch(field, q): Dataframe {
     /*
 		Return the given query on a single matrix field as a single dataframe.
 		Currently supports ONLY full column query.
@@ -278,7 +278,7 @@ export default class AnnoMatrix {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  prefetch(field, q) {
+  prefetch(field, q): void {
     /*
 		Start a data fetch & cache fill.  Identical to fetch() except it does
 		not return a value.
@@ -287,7 +287,6 @@ export default class AnnoMatrix {
     overall component rendering latency.
 		*/
     this._fetch(field, q);
-    return undefined;
   }
 
   /**
@@ -494,8 +493,8 @@ Return cache keys for columns associated with this query.  May return
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'field' implicitly has an 'any' type.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  async _fetch(field, q) {
-    if (!AnnoMatrix.fields().includes(field)) return undefined;
+  async _fetch(field, q): Dataframe {
+    if (!AnnoMatrix.fields().includes(field)) return Dataframe.empty();
     const queries = Array.isArray(q) ? q : [q];
     queries.forEach(_queryValidate);
 

--- a/client/src/annoMatrix/loader.ts
+++ b/client/src/annoMatrix/loader.ts
@@ -196,7 +196,7 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
     const data = (this as any)._cache.obs.col(col).asArray().slice();
     for (let i = 0, len = rowIndices.length; i < len; i += 1) {
       const idx = rowIndices[i];
-      if (idx === undefined) throw new Error("Unknown row label");
+      if (idx === -1) throw new Error("Unknown row label");
       data[idx] = value;
     }
 
@@ -299,8 +299,8 @@ export default class AnnoMatrixLoader extends AnnoMatrix {
       default:
         throw new Error("Unknown field name");
     }
-
     const buffer = await promiseThrottle.priorityAdd(priority, doRequest);
+    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'unknown' is not assignable to parameter of type 'ArrayBuffer | ArrayBuffer[]'.... Remove this comment to see the full error message
     let result = matrixFBSToDataframe(buffer);
     if (!result || result.isEmpty()) throw Error("Unknown field/col");
 

--- a/client/src/annoMatrix/normalize.ts
+++ b/client/src/annoMatrix/normalize.ts
@@ -1,3 +1,4 @@
+import { Schema } from "../common/types/schema";
 import { _getColumnSchema, _isIndex } from "./schema";
 import catLabelSort from "../util/catLabelSort";
 import {
@@ -5,12 +6,11 @@ import {
   overflowCategoryLabel,
   globalConfig,
 } from "../globals";
-import { Dataframe } from "../util/dataframe";
+import { Dataframe, LabelType, DataframeColumn } from "../util/dataframe";
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function normalizeResponse(
   field: string,
-  schema: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  schema: Schema,
   response: Dataframe
 ): Dataframe {
   /**
@@ -65,8 +65,7 @@ export function normalizeResponse(
   return response;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-function castColumnToBoolean(df: Dataframe, label: any): Dataframe {
+function castColumnToBoolean(df: Dataframe, label: LabelType): Dataframe {
   const colData = df.col(label).asArray();
   const newColData = new Array(colData.length);
   for (let i = 0; i < colData.length; i += 1) newColData[i] = !!colData[i];
@@ -75,7 +74,10 @@ function castColumnToBoolean(df: Dataframe, label: any): Dataframe {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function normalizeWritableCategoricalSchema(colSchema: any, col: any) {
+export function normalizeWritableCategoricalSchema(
+  colSchema: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  col: DataframeColumn
+) {
   /*
   Ensure all enum writable / categorical schema have a categories array, that
   the categories array contains all unique values in the data array, AND that 
@@ -91,12 +93,11 @@ export function normalizeWritableCategoricalSchema(colSchema: any, col: any) {
   return colSchema;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export function normalizeCategorical(
   df: Dataframe,
-  colLabel: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  colLabel: LabelType,
   colSchema: any // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) {
+): Dataframe {
   /*
   If writable, ensure schema matches data and we have an unassigned label
 

--- a/client/src/annoMatrix/views.ts
+++ b/client/src/annoMatrix/views.ts
@@ -197,7 +197,7 @@ function _clipAnnoMatrix(field, colLabel, colSchema, colData, df, qmin, qmax) {
   if (qmax > 1) qmax = 1;
   if (qmin === 0 && qmax === 1) return colData;
 
-  const quantiles = df.col(colLabel).summarize().percentiles;
+  const quantiles = df.col(colLabel).summarizeContinuous().percentiles;
   const lower = quantiles[100 * qmin];
   const upper = quantiles[100 * qmax];
   const clippedData = clip(colData.slice(), lower, upper, Number.NaN);

--- a/client/src/common/types/arraytypes.ts
+++ b/client/src/common/types/arraytypes.ts
@@ -30,6 +30,22 @@ export type TypedArrayConstructor =
 
 export type AnyArray = Array<unknown> | TypedArray;
 
+export interface GenericArrayConstructor<T extends AnyArray> {
+  new (
+    ...args: ConstructorParameters<
+      typeof Int8Array &
+        typeof Uint8Array &
+        typeof Int16Array &
+        typeof Uint16Array &
+        typeof Int32Array &
+        typeof Uint32Array &
+        typeof Float32Array &
+        typeof Float64Array &
+        typeof Array
+    >
+  ): T;
+}
+
 export type NumberArray = Array<number> | TypedArray;
 
 export type Int8 = Int8Array[0];

--- a/client/src/components/brushableHistogram/index.tsx
+++ b/client/src/components/brushableHistogram/index.tsx
@@ -262,13 +262,13 @@ class HistogramBrush extends React.PureComponent {
 
     // if we are clipped, fetch both our value and our unclipped value,
     // as we need the absolute min/max range, not just the clipped min/max.
-    const summary = column.summarize();
+    const summary = column.summarizeContinuous();
     const range = [summary.min, summary.max];
 
     let unclippedRange = [...range];
     if (isClipped) {
       const parent = await annoMatrix.viewOf.fetch(...query);
-      const { min, max } = parent.icol(0).summarize();
+      const { min, max } = parent.icol(0).summarizeContinuous();
       unclippedRange = [min, max];
     }
 
@@ -320,7 +320,7 @@ class HistogramBrush extends React.PureComponent {
      recalculate expensive stuff, notably bins, summaries, etc.
     */
     const histogramCache = {}; /* maybe change this so that it computes ... */
-    const summary = col.summarize(); /* this is memoized, so it's free the second time you call it */
+    const summary = col.summarizeContinuous(); /* this is memoized, so it's free the second time you call it */
     const { min: domainMin, max: domainMax } = summary;
     const numBins = 40;
     const { TOP: topMargin, LEFT: leftMargin } = newMargin;
@@ -333,7 +333,7 @@ class HistogramBrush extends React.PureComponent {
       .range([leftMargin, leftMargin + newWidth]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-    (histogramCache as any).bins = col.histogram(numBins, [
+    (histogramCache as any).bins = col.histogramContinuous(numBins, [
       domainMin,
       domainMax,
     ]);

--- a/client/src/components/brushableHistogram/index.tsx
+++ b/client/src/components/brushableHistogram/index.tsx
@@ -11,6 +11,7 @@ import Histogram from "./histogram";
 import HistogramFooter from "./footer";
 import StillLoading from "./loading";
 import ErrorLoading from "./error";
+import { Dataframe } from "../../util/dataframe";
 
 const MARGIN = {
   LEFT: 10, // Space for 0 tick label on X axis
@@ -116,9 +117,12 @@ class HistogramBrush extends React.PureComponent {
     };
   };
 
-  // @ts-expect-error ts-migrate(6133) FIXME: 'selection' is declared but its value is never rea... Remove this comment to see the full error message
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  onBrushEnd = (selection: any, x: any) =>
+  onBrushEnd =
+    (
+      _selection: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+      x: any // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    ) =>
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
     () => {
       const {
@@ -257,7 +261,7 @@ class HistogramBrush extends React.PureComponent {
 
     const query = this.createQuery();
     // @ts-expect-error ts-migrate(2488) FIXME: Type 'any[] | null' must have a '[Symbol.iterator]... Remove this comment to see the full error message
-    const df = await annoMatrix.fetch(...query);
+    const df: Dataframe = await annoMatrix.fetch(...query);
     const column = df.icol(0);
 
     // if we are clipped, fetch both our value and our unclipped value,
@@ -267,7 +271,7 @@ class HistogramBrush extends React.PureComponent {
 
     let unclippedRange = [...range];
     if (isClipped) {
-      const parent = await annoMatrix.viewOf.fetch(...query);
+      const parent: Dataframe = await annoMatrix.viewOf.fetch(...query);
       const { min, max } = parent.icol(0).summarizeContinuous();
       unclippedRange = [min, max];
     }
@@ -320,7 +324,8 @@ class HistogramBrush extends React.PureComponent {
      recalculate expensive stuff, notably bins, summaries, etc.
     */
     const histogramCache = {}; /* maybe change this so that it computes ... */
-    const summary = col.summarizeContinuous(); /* this is memoized, so it's free the second time you call it */
+    const summary =
+      col.summarizeContinuous(); /* this is memoized, so it's free the second time you call it */
     const { min: domainMin, max: domainMax } = summary;
     const numBins = 40;
     const { TOP: topMargin, LEFT: leftMargin } = newMargin;

--- a/client/src/components/categorical/category/index.tsx
+++ b/client/src/components/categorical/category/index.tsx
@@ -26,6 +26,7 @@ import {
   createColorQuery,
 } from "../../../util/stateManager/colorHelpers";
 import actions from "../../../actions";
+import { Dataframe } from "../../../util/dataframe";
 
 const LABEL_WIDTH = globals.leftSidebarWidth - 100;
 const ANNO_BUTTON_WIDTH = 50;
@@ -165,8 +166,20 @@ class Category extends React.PureComponent {
     };
   };
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async fetchData(annoMatrix: any, metadataField: any, colors: any) {
+  async fetchData(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    annoMatrix: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    metadataField: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    colors: any
+  ): Promise<
+    [
+      Dataframe,
+      ReturnType<typeof createCategorySummaryFromDfCol>,
+      Dataframe | null
+    ]
+  > {
     /*
     fetch our data and the color-by data if appropriate, and then build a summary
     of our category and a color table for the color-by annotation.
@@ -175,7 +188,7 @@ class Category extends React.PureComponent {
     const { colorAccessor, colorMode } = colors;
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'genesets' does not exist on type 'Readon... Remove this comment to see the full error message
     const { genesets } = this.props;
-    let colorDataPromise = Promise.resolve(null);
+    let colorDataPromise: Promise<Dataframe | null> = Promise.resolve(null);
     if (colorAccessor) {
       const query = createColorQuery(
         colorMode,
@@ -185,10 +198,10 @@ class Category extends React.PureComponent {
       );
       if (query) colorDataPromise = annoMatrix.fetch(...query);
     }
-    const [categoryData, colorData] = await Promise.all([
-      annoMatrix.fetch("obs", metadataField),
-      colorDataPromise,
-    ]);
+    const [categoryData, colorData] = await Promise.all<
+      Dataframe,
+      Dataframe | null
+    >([annoMatrix.fetch("obs", metadataField), colorDataPromise]);
 
     // our data
     const column = categoryData.icol(0);
@@ -200,8 +213,8 @@ class Category extends React.PureComponent {
     return [categoryData, categorySummary, colorData];
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  updateColorTable(colorData: any) {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types -- - FIXME: disabled temporarily on migrate to TS.
+  updateColorTable(colorData: Dataframe|null) {
     // color table, which may be null
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
     const { schema, colors, metadataField } = this.props;

--- a/client/src/components/categorical/value/index.tsx
+++ b/client/src/components/categorical/value/index.tsx
@@ -25,6 +25,7 @@ import actions from "../../../actions";
 import MiniHistogram from "../../miniHistogram";
 import MiniStackedBar from "../../miniStackedBar";
 import { CategoryCrossfilterContext } from "../categoryContext";
+import { Dataframe, ContinuousHistogram } from "../../../util/dataframe";
 
 const STACKED_BAR_HEIGHT = 11;
 const STACKED_BAR_WIDTH = 100;
@@ -327,13 +328,11 @@ class CategoryValue extends React.Component<{}, State> {
   createHistogramBins = (
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     metadataField: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    categoryData: any,
+    categoryData: Dataframe,
     // @ts-expect-error ts-migrate(6133) FIXME: 'colorAccessor' is declared but its value is never... Remove this comment to see the full error message
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorAccessor: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    colorData: any,
+    colorData: Dataframe,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryValue: any,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
@@ -348,17 +347,17 @@ class CategoryValue extends React.Component<{}, State> {
     */
     const groupBy = categoryData.col(metadataField);
     const col = colorData.icol(0);
-    const range = col.summarize();
+    const range = col.summarizeContinuous();
 
-    const histogramMap = col.histogram(
+    const histogramMap = col.histogramContinuousBy(
       50,
       [range.min, range.max],
       groupBy
-    ); /* Because the signature changes we really need different names for histogram to differentiate signatures  */
+    ); 
 
     const bins = histogramMap.has(categoryValue)
-      ? histogramMap.get(categoryValue)
-      : new Array(50).fill(0);
+      ? histogramMap.get(categoryValue) as ContinuousHistogram
+      : new Array<number>(50).fill(0);
 
     const xScale = d3.scaleLinear().domain([0, bins.length]).range([0, width]);
 
@@ -377,12 +376,10 @@ class CategoryValue extends React.Component<{}, State> {
   createStackedGraphBins = (
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     metadataField: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    categoryData: any,
+    categoryData: Dataframe,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     colorAccessor: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    colorData: any,
+    colorData: Dataframe,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     categoryValue: any,
     // @ts-expect-error ts-migrate(6133) FIXME: 'colorTable' is declared but its value is never re... Remove this comment to see the full error message
@@ -401,7 +398,7 @@ class CategoryValue extends React.Component<{}, State> {
     const groupBy = categoryData.col(metadataField);
     const occupancyMap = colorData
       .col(colorAccessor)
-      .histogramCategorical(groupBy);
+      .histogramCategoricalBy(groupBy);
 
     const occupancy = occupancyMap.get(categoryValue);
 

--- a/client/src/components/categorical/value/occupancy.tsx
+++ b/client/src/components/categorical/value/occupancy.tsx
@@ -41,12 +41,12 @@ class Occupancy extends React.PureComponent {
     if (!this.canvas) return;
     const groupBy = categoryData.col(metadataField);
     const col = colorData.icol(0);
-    const range = col.summarize();
-    const histogramMap = col.histogram(
+    const range = col.summarizeContinuous();
+    const histogramMap = col.histogramContinuousBy(
       50,
       [range.min, range.max],
       groupBy
-    ); /* Because the signature changes we really need different names for histogram to differentiate signatures  */
+    ); 
     const bins = histogramMap.has(categoryValue)
       ? histogramMap.get(categoryValue)
       : new Array(50).fill(0);
@@ -100,7 +100,7 @@ class Occupancy extends React.PureComponent {
     const groupBy = categoryData.col(metadataField);
     const occupancyMap = colorData
       .col(colorAccessor)
-      .histogramCategorical(groupBy);
+      .histogramCategoricalBy(groupBy);
     const occupancy = occupancyMap.get(categoryValue);
     if (occupancy && occupancy.size > 0) {
       // not all categories have occupancy, so occupancy may be undefined.

--- a/client/src/components/categorical/value/occupancy.tsx
+++ b/client/src/components/categorical/value/occupancy.tsx
@@ -8,6 +8,8 @@ import {
   Position,
 } from "@blueprintjs/core";
 
+import { Dataframe } from "../../../util/dataframe";
+
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state) => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
@@ -21,23 +23,21 @@ class Occupancy extends React.PureComponent {
 
   _HEIGHT = 11;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  createHistogram = () => {
+  createHistogram = (): void => {
     /*
-          Knowing that colorScale is based off continous data,
-          createHistogram fetches the continous data in relation to the cells releveant to the catagory value.
-          It then seperates that data into 50 bins for drawing the mini-histogram
+          Knowing that colorScale is based off continuous data,
+          createHistogram fetches the continuous data in relation to the cells relevant to the category value.
+          It then separates that data into 50 bins for drawing the mini-histogram
         */
-    const {
+    const { metadataField, categoryData, colorData, categoryValue } = this
+      .props as {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
-      metadataField,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryData' does not exist on type 'Re... Remove this comment to see the full error message
-      categoryData,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorData' does not exist on type 'Reado... Remove this comment to see the full error message
-      colorData,
+      metadataField;
+      categoryData: Dataframe;
+      colorData: Dataframe;
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryValue' does not exist on type 'R... Remove this comment to see the full error message
-      categoryValue,
-    } = this.props;
+      categoryValue;
+    };
     if (!this.canvas) return;
     const groupBy = categoryData.col(metadataField);
     const col = colorData.icol(0);
@@ -46,9 +46,9 @@ class Occupancy extends React.PureComponent {
       50,
       [range.min, range.max],
       groupBy
-    ); 
+    );
     const bins = histogramMap.has(categoryValue)
-      ? histogramMap.get(categoryValue)
+      ? (histogramMap.get(categoryValue) as number[])
       : new Array(50).fill(0);
     const xScale = d3
       .scaleLinear()
@@ -71,29 +71,34 @@ class Occupancy extends React.PureComponent {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  createOccupancyStack = () => {
+  createOccupancyStack = (): void => {
     /*
           Knowing that the color scale is based off of catagorical data,
           createOccupancyStack obtains a map showing the number if cells per colored value
           Using the colorScale a stack of colored bars is drawn representing the map
          */
     const {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'metadataField' does not exist on type 'R... Remove this comment to see the full error message
       metadataField,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryData' does not exist on type 'Re... Remove this comment to see the full error message
       categoryData,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorAccessor' does not exist on type 'R... Remove this comment to see the full error message
       colorAccessor,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryValue' does not exist on type 'R... Remove this comment to see the full error message
       categoryValue,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorTable' does not exist on type 'Read... Remove this comment to see the full error message
       colorTable,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'schema' does not exist on type 'Readonly... Remove this comment to see the full error message
       schema,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'colorData' does not exist on type 'Reado... Remove this comment to see the full error message
       colorData,
-    } = this.props;
+    } = this.props as {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      metadataField: any;
+      categoryData: Dataframe;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      colorAccessor: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      categoryValue: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      colorTable: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
+      schema: any;
+      colorData: Dataframe;
+    };
     const { scale: colorScale } = colorTable;
     const ctx = this.canvas?.getContext("2d");
     if (!ctx) return;
@@ -119,7 +124,7 @@ class Occupancy extends React.PureComponent {
       let value;
       for (let i = 0, { length } = categoryValues; i < length; i += 1) {
         value = categoryValues[i];
-        o = occupancy.get(value);
+        o = occupancy.get(value) as number;
         scaledValue = x(o);
         ctx.fillStyle = o
           ? colorScale(categories.indexOf(value))

--- a/client/src/components/embedding/index.tsx
+++ b/client/src/components/embedding/index.tsx
@@ -121,6 +121,7 @@ const loadAllEmbeddingCounts = async ({ annoMatrix, available }: any) => {
   return available.map((name, idx) => ({
     embeddingName: name,
     embedding: embeddings[idx],
+    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'unknown' is not assignable...
     discreteCellIndex: getDiscreteCellEmbeddingRowIndex(embeddings[idx]),
   }));
 };

--- a/client/src/components/geneExpression/menus/addGenes.tsx
+++ b/client/src/components/geneExpression/menus/addGenes.tsx
@@ -19,6 +19,7 @@ import {
 
 import { memoize } from "../../../util/dataframe/util";
 import parseBulkGeneString from "../../../util/parseBulkGeneString";
+import { Dataframe } from "../../../util/dataframe";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const renderGene = (fuzzySortResult: any, { handleClick, modifiers }: any) => {
@@ -187,7 +188,7 @@ class AddGenes extends React.Component<{}, AddGenesState> {
 
       this.setState({ status: "pending" });
       try {
-        const df = await annoMatrix.fetch("var", varIndex);
+        const df: Dataframe = await annoMatrix.fetch("var", varIndex);
         this.setState({
           status: "success",
           geneNames: df.col(varIndex).asArray(),

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -9,6 +9,7 @@ import Gene from "./gene";
 
 import { postUserErrorToast } from "../framework/toasters";
 import actions from "../../actions";
+import { Dataframe, DataframeValue } from "../../util/dataframe";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const usePrevious = (value: any) => {
@@ -24,7 +25,7 @@ function QuickGene() {
   const dispatch = useDispatch();
 
   const [isExpanded, setIsExpanded] = useState(true);
-  const [geneNames, setGeneNames] = useState([]);
+  const [geneNames, setGeneNames] = useState([] as DataframeValue[]);
   const [, setStatus] = useState("pending");
 
   const { annoMatrix, userDefinedGenes, userDefinedGenesLoading } = useSelector(
@@ -50,9 +51,9 @@ function QuickGene() {
 
       setStatus("pending");
       try {
-        const df = await annoMatrix.fetch("var", varIndex);
+        const df: Dataframe = await annoMatrix.fetch("var", varIndex);
         setStatus("success");
-        setGeneNames(df.col(varIndex).asArray());
+        setGeneNames(df.col(varIndex).asArray() as DataframeValue[]);
       } catch (error) {
         setStatus("error");
         throw error;
@@ -95,7 +96,6 @@ function QuickGene() {
     const gene = g.target;
     if (userDefinedGenes.indexOf(gene) !== -1) {
       postUserErrorToast("That gene already exists");
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'any' is not assignable to parame... Remove this comment to see the full error message
     } else if (geneNames.indexOf(gene) === undefined) {
       postUserErrorToast("That doesn't appear to be a valid gene name.");
     } else {

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -26,6 +26,7 @@ import {
   flagSelected,
   flagHighlight,
 } from "../../util/glHelpers";
+import { Dataframe } from "../../util/dataframe";
 
 /*
 Simple 2D transforms control all point painting.  There are three:
@@ -558,7 +559,11 @@ class Graph extends React.Component<{}, GraphState> {
       handleEnd = this.handleLassoEnd.bind(this);
       handleCancel = this.handleLassoCancel.bind(this);
     }
-    const { svg: newToolSVG, tool, container } = setupSVGandBrushElements(
+    const {
+      svg: newToolSVG,
+      tool,
+      container,
+    } = setupSVGandBrushElements(
       selectionTool,
       handleStart,
       handleDrag,
@@ -626,7 +631,7 @@ class Graph extends React.Component<{}, GraphState> {
     colors: any,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointDilation: any
-  ) {
+  ): Promise<[Dataframe, Dataframe | null, Dataframe | null]> {
     /*
         fetch all data needed.  Includes:
           - the color by dataframe
@@ -634,22 +639,18 @@ class Graph extends React.Component<{}, GraphState> {
           - the point dilation dataframe
         */
     const { metadataField: pointDilationAccessor } = pointDilation;
-    const promises = [];
-    // layout
-    promises.push(annoMatrix.fetch("emb", layoutChoice.current));
-    // color
     const query = this.createColorByQuery(colors);
-    if (query) {
-      promises.push(annoMatrix.fetch(...query));
-    } else {
-      promises.push(Promise.resolve(null));
-    }
-    // point highlighting
-    if (pointDilationAccessor) {
-      promises.push(annoMatrix.fetch("obs", pointDilationAccessor));
-    } else {
-      promises.push(Promise.resolve(null));
-    }
+    const promises: [
+      Promise<Dataframe>,
+      Promise<Dataframe | null>,
+      Promise<Dataframe | null>
+    ] = [
+      annoMatrix.fetch("emb", layoutChoice.current),
+      query ? annoMatrix.fetch(...query) : Promise.resolve(null),
+      pointDilationAccessor
+        ? annoMatrix.fetch("obs", pointDilationAccessor)
+        : Promise.resolve(null),
+    ];
     return Promise.all(promises);
   }
 

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -592,8 +592,7 @@ class Graph extends React.Component<{}, GraphState> {
     const positions = this.computePointPositions(X, Y, modelTF);
     const colorTable = this.updateColorTable(colorsProp, colorDf);
     const colors = this.computePointColors(colorTable.rgb);
-    const { colorAccessor } = colorsProp;
-    const colorByData = colorDf?.col(colorAccessor)?.asArray();
+    const colorByData = colorDf?.icol(0)?.asArray();
     const {
       metadataField: pointDilationCategory,
       categoryField: pointDilationLabel,

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -400,30 +400,6 @@ class Scatterplot extends React.PureComponent<{}, State> {
           : Promise.resolve(null),
       ];
 
-    // const promises: Promise<Dataframe|null>[] = [];    // X and Y dimensions
-    // promises.push(
-    //   // @ts-expect-error ts-migrate(2488) FIXME: Type '(string | { where: { field: string; column: ... Remove this comment to see the full error message
-    //   annoMatrix.fetch(...this.createXQuery(scatterplotXXaccessor))
-    // );
-    // promises.push(
-    //   annoMatrix.fetch(...this.createXQuery(scatterplotYYaccessor))
-    // );
-
-    // // color
-    // const query = this.createColorByQuery(colors);
-    // if (query) {
-    //   promises.push(annoMatrix.fetch(...query));
-    // } else {
-    //   promises.push(Promise.resolve(null));
-    // }
-
-    // // point highlighting
-    // if (pointDilationAccessor) {
-    //   promises.push(annoMatrix.fetch("obs", pointDilationAccessor));
-    // } else {
-    //   promises.push(Promise.resolve(null));
-    // }
-
     return Promise.all<
       Dataframe,
       Dataframe,

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -22,7 +22,7 @@ import {
   flagSelected,
   flagHighlight,
 } from "../../util/glHelpers";
-import { DataframeColumn } from "../../util/dataframe";
+import { Dataframe, DataframeColumn } from "../../util/dataframe";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function createProjectionTF(viewportWidth: any, viewportHeight: any) {
@@ -277,17 +277,13 @@ class Scatterplot extends React.PureComponent<{}, State> {
       pointDilation,
     } = props.watchProps;
 
-    const [
-      expressionXDf,
-      expressionYDf,
-      colorDf,
-      pointDilationDf,
-    ] = await this.fetchData(
-      scatterplotXXaccessor,
-      scatterplotYYaccessor,
-      colorsProp,
-      pointDilation
-    );
+    const [expressionXDf, expressionYDf, colorDf, pointDilationDf] =
+      await this.fetchData(
+        scatterplotXXaccessor,
+        scatterplotYYaccessor,
+        colorsProp,
+        pointDilation
+      );
     const colorTable = this.updateColorTable(colorsProp, colorDf);
 
     const xCol = expressionXDf.icol(0);
@@ -384,37 +380,56 @@ class Scatterplot extends React.PureComponent<{}, State> {
     colors: any,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointDilation: any
-  ) {
+  ): Promise<
+    [Dataframe, Dataframe, Dataframe | null, Dataframe | null]
+  > {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix } = this.props;
     const { metadataField: pointDilationAccessor } = pointDilation;
 
-    const promises = [];
-    // X and Y dimensions
-    promises.push(
-      // @ts-expect-error ts-migrate(2488) FIXME: Type '(string | { where: { field: string; column: ... Remove this comment to see the full error message
-      annoMatrix.fetch(...this.createXQuery(scatterplotXXaccessor))
-    );
-    promises.push(
-      annoMatrix.fetch(...this.createXQuery(scatterplotYYaccessor))
-    );
-
-    // color
     const query = this.createColorByQuery(colors);
-    if (query) {
-      promises.push(annoMatrix.fetch(...query));
-    } else {
-      promises.push(Promise.resolve(null));
-    }
 
-    // point highlighting
-    if (pointDilationAccessor) {
-      promises.push(annoMatrix.fetch("obs", pointDilationAccessor));
-    } else {
-      promises.push(Promise.resolve(null));
-    }
+    const promises: [Dataframe, Dataframe, Dataframe | null, Dataframe | null] =
+      [
+        // @ts-expect-error ts-migrate(2488) FIXME: Type '(string | { where: { field: string; column: ... Remove this comment to see the full error message
+        annoMatrix.fetch(...this.createXQuery(scatterplotXXaccessor)),
+        annoMatrix.fetch(...this.createXQuery(scatterplotYYaccessor)),
+        query ? annoMatrix.fetch(...query) : Promise.resolve(null),
+        pointDilationAccessor
+          ? annoMatrix.fetch("obs", pointDilationAccessor)
+          : Promise.resolve(null),
+      ];
 
-    return Promise.all(promises);
+    // const promises: Promise<Dataframe|null>[] = [];    // X and Y dimensions
+    // promises.push(
+    //   // @ts-expect-error ts-migrate(2488) FIXME: Type '(string | { where: { field: string; column: ... Remove this comment to see the full error message
+    //   annoMatrix.fetch(...this.createXQuery(scatterplotXXaccessor))
+    // );
+    // promises.push(
+    //   annoMatrix.fetch(...this.createXQuery(scatterplotYYaccessor))
+    // );
+
+    // // color
+    // const query = this.createColorByQuery(colors);
+    // if (query) {
+    //   promises.push(annoMatrix.fetch(...query));
+    // } else {
+    //   promises.push(Promise.resolve(null));
+    // }
+
+    // // point highlighting
+    // if (pointDilationAccessor) {
+    //   promises.push(annoMatrix.fetch("obs", pointDilationAccessor));
+    // } else {
+    //   promises.push(Promise.resolve(null));
+    // }
+
+    return Promise.all<
+      Dataframe,
+      Dataframe,
+      Dataframe | null,
+      Dataframe | null
+    >(promises);
   }
 
   renderCanvas = renderThrottle(() => {

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -22,6 +22,7 @@ import {
   flagSelected,
   flagHighlight,
 } from "../../util/glHelpers";
+import { DataframeColumn } from "../../util/dataframe";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function createProjectionTF(viewportWidth: any, viewportHeight: any) {
@@ -33,9 +34,9 @@ function createProjectionTF(viewportWidth: any, viewportHeight: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function getScale(col: any, rangeMin: any, rangeMax: any) {
+function getScale(col: DataframeColumn, rangeMin: any, rangeMax: any) {
   if (!col) return null;
-  const { min, max } = col.summarize();
+  const { min, max } = col.summarizeContinuous();
   return d3.scaleLinear().domain([min, max]).range([rangeMin, rangeMax]);
 }
 const getXScale = memoize(getScale);

--- a/client/src/util/centroid.ts
+++ b/client/src/util/centroid.ts
@@ -1,5 +1,6 @@
 import quantile from "./quantile";
 import { memoize } from "./dataframe/util";
+import { Dataframe } from "./dataframe";
 import { unassignedCategoryLabel } from "../globals";
 import {
   createCategorySummaryFromDfCol,
@@ -27,12 +28,10 @@ const getCoordinatesByLabel = (
   schema: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  categoryDf: any,
+  categoryDf: Dataframe,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  layoutDf: any
+  layoutDf: Dataframe
 ) => {
   const coordsByCategoryLabel = new Map();
   // If the coloredBy is not a categorical col
@@ -50,11 +49,8 @@ const getCoordinatesByLabel = (
     schema.annotations.obsByName[categoryName]
   );
 
-  const {
-    isUserAnno,
-    categoryValueIndices,
-    categoryValueCounts,
-  } = categorySummary;
+  const { isUserAnno, categoryValueIndices, categoryValueCounts } =
+    categorySummary;
 
   // Iterate over all cells
   for (let i = 0, len = categoryArray.length; i < len; i += 1) {
@@ -114,12 +110,10 @@ const calcMedianCentroid = (
   schema: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  categoryDf: any,
+  categoryDf: Dataframe,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  layoutDf: any
+  layoutDf: Dataframe
 ) => {
   // generate a map describing the coordinates for each label within the given category
   const dataMap = getCoordinatesByLabel(
@@ -159,13 +153,11 @@ const hashMedianCentroid = (
   schema: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  categoryDf: any,
+  categoryDf: Dataframe,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   layoutChoice: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  layoutDf: any
-) => {
+  layoutDf: Dataframe
+): string => {
   const category = categoryDf.col(categoryName);
   const layoutDimNames = layoutChoice.currentDimNames;
   const layoutX = layoutDf.col(layoutDimNames[0]);

--- a/client/src/util/dataframe/cache.ts
+++ b/client/src/util/dataframe/cache.ts
@@ -9,12 +9,13 @@ This is a function that will maintain a least-recently created cache of Datafram
 objects.
 */
 
-import { memoize, AnyFunction } from "./util";
+import { AnyFunction } from "./types";
+import { memoize } from "./util";
 import Dataframe from "./dataframe";
 
 function hashDataframe(df: Dataframe): string {
   if (df.isEmpty()) return "";
-  return df.__columnsAccessor.map((c: any) => c.__id).join(",");
+  return df.__columnsAccessor.map((c) => c.__id).join(",");
 }
 
 function noop(df: Dataframe) {

--- a/client/src/util/dataframe/cache.ts
+++ b/client/src/util/dataframe/cache.ts
@@ -9,22 +9,19 @@ This is a function that will maintain a least-recently created cache of Datafram
 objects.
 */
 
-import { memoize } from "./util";
+import { memoize, AnyFunction } from "./util";
+import Dataframe from "./dataframe";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function hashDataframe(df: any) {
+function hashDataframe(df: Dataframe): string {
   if (df.isEmpty()) return "";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   return df.__columnsAccessor.map((c: any) => c.__id).join(",");
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function noop(df: any) {
+function noop(df: Dataframe) {
   return df;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-const dataframeMemo = (capacity = 100) =>
+const dataframeMemo = (capacity = 100): AnyFunction<Dataframe> =>
   memoize(noop, hashDataframe, capacity);
 
 export default dataframeMemo;

--- a/client/src/util/dataframe/cache.ts
+++ b/client/src/util/dataframe/cache.ts
@@ -9,7 +9,6 @@ This is a function that will maintain a least-recently created cache of Datafram
 objects.
 */
 
-import { AnyFunction } from "./types";
 import { memoize } from "./util";
 import Dataframe from "./dataframe";
 
@@ -18,11 +17,11 @@ function hashDataframe(df: Dataframe): string {
   return df.__columnsAccessor.map((c) => c.__id).join(",");
 }
 
-function noop(df: Dataframe) {
+function noop(df: Dataframe): Dataframe {
   return df;
 }
 
-const dataframeMemo = (capacity = 100): AnyFunction<Dataframe> =>
+const dataframeMemo = (capacity = 100): ((df: Dataframe) => Dataframe) =>
   memoize(noop, hashDataframe, capacity);
 
 export default dataframeMemo;

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -25,8 +25,7 @@ import {
   OffsetType,
   OffsetArray,
   LabelType,
-  ColLabelArray,
-  RowLabelArray,
+  LabelArray,
 } from "./types";
 
 /*
@@ -93,13 +92,16 @@ export type MapColumnsCallbackFn = (
   df: Dataframe
 ) => DataframeValueArray;
 
+/** @internal */
 const raiseIsNotContinuous = () => {
   throw TypeError("Column is not a continuous data type.");
 };
 
 class Dataframe {
+  /** @internal */
   __columns: DataframeValueArray[];
 
+  /** @internal */
   __columnsAccessor: DataframeColumn[] = [];
 
   __id: string;
@@ -111,6 +113,7 @@ class Dataframe {
   length: number;
 
   rowIndex: LabelIndex;
+
   /**
   Constructors & factories
   **/
@@ -160,6 +163,7 @@ class Dataframe {
     Object.freeze(this);
   }
 
+  /** @internal */
   static __errorChecks(
     dims: [number, number],
     columnarData: AnyArray[],
@@ -203,6 +207,7 @@ class Dataframe {
     }
   }
 
+  /** @internal */
   static __compileColumn(
     column: DataframeValueArray,
     getRowOffset: (label: LabelType) => OffsetType | -1,
@@ -324,6 +329,7 @@ class Dataframe {
     return get;
   }
 
+  /** @internal */
   __compile(accessors: (DataframeColumn | null)[]): void {
     /*
     Compile data accessors for each column.
@@ -430,8 +436,8 @@ class Dataframe {
      */
 
     // resolve the source and dest label names.
-    let srcLabels: ColLabelArray;
-    let dstLabels: ColLabelArray;
+    let srcLabels: LabelArray;
+    let dstLabels: LabelArray;
     if (!labels) {
       // combine all columns
       dstLabels = dataframe.colIndex.labels();
@@ -612,6 +618,7 @@ class Dataframe {
     return new Dataframe(dims, columnarData);
   }
 
+  /** @internal */
   __subset(
     newRowIndex: LabelIndex | null,
     newColIndex: LabelIndex | null
@@ -664,8 +671,8 @@ class Dataframe {
   }
 
   subset(
-    rowLabels: RowLabelArray | null,
-    colLabels: ColLabelArray | null,
+    rowLabels: LabelArray | null,
+    colLabels: LabelArray | null,
     withRowIndex?: LabelIndex | null
   ): Dataframe {
     /*

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -20,7 +20,7 @@ import {
 } from "./histogram";
 import {
   DataframeValue,
-  DataframeColumnarArray,
+  DataframeValueArray,
   DataframeColumn,
   OffsetType,
   OffsetArray,
@@ -88,17 +88,17 @@ interface DataframeConstructor {
 }
 
 export type MapColumnsCallbackFn = (
-  data: DataframeColumnarArray,
+  data: DataframeValueArray,
   idx: number,
   df: Dataframe
-) => DataframeColumnarArray;
+) => DataframeValueArray;
 
 const raiseIsNotContinuous = () => {
   throw TypeError("Column is not a continuous data type.");
 };
 
 class Dataframe {
-  __columns: DataframeColumnarArray[];
+  __columns: DataframeValueArray[];
 
   __columnsAccessor: DataframeColumn[] = [];
 
@@ -117,7 +117,7 @@ class Dataframe {
 
   constructor(
     dims: [number, number],
-    columnarData: DataframeColumnarArray[],
+    columnarData: DataframeValueArray[],
     rowIndex?: LabelIndex | null,
     colIndex?: LabelIndex | null,
     __columnsAccessor: (DataframeColumn | null)[] = [] // private interface
@@ -204,7 +204,7 @@ class Dataframe {
   }
 
   static __compileColumn(
-    column: DataframeColumnarArray,
+    column: DataframeValueArray,
     getRowOffset: (label: LabelType) => OffsetType | -1,
     getRowLabel: (offset: number) => LabelType | undefined
   ): DataframeColumn {
@@ -358,7 +358,7 @@ class Dataframe {
 
   withCol(
     label: LabelType,
-    colData: DataframeColumnarArray,
+    colData: DataframeValueArray,
     withRowIndex?: LabelIndex
   ): Dataframe {
     /*
@@ -481,7 +481,7 @@ class Dataframe {
       this.dims[1] + srcOffsets.length,
     ];
     const { rowIndex } = this;
-    const columns: DataframeColumnarArray[] = [
+    const columns: DataframeValueArray[] = [
       ...this.__columns,
       ...srcOffsets.map((i) => dataframe.__columns[i]),
     ];
@@ -566,10 +566,7 @@ class Dataframe {
     );
   }
 
-  replaceColData(
-    label: LabelType,
-    newColData: DataframeColumnarArray
-  ): Dataframe {
+  replaceColData(label: LabelType, newColData: DataframeValueArray): Dataframe {
     /*
     Accelerator for dropping a column then adding it again with same
     label and different values.
@@ -603,7 +600,7 @@ class Dataframe {
 
   static create(
     dims: [number, number],
-    columnarData: DataframeColumnarArray[]
+    columnarData: DataframeValueArray[]
   ): Dataframe {
     /*
     Create a dataframe from raw columnar data.  All column arrays

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -14,9 +14,11 @@ import {
   histogramCategorical as _histogramCategorical,
   histogramCategoricalBy as _histogramCategoricalBy,
   hashCategorical,
+  hashCategoricalBy,
   histogramContinuous as _histogramContinuous,
   histogramContinuousBy as _histogramContinuousBy,
   hashContinuous,
+  hashContinuousBy,
 } from "./histogram";
 import {
   DataframeValue,
@@ -26,6 +28,8 @@ import {
   OffsetArray,
   LabelType,
   LabelArray,
+  ContinuousHistogram,
+  ContinuousHistogramBy,
 } from "./types";
 
 /*
@@ -93,9 +97,9 @@ export type MapColumnsCallbackFn = (
 ) => DataframeValueArray;
 
 /** @internal */
-const raiseIsNotContinuous = () => {
+function raiseIsNotContinuous<R = void>(): R {
   throw TypeError("Column is not a continuous data type.");
-};
+}
 
 class Dataframe {
   /** @internal */
@@ -267,7 +271,7 @@ class Dataframe {
     /* test for row label inclusion in column */
     const has = function has(rlabel: LabelType) {
       const offset = getRowOffset(rlabel);
-      return offset !== undefined && offset >= 0 && offset < length;
+      return offset >= 0 && offset < length;
     };
 
     const ihas = function ihas(offset: OffsetType) {
@@ -305,17 +309,26 @@ class Dataframe {
     Create histogram bins for this column.  Memoized.
     */
     get.histogramContinuous = isContinuous
-      ? (bins: number, domain: [number, number]) =>
+      ? (bins: number, domain: [number, number]): ContinuousHistogram =>
           memoize(_histogramContinuous, hashContinuous)(get, bins, domain)
       : raiseIsNotContinuous;
     get.histogramContinuousBy = isContinuous
-      ? (bins: number, domain: [number, number], by: DataframeColumn) =>
-          memoize(_histogramContinuousBy, hashContinuous)(get, bins, domain, by)
+      ? (
+          bins: number,
+          domain: [number, number],
+          by: DataframeColumn
+        ): ContinuousHistogramBy =>
+          memoize(_histogramContinuousBy, hashContinuousBy)(
+            get,
+            bins,
+            domain,
+            by
+          )
       : raiseIsNotContinuous;
     get.histogramCategorical = () =>
       memoize(_histogramCategorical, hashCategorical)(get);
     get.histogramCategoricalBy = (by: DataframeColumn) =>
-      memoize(_histogramCategoricalBy, hashCategorical)(get, by);
+      memoize(_histogramCategoricalBy, hashCategoricalBy)(get, by);
 
     get.asArray = asArray;
     get.has = has;

--- a/client/src/util/dataframe/histogram.ts
+++ b/client/src/util/dataframe/histogram.ts
@@ -1,16 +1,27 @@
 /*
 Dataframe histogram
 */
-import { isTypedArray } from "../../common/types/arraytypes";
+import { NumberArray } from "../../common/types/arraytypes";
+import {
+  DataframeColumn,
+  ContinuousHistogram,
+  ContinuousHistogramBy,
+  CategoricalHistogram,
+  CategoricalHistogramBy,
+} from "./types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function _histogramContinuous(column: any, bins: any, min: any, max: any) {
+export function histogramContinuous(
+  column: DataframeColumn,
+  bins: number,
+  domain: [number, number]
+): ContinuousHistogram {
   const valBins = new Array(bins).fill(0);
   if (!column) {
     return valBins;
   }
+  const [min, max] = domain;
   const binWidth = (max - min) / bins;
-  const colArray = column.asArray();
+  const colArray: NumberArray = column.asArray() as NumberArray;
   for (let r = 0, len = colArray.length; r < len; r += 1) {
     const val = colArray[r];
     if (val <= max && val >= min) {
@@ -22,25 +33,20 @@ function _histogramContinuous(column: any, bins: any, min: any, max: any) {
   return valBins;
 }
 
-function _histogramContinuousBy(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  column: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  bins: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  min: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  max: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  by: any
-) {
+export function histogramContinuousBy(
+  column: DataframeColumn,
+  bins: number,
+  domain: [number, number],
+  by: DataframeColumn
+): ContinuousHistogramBy {
   const byMap = new Map();
   if (!column || !by) {
     return byMap;
   }
+  const [min, max] = domain;
   const binWidth = (max - min) / bins;
   const byArray = by.asArray();
-  const colArray = column.asArray();
+  const colArray = column.asArray() as NumberArray;
   for (let r = 0, len = colArray.length; r < len; r += 1) {
     const byBin = byArray[r];
     let valBins = byMap.get(byBin);
@@ -58,8 +64,9 @@ function _histogramContinuousBy(
   return byMap;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function _histogramCategorical(column: any) {
+export function histogramCategorical(
+  column: DataframeColumn
+): CategoricalHistogram {
   const valMap = new Map();
   if (!column) {
     return valMap;
@@ -76,8 +83,10 @@ function _histogramCategorical(column: any) {
   return valMap;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function _histogramCategoricalBy(column: any, by: any) {
+export function histogramCategoricalBy(
+  column: DataframeColumn,
+  by: DataframeColumn
+): CategoricalHistogramBy {
   const byMap = new Map();
   if (!column || !by) {
     return byMap;
@@ -102,23 +111,12 @@ function _histogramCategoricalBy(column: any, by: any) {
 }
 
 /*
-Count category occupancy.  Optional group-by category.
-*/
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function histogramCategorical(column: any, by: any) {
-  if (by && isTypedArray(by)) {
-    throw new Error("Group by column must be categorical");
-  }
-  return by
-    ? _histogramCategoricalBy(column, by)
-    : _histogramCategorical(column);
-}
-
-/*
 Memoization hash for histogramCategorical()
 */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function hashCategorical(column: any, by: any) {
+export function hashCategorical(
+  column: DataframeColumn,
+  by?: DataframeColumn
+): string {
   if (by) {
     return `${column.__id}:${by.__id}`;
   }
@@ -126,39 +124,14 @@ export function hashCategorical(column: any, by: any) {
 }
 
 /*
-Bin counts for continuous/scalar values, with optional group-by category.
-Values outside domain are ignored.
-*/
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function histogramContinuous(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  column: any,
-  bins = 40,
-  domain = [0, 1],
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  by: any
-) {
-  if (by && isTypedArray(by)) {
-    throw new Error("Group by column must be categorical");
-  }
-  const [min, max] = domain;
-  return by
-    ? _histogramContinuousBy(column, bins, min, max, by)
-    : _histogramContinuous(column, bins, min, max);
-}
-
-/*
 Memoization hash for histogramContinuous
 */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export function hashContinuous(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  column: any,
+  column: DataframeColumn,
   bins = "",
-  domain = [0, 0],
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  by: any
-) {
+  domain: [number, number] = [0, 0],
+  by?: DataframeColumn
+): string {
   const [min, max] = domain;
   if (by) {
     return `${column.__id}:${bins}:${min}:${max}:${by.__id}`;

--- a/client/src/util/dataframe/histogram.ts
+++ b/client/src/util/dataframe/histogram.ts
@@ -113,14 +113,15 @@ export function histogramCategoricalBy(
 /*
 Memoization hash for histogramCategorical()
 */
-export function hashCategorical(
-  column: DataframeColumn,
-  by?: DataframeColumn
-): string {
-  if (by) {
-    return `${column.__id}:${by.__id}`;
-  }
+export function hashCategorical(column: DataframeColumn): string {
   return `${column.__id}:`;
+}
+
+export function hashCategoricalBy(
+  column: DataframeColumn,
+  by: DataframeColumn
+): string {
+  return `${column.__id}:${by.__id}`;
 }
 
 /*
@@ -128,13 +129,19 @@ Memoization hash for histogramContinuous
 */
 export function hashContinuous(
   column: DataframeColumn,
-  bins = "",
-  domain: [number, number] = [0, 0],
-  by?: DataframeColumn
+  bins: number,
+  domain: [number, number]
 ): string {
   const [min, max] = domain;
-  if (by) {
-    return `${column.__id}:${bins}:${min}:${max}:${by.__id}`;
-  }
   return `${column.__id}::${bins}:${min}:${max}`;
+}
+
+export function hashContinuousBy(
+  column: DataframeColumn,
+  bins: number,
+  domain: [number, number],
+  by: DataframeColumn
+): string {
+  const [min, max] = domain;
+  return `${column.__id}:${bins}:${min}:${max}:${by.__id}`;
 }

--- a/client/src/util/dataframe/index.ts
+++ b/client/src/util/dataframe/index.ts
@@ -8,6 +8,8 @@ export {
 export { default as dataframeMemo } from "./cache";
 export type {
   LabelType,
+  DataframeValue,
+  DataframeValueArray,
   DataframeColumn,
   ContinuousHistogram,
   ContinuousHistogramBy,

--- a/client/src/util/dataframe/index.ts
+++ b/client/src/util/dataframe/index.ts
@@ -6,3 +6,14 @@ export {
   isLabelIndex,
 } from "./labelIndex";
 export { default as dataframeMemo } from "./cache";
+export type {
+  LabelType,
+  DataframeColumn,
+  ContinuousHistogram,
+  ContinuousHistogramBy,
+  CategoricalHistogram,
+  CategoricalHistogramBy,
+  ContinuousColumnSummary,
+  CategoricalColumnSummary,
+} from "./types";
+export type { LabelIndex } from "./labelIndex";

--- a/client/src/util/dataframe/summarize.ts
+++ b/client/src/util/dataframe/summarize.ts
@@ -5,92 +5,68 @@ TODO / XXX: for scalar/continuous data, this uses a naive method
 of computing quantiles.  Would be good to switch from sort to 
 partition at some point.
 */
-
+import {
+  AnyArray,
+  GenericArrayConstructor,
+} from "../../common/types/arraytypes";
+import { ContinuousColumnSummary, CategoricalColumnSummary } from "./types";
 import quantile from "../quantile";
 import { sortArray } from "../typedCrossfilter/sort";
-
-export type ContinuousColumnSummary = {
-  categorical: false;
-  min: number | undefined;
-  max: number | undefined;
-  nan: number;
-  pinf: number;
-  ninf: number;
-  percentiles: number[] | undefined;
-};
-
-export type CategoricalColumnSummary = {
-  categorical: true;
-  categories: (number | string | boolean)[];
-  categoryCounts: Map<number | string | boolean, number>;
-  numCategories: number;
-};
-
-export type ColumnSummary = ContinuousColumnSummary | CategoricalColumnSummary;
 
 // [ 0, 0.01, 0.02, ..., 1.0]
 const centileNames = new Array(101).fill(0).map((_v, idx) => idx / 100);
 
-export function summarizeContinuous(col: any): ContinuousColumnSummary {
-  if (col) {
-    let nan = 0;
-    let pinf = 0;
-    let ninf = 0;
+export function summarizeContinuous(col: AnyArray): ContinuousColumnSummary {
+  let nan = 0;
+  let pinf = 0;
+  let ninf = 0;
 
-    // -Inf < finite < Inf < NaN
-    const sortedCol = sortArray(new col.constructor(col));
+  // -Inf < finite < Inf < NaN
+  const sortedCol = sortArray(
+    new (col.constructor as GenericArrayConstructor<typeof col>)(col)
+  );
 
-    // count non-finites, which are at each end of sorted data
-    for (let i = sortedCol.length - 1; i >= 0; i -= 1) {
-      if (!Number.isNaN(sortedCol[i])) {
-        nan = sortedCol.length - i - 1;
-        break;
-      }
+  // count non-finites, which are at each end of sorted data
+  for (let i = sortedCol.length - 1; i >= 0; i -= 1) {
+    if (!Number.isNaN(sortedCol[i])) {
+      nan = sortedCol.length - i - 1;
+      break;
     }
-    for (let i = 0, l = sortedCol.length; i < l; i += 1) {
-      if (sortedCol[i] !== Number.NEGATIVE_INFINITY) {
-        ninf = i;
-        break;
-      }
-    }
-    for (let i = sortedCol.length - nan - 1; i >= 0; i -= 1) {
-      if (sortedCol[i] !== Number.POSITIVE_INFINITY) {
-        pinf = sortedCol.length - i - nan - 1;
-        break;
-      }
-    }
-
-    // compute percentiles on finite data ONLY
-    const sortedColFiniteOnly = sortedCol.slice(
-      ninf,
-      sortedCol.length - nan - pinf
-    );
-    const percentiles = quantile(centileNames, sortedColFiniteOnly, true);
-    const min = percentiles[0];
-    const max = percentiles[100];
-
-    return {
-      categorical: false,
-      min,
-      max,
-      nan,
-      pinf,
-      ninf,
-      percentiles,
-    };
   }
+  for (let i = 0, l = sortedCol.length; i < l; i += 1) {
+    if (sortedCol[i] !== Number.NEGATIVE_INFINITY) {
+      ninf = i;
+      break;
+    }
+  }
+  for (let i = sortedCol.length - nan - 1; i >= 0; i -= 1) {
+    if (sortedCol[i] !== Number.POSITIVE_INFINITY) {
+      pinf = sortedCol.length - i - nan - 1;
+      break;
+    }
+  }
+
+  // compute percentiles on finite data ONLY
+  const sortedColFiniteOnly = sortedCol.slice(
+    ninf,
+    sortedCol.length - nan - pinf
+  );
+  const percentiles = quantile(centileNames, sortedColFiniteOnly, true);
+  const min = percentiles[0];
+  const max = percentiles[100];
+
   return {
     categorical: false,
-    min: undefined,
-    max: undefined,
-    nan: 0,
-    pinf: 0,
-    ninf: 0,
-    percentiles: undefined,
+    min,
+    max,
+    nan,
+    pinf,
+    ninf,
+    percentiles,
   };
 }
 
-export function summarizeCategorical(col: any): CategoricalColumnSummary {
+export function summarizeCategorical(col: AnyArray): CategoricalColumnSummary {
   const categoryCounts = new Map();
   if (col) {
     for (let r = 0, l = col.length; r < l; r += 1) {

--- a/client/src/util/dataframe/types.ts
+++ b/client/src/util/dataframe/types.ts
@@ -47,7 +47,7 @@ export type CategoricalHistogramBy = Map<DataframeValue, CategoricalHistogram>;
 
 export type DataframeValue = number | string | boolean;
 
-export type DataframeColumnarArray = DataframeValue[] | TypedArray;
+export type DataframeValueArray = DataframeValue[] | TypedArray;
 
 export type DataframeColumnGetter = (
   label: LabelType
@@ -57,7 +57,7 @@ export interface DataframeColumn extends DataframeColumnGetter {
   readonly __id: string;
   isContinuous: boolean;
 
-  asArray: () => DataframeColumnarArray;
+  asArray: () => DataframeValueArray;
 
   summarizeContinuous: () => ContinuousColumnSummary;
   summarizeCategorical: () => CategoricalColumnSummary;

--- a/client/src/util/dataframe/types.ts
+++ b/client/src/util/dataframe/types.ts
@@ -137,9 +137,3 @@ export interface DataframeColumn extends DataframeColumnGetter {
    */
   iget: (offset: OffsetType) => DataframeValue | undefined;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
-export type AnyFunction<T = unknown> = (...args: any[]) => T;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
-export type HashArgsFunction = (...args: any[]) => string | number;

--- a/client/src/util/dataframe/types.ts
+++ b/client/src/util/dataframe/types.ts
@@ -1,0 +1,88 @@
+import { TypedArray } from "../../common/types/arraytypes";
+
+export type LabelType = number | string;
+
+type CommonProps<A, B> = {
+  [K in keyof A & keyof B]: A[K] | B[K];
+};
+export type GenericLabelArray<T> = CommonProps<Array<T>, Int32Array>;
+
+export type RowLabelArray = GenericLabelArray<number>;
+export type ColLabelArray = GenericLabelArray<number | string>;
+export type LabelArray = GenericLabelArray<number | string>;
+
+export type OffsetType = number;
+export type OffsetArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | number[];
+
+export type ContinuousColumnSummary = {
+  categorical: false;
+  min: number;
+  max: number;
+  nan: number;
+  pinf: number;
+  ninf: number;
+  percentiles: number[];
+};
+
+export type CategoricalColumnSummary = {
+  categorical: true;
+  categories: (number | string | boolean)[];
+  categoryCounts: Map<number | string | boolean, number>;
+  numCategories: number;
+};
+
+export type ColumnSummary = ContinuousColumnSummary | CategoricalColumnSummary;
+
+export type ContinuousHistogram = number[];
+export type ContinuousHistogramBy = Map<DataframeValue, ContinuousHistogram>;
+export type CategoricalHistogram = Map<DataframeValue, number>;
+export type CategoricalHistogramBy = Map<DataframeValue, CategoricalHistogram>;
+
+export type DataframeValue = number | string | boolean;
+
+export type DataframeColumnarArray = DataframeValue[] | TypedArray;
+
+export type DataframeColumnGetter = (
+  label: LabelType
+) => DataframeValue | undefined;
+
+export interface DataframeColumn extends DataframeColumnGetter {
+  readonly __id: string;
+  isContinuous: boolean;
+
+  asArray: () => DataframeColumnarArray;
+
+  summarizeContinuous: () => ContinuousColumnSummary;
+  summarizeCategorical: () => CategoricalColumnSummary;
+
+  histogramContinuous: (
+    bins: number,
+    domain: [number, number]
+  ) => ContinuousHistogram;
+  histogramContinuousBy: (
+    bins: number,
+    domain: [number, number],
+    by: DataframeColumn
+  ) => ContinuousHistogramBy;
+
+  histogramCategorical: () => CategoricalHistogram;
+  histogramCategoricalBy: (by: DataframeColumn) => CategoricalHistogramBy;
+
+  has: (label: LabelType) => boolean;
+  ihas: (offset: OffsetType) => boolean;
+  indexOf: (value: DataframeValue) => LabelType | undefined;
+  iget: (offset: OffsetType) => DataframeValue;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
+export type AnyFunction<T = unknown> = (...args: any[]) => T;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
+export type HashArgsFunction = (...args: any[]) => string | number;

--- a/client/src/util/dataframe/types.ts
+++ b/client/src/util/dataframe/types.ts
@@ -6,9 +6,6 @@ type CommonProps<A, B> = {
   [K in keyof A & keyof B]: A[K] | B[K];
 };
 export type GenericLabelArray<T> = CommonProps<Array<T>, Int32Array>;
-
-export type RowLabelArray = GenericLabelArray<number>;
-export type ColLabelArray = GenericLabelArray<number | string>;
 export type LabelArray = GenericLabelArray<number | string>;
 
 export type OffsetType = number;
@@ -53,32 +50,92 @@ export type DataframeColumnGetter = (
   label: LabelType
 ) => DataframeValue | undefined;
 
+/**
+ * Interface representing a Dataframe column.  Eg, returned by
+ * Dataframe.col().
+ */
 export interface DataframeColumn extends DataframeColumnGetter {
+  /**
+   * __id is unique per Dataframe and DataframeColumn, and is used as a memoization key.
+   */
   readonly __id: string;
+
+  /**
+   * Boolean indicating if the underlying data supports continuous operations, eg,
+   * summarizeContinuous.
+   */
   isContinuous: boolean;
 
+  /**
+   * Return underlying column data as an array-like object.
+   */
   asArray: () => DataframeValueArray;
 
+  /**
+   * Continuous data summary.  Will throw if !isContinuous.
+   */
   summarizeContinuous: () => ContinuousColumnSummary;
+
+  /**
+   * Categorical data summary.
+   */
   summarizeCategorical: () => CategoricalColumnSummary;
 
+  /**
+   * Continuous bin/histogram.  Will throw if !isContinuous.
+   * @param bins - array of bin boundary fractions, in range [0., 1.]
+   * @param domain - data domain [min, max]
+   */
   histogramContinuous: (
     bins: number,
     domain: [number, number]
   ) => ContinuousHistogram;
+
+  /**
+   * Continuous bin/histogram, grouped by another categorical column.  Will throw if !isContinuous.
+   * @param bins - array of bin boundary fractions, in range [0., 1.]
+   * @param domain - data domain [min, max]
+   * @param by - group by categorical column
+   */
   histogramContinuousBy: (
     bins: number,
     domain: [number, number],
     by: DataframeColumn
   ) => ContinuousHistogramBy;
 
+  /**
+   * Categorical bin/histogram.
+   */
   histogramCategorical: () => CategoricalHistogram;
+
+  /**
+   * Categorical bin/histogram grouped by another column.
+   * @param by - group by categorical column
+   */
   histogramCategoricalBy: (by: DataframeColumn) => CategoricalHistogramBy;
 
-  has: (label: LabelType) => boolean;
+  /**
+   * Return true if the column contains the row label.
+   */
+  has: (rlabel: LabelType) => boolean;
+
+  /**
+   * Return true if the column contains the row offset. Identical to
+   * (offset >= 0 && offset < dataframe.length)
+   */
   ihas: (offset: OffsetType) => boolean;
+
+  /**
+   * Return index of the value, as a _label_. Returns undefined if
+   * not present.  *NOTE*: unlike Array.indexOf, does not return an
+   * offset.
+   */
   indexOf: (value: DataframeValue) => LabelType | undefined;
-  iget: (offset: OffsetType) => DataframeValue;
+
+  /**
+   * Return the value at the given offset, or undefined if not present.
+   */
+  iget: (offset: OffsetType) => DataframeValue | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.

--- a/client/src/util/dataframe/util.ts
+++ b/client/src/util/dataframe/util.ts
@@ -1,12 +1,7 @@
 /*
 Private utility code for dataframe
 */
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any, does not require a fix.
-export type AnyFunction<T = unknown> = (...args: any[]) => T;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any, does not require a fix.
-export type HashArgsFunction = (...args: any[]) => string | number;
+import { AnyFunction, HashArgsFunction } from "./types";
 
 export function callOnceLazy<T>(f: AnyFunction<T>): AnyFunction<T> {
   /*
@@ -62,8 +57,8 @@ export function memoize<T>(
 }
 
 /**
-memoization helpers - just a global counter.
-**/
+ *memoization helpers - just a global counter.
+ */
 let __DataframeMemoId__ = 0;
 export function __getMemoId(): string {
   const id = __DataframeMemoId__;

--- a/client/src/util/dataframe/util.ts
+++ b/client/src/util/dataframe/util.ts
@@ -2,17 +2,20 @@
 Private utility code for dataframe
 */
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function callOnceLazy(f: any) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any, does not require a fix.
+export type AnyFunction<T = unknown> = (...args: any[]) => T;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any, does not require a fix.
+export type HashArgsFunction = (...args: any[]) => string | number;
+
+export function callOnceLazy<T>(f: AnyFunction<T>): AnyFunction<T> {
   /*
   call function once, and save the result, regardless of arguments (this is not
   the same as typical memoization).
   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  let value: any;
+  let value: T;
   let calledOnce = false;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  const result = function result(...args: any[]) {
+  const result = function result(...args: unknown[]): T {
     if (!calledOnce) {
       value = f(...args);
       calledOnce = true;
@@ -22,8 +25,11 @@ export function callOnceLazy(f: any) {
   return result;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
+export function memoize<T>(
+  fn: AnyFunction<T>,
+  hashFn: HashArgsFunction,
+  maxResultsCached = -1
+): AnyFunction<T> {
   /* 
   function memoization, with user-provided hash.  hashFn must return a
   key which will be unique as a Map key (ie, obeys "sameValueZero" algorithm
@@ -31,8 +37,7 @@ export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Key_equality
   */
   const cache = new Map();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  const wrap = function wrap(...args: any[]) {
+  const wrap = function wrap(...args: unknown[]) {
     const key = hashFn(...args);
     if (cache.has(key)) {
       return cache.get(key);
@@ -60,9 +65,8 @@ export function memoize(fn: any, hashFn: any, maxResultsCached = -1) {
 memoization helpers - just a global counter.
 **/
 let __DataframeMemoId__ = 0;
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function __getMemoId() {
+export function __getMemoId(): string {
   const id = __DataframeMemoId__;
   __DataframeMemoId__ += 1;
-  return id;
+  return id.toString();
 }

--- a/client/src/util/dataframe/util.ts
+++ b/client/src/util/dataframe/util.ts
@@ -1,18 +1,20 @@
 /*
 Private utility code for dataframe
 */
-import { AnyFunction, HashArgsFunction } from "./types";
 
-export function callOnceLazy<T>(f: AnyFunction<T>): AnyFunction<T> {
+export function callOnceLazy<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
+  T extends (...args: any[]) => any = (...args: any[]) => any
+>(fn: T): (...args: Parameters<T>) => ReturnType<T> {
   /*
   call function once, and save the result, regardless of arguments (this is not
   the same as typical memoization).
   */
-  let value: T;
+  let value: ReturnType<T>;
   let calledOnce = false;
-  const result = function result(...args: unknown[]): T {
+  const result = function result(...args: Parameters<T>): ReturnType<T> {
     if (!calledOnce) {
-      value = f(...args);
+      value = fn(...args);
       calledOnce = true;
     }
     return value;
@@ -20,11 +22,14 @@ export function callOnceLazy<T>(f: AnyFunction<T>): AnyFunction<T> {
   return result;
 }
 
-export function memoize<T>(
-  fn: AnyFunction<T>,
-  hashFn: HashArgsFunction,
+export function memoize<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- a legitimate use of any.
+  T extends (...args: any[]) => any = (...args: any[]) => any
+>(
+  fn: T,
+  hashFn: (...args: Parameters<T>) => string,
   maxResultsCached = -1
-): AnyFunction<T> {
+): (...args: Parameters<T>) => ReturnType<T> {
   /* 
   function memoization, with user-provided hash.  hashFn must return a
   key which will be unique as a Map key (ie, obeys "sameValueZero" algorithm
@@ -32,7 +37,7 @@ export function memoize<T>(
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Key_equality
   */
   const cache = new Map();
-  const wrap = function wrap(...args: unknown[]) {
+  const wrap = function wrap(...args: Parameters<T>): ReturnType<T> {
     const key = hashFn(...args);
     if (cache.has(key)) {
       return cache.get(key);

--- a/client/src/util/quantile.ts
+++ b/client/src/util/quantile.ts
@@ -24,6 +24,11 @@ export default function quantile(
   /*
 	start with the naive (sort) implementation.  Later, use a faster partition
 	*/
+
+  if (tarr.length === 0) {
+    return new Array(quantArr.length).fill(0);
+  }
+
   const Ctor: TypedArrayConstructor = tarr.constructor as TypedArrayConstructor;
   const arr = sorted ? tarr : sortArray(new Ctor(tarr)); // copy
   const len = arr.length;

--- a/client/src/util/quantile.ts
+++ b/client/src/util/quantile.ts
@@ -12,17 +12,21 @@ Arguments:
 
 */
 
+import { TypedArray, TypedArrayConstructor } from "../common/types/arraytypes";
+
 import { sortArray } from "./typedCrossfilter/sort";
 
-// @ts-expect-error ts-migrate(7006) FIXME: Parameter 'quantArr' implicitly has an 'any' type.
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export default function quantile(quantArr, tarr, sorted = false) {
+export default function quantile(
+  quantArr: number[],
+  tarr: TypedArray,
+  sorted = false
+): number[] {
   /*
 	start with the naive (sort) implementation.  Later, use a faster partition
 	*/
-  const arr = sorted ? tarr : sortArray(new tarr.constructor(tarr)); // copy
+  const Ctor: TypedArrayConstructor = tarr.constructor as TypedArrayConstructor;
+  const arr = sorted ? tarr : sortArray(new Ctor(tarr)); // copy
   const len = arr.length;
-  // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'q' implicitly has an 'any' type.
   return quantArr.map((q) => {
     if (q === 1) {
       return arr[len - 1];

--- a/client/src/util/quantile.ts
+++ b/client/src/util/quantile.ts
@@ -12,13 +12,13 @@ Arguments:
 
 */
 
-import { TypedArray, TypedArrayConstructor } from "../common/types/arraytypes";
+import { NumberArray, TypedArrayConstructor } from "../common/types/arraytypes";
 
 import { sortArray } from "./typedCrossfilter/sort";
 
 export default function quantile(
   quantArr: number[],
-  tarr: TypedArray,
+  tarr: NumberArray,
   sorted = false
 ): number[] {
   /*

--- a/client/src/util/stateManager/annotationsHelpers.ts
+++ b/client/src/util/stateManager/annotationsHelpers.ts
@@ -4,6 +4,7 @@ See also reducers/annotations.js
 */
 
 import { Schema } from "../../common/types/schema";
+import { Dataframe, LabelType } from "../dataframe";
 
 /*
 There are a number of state constraints assumed throughout the
@@ -57,9 +58,12 @@ export function isUserAnnotation(annoMatrix, name) {
   return _isUserAnnotation(annoMatrix.schema, name);
 }
 
-// @ts-expect-error ts-migrate(7006) FIXME: Parameter 'df' implicitly has an 'any' type.
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function allHaveLabelByMask(df, colName, label, mask) {
+export function allHaveLabelByMask(
+  df: Dataframe,
+  colName: LabelType,
+  label: string,
+  mask: Uint8Array
+): boolean {
   // return true if all rows as indicated by mask have the colname set to label.
   // False if not.
   const col = df.col(colName);

--- a/client/src/util/stateManager/colorHelpers.ts
+++ b/client/src/util/stateManager/colorHelpers.ts
@@ -7,6 +7,7 @@ import memoize from "memoize-one";
 import * as globals from "../../globals";
 import parseRGB from "../parseRGB";
 import { range } from "../range";
+import { Dataframe, LabelType } from "../dataframe";
 
 /*
 given a color mode & accessor, generate an annoMatrix query that will
@@ -95,18 +96,19 @@ Returns:
   }
 */
 function _createColorTable(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  colorMode: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  colorByAccessor: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  colorByData: any,
+  colorMode: string | null,
+  colorByAccessor: LabelType | null,
+  colorByData: Dataframe | null,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   schema: any,
   userColors = null
 ) {
+  if (colorMode === null || colorByData === null)
+    return defaultColors(schema.dataframe.nObs);
+
   switch (colorMode) {
     case "color by categorical metadata": {
+      if (colorByAccessor === null) return defaultColors(schema.dataframe.nObs);
       const data = colorByData.col(colorByAccessor).asArray();
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
       if (userColors && colorByAccessor in userColors) {
@@ -115,18 +117,19 @@ function _createColorTable(
       return createColorsByCategoricalMetadata(data, colorByAccessor, schema);
     }
     case "color by continuous metadata": {
+      if (colorByAccessor === null) return defaultColors(schema.dataframe.nObs);
       const col = colorByData.col(colorByAccessor);
-      const { min, max } = col.summarize();
+      const { min, max } = col.summarizeContinuous();
       return createColorsByContinuousMetadata(col.asArray(), min, max);
     }
     case "color by expression": {
       const col = colorByData.icol(0);
-      const { min, max } = col.summarize();
+      const { min, max } = col.summarizeContinuous();
       return createColorsByContinuousMetadata(col.asArray(), min, max);
     }
     case "color by geneset mean expression": {
       const col = colorByData.icol(0);
-      const { min, max } = col.summarize();
+      const { min, max } = col.summarizeContinuous();
       return createColorsByContinuousMetadata(col.asArray(), min, max);
     }
     default: {

--- a/client/src/util/stateManager/viewStackHelpers.ts
+++ b/client/src/util/stateManager/viewStackHelpers.ts
@@ -176,7 +176,6 @@ export function _getDiscreteCellEmbeddingRowIndex(embeddingDf) {
 }
 export const getDiscreteCellEmbeddingRowIndex = memoize(
   _getDiscreteCellEmbeddingRowIndex,
-  // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'df' implicitly has an 'any' type.
   (df) => df.__id
 );
 

--- a/client/src/util/stateManager/viewStackHelpers.ts
+++ b/client/src/util/stateManager/viewStackHelpers.ts
@@ -37,6 +37,7 @@ Views can be interogated for their type with the following:
 
 import { clip, isubsetMask, isubset } from "../../annoMatrix";
 import { memoize } from "../dataframe/util";
+import { Dataframe, LabelIndex } from "../dataframe";
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
@@ -101,7 +102,7 @@ export function _userResetSubsetAnnoMatrix(annoMatrix) {
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function _setEmbeddingSubset(annoMatrix, embeddingDf) {
+export function _setEmbeddingSubset(annoMatrix, embeddingDf: Dataframe) {
   /*
   Set the embedding subset view.  Only create a subset view for the embedding
   when it is needed, ie, there are NaN values in the embeddings.
@@ -141,8 +142,10 @@ export function _setEmbeddingSubset(annoMatrix, embeddingDf) {
   return annoMatrix;
 }
 
-// @ts-expect-error ts-migrate(6133) FIXME: 'baseRowIndex' is declared but its value is never ... Remove this comment to see the full error message
-function _getEmbeddingRowOffsets(baseRowIndex, embeddingDf) {
+function _getEmbeddingRowOffsets(
+  _baseRowIndex: LabelIndex,
+  embeddingDf: Dataframe
+) {
   /*
   given a dataframe containing an embedding:
     - if the embedding contains no NaN coordinates, return null
@@ -167,16 +170,16 @@ function _getEmbeddingRowOffsets(baseRowIndex, embeddingDf) {
   return offsets.subarray(0, numOffsets);
 }
 
-// @ts-expect-error ts-migrate(7006) FIXME: Parameter 'embeddingDf' implicitly has an 'any' ty... Remove this comment to see the full error message
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function _getDiscreteCellEmbeddingRowIndex(embeddingDf) {
+export function _getDiscreteCellEmbeddingRowIndex(
+  embeddingDf: Dataframe
+): LabelIndex {
   const idx = _getEmbeddingRowOffsets(embeddingDf.rowIndex, embeddingDf);
   if (idx === null) return embeddingDf.rowIndex;
   return embeddingDf.rowIndex.isubset(idx);
 }
 export const getDiscreteCellEmbeddingRowIndex = memoize(
   _getDiscreteCellEmbeddingRowIndex,
-  (df) => df.__id
+  (df: Dataframe) => df.__id
 );
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'annoMatrix' implicitly has an 'any' typ... Remove this comment to see the full error message

--- a/client/src/util/typedCrossfilter/crossfilter.ts
+++ b/client/src/util/typedCrossfilter/crossfilter.ts
@@ -12,9 +12,8 @@ import { makeSortIndex } from "./util";
 import { isAnyArray } from "../../common/types/arraytypes";
 
 class NotImplementedError extends Error {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  constructor(...params: any[]) {
-    super(...params);
+  constructor(msg: string) {
+    super(msg);
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {
@@ -63,8 +62,7 @@ export default class ImmutableTypedCrossfilter {
     Object.preventExtensions(this);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  size() {
+  size(): number {
     return this.data.length;
   }
 


### PR DESCRIPTION
This PR includes:
* TS typing for Dataframe
* a few minor bug fixes turned up by static type analysis
* Partial upstream typing of Dataframe users.  (the PR was getting big, so I will finish the rest of the Dataframe-consumer typing in another PR).

Notable API changes:
* summarize() and histogram() are no longer polymorphic and have separate functions for categorical, continuous and by-category (eg, summarizeContinuous(), summarizeCategorical(), etc).
* LabelIndex.getOffset() and getOffsets() returns -1 instead of undefined if the label is unknown. 

This is another partial fix for #2366 
