### PR TITLE
specify numpy range based on numba requirements

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -15,7 +15,7 @@ fsspec>=0.4.4,<0.8.0
 gunicorn>=20.0.4
 h5py>=3.0.0
 numba>=0.51.2
-numpy>=1.17.5
+numpy>=1.17.5,<1.21
 packaging>=20.0
 pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pandas/issues/35446
 PyYAML>=5.4  # CVE-2020-14343


### PR DESCRIPTION
I had to downgrade numpy based on requirements for Numba.  Console output below (on WSL / Ubuntu 20.04.2 LTS).  I created this PR based on what I assume the fix is, but I haven't tested.

```
$ pip install cellxgene
Processing /home/asu/.cache/pip/wheels/bb/39/54/725d6efd692887d6f583b7dfbaf5b60f401b47e512ac945607/cellxgene-1.0.0-py3-none-any.whl
Collecting Flask-Cors>=3.0.9
  Using cached Flask_Cors-3.0.10-py2.py3-none-any.whl (14 kB)
Collecting boto3>=1.12.18
  Using cached boto3-1.20.21-py3-none-any.whl (131 kB)
Collecting Flask>=1.0.2
  Using cached Flask-2.0.2-py3-none-any.whl (95 kB)
Collecting fsspec<0.8.0,>=0.4.4
  Using cached fsspec-0.7.4-py3-none-any.whl (75 kB)
Collecting gunicorn>=20.0.4
  Using cached gunicorn-20.1.0-py3-none-any.whl (79 kB)
Collecting numba>=0.51.2
  Using cached numba-0.54.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (3.3 MB)
Collecting flask-talisman>=0.7.0
  Using cached flask_talisman-0.8.1-py2.py3-none-any.whl (18 kB)
Collecting packaging>=20.0
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting Flask-RESTful>=0.3.6
  Using cached Flask_RESTful-0.3.9-py2.py3-none-any.whl (25 kB)
Collecting numpy>=1.17.5
  Using cached numpy-1.21.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.7 MB)
Processing /home/asu/.cache/pip/wheels/73/ba/de/68f564b32886959a5701b1a4714e11f7e9a983319eba4b7a99/flask_server_timing-0.1.2-py3-none-any.whl
Collecting Flask-Compress>=1.4.0
  Using cached Flask_Compress-1.10.1-py3-none-any.whl (7.9 kB)
Collecting h5py>=3.0.0
  Using cached h5py-3.6.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (4.5 MB)
Collecting flatbuffers<2.0.0,>=1.11.0
  Using cached flatbuffers-1.12-py2.py3-none-any.whl (15 kB)
Collecting flatten-dict>=0.2.0
  Using cached flatten_dict-0.4.2-py2.py3-none-any.whl (9.7 kB)
Collecting PyYAML>=5.4
  Using cached PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (701 kB)
Collecting s3fs==0.4.2
  Using cached s3fs-0.4.2-py3-none-any.whl (19 kB)
Collecting scipy>=1.4
  Using cached scipy-1.7.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (39.3 MB)
Collecting requests>=2.22.0
  Using cached requests-2.26.0-py2.py3-none-any.whl (62 kB)
Collecting anndata>=0.7.6
  Using cached anndata-0.7.8-py3-none-any.whl (91 kB)
Collecting pandas!=1.1,>=1.0
  Using cached pandas-1.3.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.5 MB)
Collecting click>=7.1.2
  Using cached click-8.0.3-py3-none-any.whl (97 kB)
Collecting Six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting botocore<1.24.0,>=1.23.21
  Using cached botocore-1.23.21-py3-none-any.whl (8.4 MB)
Collecting s3transfer<0.6.0,>=0.5.0
  Using cached s3transfer-0.5.0-py3-none-any.whl (79 kB)
Collecting jmespath<1.0.0,>=0.7.1
  Using cached jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting Werkzeug>=2.0
  Using cached Werkzeug-2.0.2-py3-none-any.whl (288 kB)
Collecting Jinja2>=3.0
  Using cached Jinja2-3.0.3-py3-none-any.whl (133 kB)
Collecting itsdangerous>=2.0
  Using cached itsdangerous-2.0.1-py3-none-any.whl (18 kB)
Requirement already satisfied: setuptools>=3.0 in ./cellxgene/lib/python3.8/site-packages (from gunicorn>=20.0.4->cellxgene) (44.0.0)
Collecting llvmlite<0.38,>=0.37.0rc1
  Using cached llvmlite-0.37.0-cp38-cp38-manylinux2014_x86_64.whl (26.3 MB)
Collecting pyparsing!=3.0.5,>=2.0.2
  Using cached pyparsing-3.0.6-py3-none-any.whl (97 kB)
Collecting pytz
  Using cached pytz-2021.3-py2.py3-none-any.whl (503 kB)
Collecting aniso8601>=0.82
  Using cached aniso8601-9.0.1-py2.py3-none-any.whl (52 kB)
Collecting brotli
  Using cached Brotli-1.0.9-cp38-cp38-manylinux1_x86_64.whl (357 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Collecting charset-normalizer~=2.0.0; python_version >= "3"
  Using cached charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5; python_version >= "3"
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
Collecting natsort
  Using cached natsort-8.0.0-py3-none-any.whl (37 kB)
Collecting xlrd<2.0
  Using cached xlrd-1.2.0-py2.py3-none-any.whl (103 kB)
Collecting python-dateutil>=2.7.3
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl (30 kB)
ERROR: numba 0.54.1 has requirement numpy<1.21,>=1.17, but you'll have numpy 1.21.4 which is incompatible.
Installing collected packages: Werkzeug, click, MarkupSafe, Jinja2, itsdangerous, Flask, Six, Flask-Cors, python-dateutil, jmespath, urllib3, botocore, s3transfer, boto3, fsspec, gunicorn, numpy, llvmlite, numba, flask-talisman, pyparsing, packaging, pytz, aniso8601, Flask-RESTful, flask-server-timing, brotli, Flask-Compress, h5py, flatbuffers, flatten-dict, PyYAML, s3fs, scipy, certifi, charset-normalizer, idna, requests, pandas, natsort, xlrd, anndata, cellxgene
Successfully installed Flask-2.0.2 Flask-Compress-1.10.1 Flask-Cors-3.0.10 Flask-RESTful-0.3.9 Jinja2-3.0.3 MarkupSafe-2.0.1 PyYAML-6.0 Six-1.16.0 Werkzeug-2.0.2 aniso8601-9.0.1 anndata-0.7.8 boto3-1.20.21 botocore-1.23.21 brotli-1.0.9 cellxgene-1.0.0 certifi-2021.10.8 charset-normalizer-2.0.9 click-8.0.3 flask-server-timing-0.1.2 flask-talisman-0.8.1 flatbuffers-1.12 flatten-dict-0.4.2 fsspec-0.7.4 gunicorn-20.1.0 h5py-3.6.0 idna-3.3 itsdangerous-2.0.1 jmespath-0.10.0 llvmlite-0.37.0 natsort-8.0.0 numba-0.54.1 numpy-1.21.4 packaging-21.3 pandas-1.3.4 pyparsing-3.0.6 python-dateutil-2.8.2 pytz-2021.3 requests-2.26.0 s3fs-0.4.2 s3transfer-0.5.0 scipy-1.7.3 urllib3-1.26.7 xlrd-1.2.0
$ cellxgene launch https://cellxgene-example-data.czi.technology/pbmc3k.h5ad
[cellxgene] Starting the CLI...
ImportError: Numba needs NumPy 1.20 or less
$ pip install numpy==1.20
Collecting numpy==1.20
  Using cached numpy-1.20.0-cp38-cp38-manylinux2010_x86_64.whl (15.4 MB)
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 1.21.4
    Uninstalling numpy-1.21.4:
      Successfully uninstalled numpy-1.21.4
Successfully installed numpy-1.20.0
$ cellxgene launch https://cellxgene-example-data.czi.technology/pbmc3k.h5ad
[cellxgene] Starting the CLI...
[cellxgene] Loading data from pbmc3k.h5ad.
[cellxgene] Warning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].

This is where adjacency matrices should go now.
[cellxgene] Warning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].

This is where adjacency matrices should go now.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
WARNING:root:Type float64 will be converted to 32 bit float and may lose precision.
[cellxgene] Launching! Please go to http://localhost:5005 in your browser.
[cellxgene] Type CTRL-C at any time to exit.
```