### PR TITLE
add cloud storage support for annotations

### DIFF
--- a/server/common/annotations/annotations.py
+++ b/server/common/annotations/annotations.py
@@ -57,7 +57,7 @@ class Annotations(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def write_gene_sets(self, gs, data_adaptor):
+    def write_gene_sets(self, gs, tid, data_adaptor):
         """Write the gene sets (gs) to a persistent storage such that it can later be read"""
         pass
 

--- a/server/common/utils/data_locator.py
+++ b/server/common/utils/data_locator.py
@@ -52,8 +52,10 @@ class DataLocator:
             self.fs = fsspec.filesystem(self.protocol)
 
     def __repr__(self):
-        return f"DataLocator(protocol={self.protocol}, cname={self.cname}, "
-        f"path={self.path}, uri_or_path={self.uri_or_path})"
+        return (
+            f"DataLocator(protocol={self.protocol}, cname={self.cname}, "
+            f"path={self.path}, uri_or_path={self.uri_or_path})"
+        )
 
     @staticmethod
     def _get_protocol_and_path(uri_or_path):
@@ -65,6 +67,10 @@ class DataLocator:
                 return protocol, path
         return None, uri_or_path
 
+    @staticmethod
+    def strip_protocol(uri_or_path):
+        return DataLocator._get_protocol_and_path(uri_or_path)[1]
+
     def exists(self):
         return self.fs.exists(self.cname)
 
@@ -72,7 +78,7 @@ class DataLocator:
         return self.fs.size(self.cname)
 
     def lastmodtime(self):
-        """ return datetime object representing last modification time, or None if unavailable """
+        """return datetime object representing last modification time, or None if unavailable"""
         info = self.fs.info(self.cname)
         if self.islocal() and info is not None:
             return datetime.fromtimestamp(info["mtime"])
@@ -92,8 +98,8 @@ class DataLocator:
     def isfile(self):
         return self.fs.isfile(self.cname)
 
-    def open(self, *args):
-        return self.fs.open(self.uri_or_path, *args)
+    def open(self, *args, **kwargs):
+        return self.fs.open(self.uri_or_path, *args, **kwargs)
 
     def islocal(self):
         return self.protocol is None or self.protocol == "file"


### PR DESCRIPTION
This PR is a re-codification of #2501, resolving a number of issues with that PR.  Many thanks to @arogozhnikov for the idea and draft PR.


#### Reviewers
**Functional:**  @ seve

**Readability:**  @seve

---

## Changes
* Port gene set and label annotation read/write routes to use DataLocator and the underlying fsspec package.
* In support of this, add a couple of new API surfaces to DataLocator
* Incorporate a couple of minor bug fixes noted in the original PR (eg, missing argument in annotations.py:write_gene_sets()) 
* Reformatting to current conventions