### PR TITLE
use fsspec.download for S3 artifacts + additional logging

### DIFF
--- a/server/common/utils/data_locator.py
+++ b/server/common/utils/data_locator.py
@@ -113,10 +113,9 @@ class DataLocator:
         # do our best to create a file with the same.
         ext = os.path.splitext(self.path)
         suffix = None if ext[1] == "" else ext[1]
-        with self.open() as src, tempfile.NamedTemporaryFile(prefix="cellxgene_", suffix=suffix, delete=False) as tmp:
-            tmp.write(src.read())
+        with tempfile.NamedTemporaryFile(prefix="cellxgene_", suffix=suffix, delete=False) as tmp:
+            self.fs.download(self.uri_or_path, tmp.name)
             tmp.close()
-            src.close()
             tmp_path = tmp.name
             return LocalFilePath(tmp_path, delete=True)
 

--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -173,11 +173,15 @@ class AnndataAdaptor(DataAdaptor):
             )
         except MemoryError:
             raise DatasetAccessError("Out of memory - file is too large for available memory.")
-        except Exception:
-            raise DatasetAccessError(
+        except Exception as e:
+            import traceback
+            message = (
                 "File not found or is inaccessible. File must be an .h5ad object. "
                 "Please check your input and try again."
-            )
+                )
+            if self.server_config.app__verbose:
+                message += f"\n{traceback.format_exc()}"
+            raise DatasetAccessError(message)
 
     def _validate_and_initialize(self):
         if anndata_version_is_pre_070():

--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -173,7 +173,7 @@ class AnndataAdaptor(DataAdaptor):
             )
         except MemoryError:
             raise DatasetAccessError("Out of memory - file is too large for available memory.")
-        except Exception as e:
+        except Exception:
             import traceback
             message = (
                 "File not found or is inaccessible. File must be an .h5ad object. "


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@bkmartinjr 

**Readability:** 

---

## Changes
- Replaces the old method to download a remote h5ad with `fsspec.download`, which should use buffering instead of loading the whole file in memoy.
- When the S3 download function fails, no additional logs were displayed. Now they are (in verbose mode).
