### PR TITLE
feat: annotate command improvements

### DIFF
--- a/server/cli/annotate.py
+++ b/server/cli/annotate.py
@@ -49,7 +49,6 @@ def annotate_args(func):
 )
 @click.option(
     "-o",
-    # "--output",
     "--output-h5ad-file",
     default="",
     help="The output H5AD file that will contain the generated annotation values.",
@@ -60,7 +59,7 @@ def annotate_args(func):
     default=False,
     is_flag=True,
     help="Overwrite the H5AD input file, adding the predicted annotation values. For safety, you must specify this "
-    "flag if the --output option is not specified.",
+    "flag if the --output-h5ad-file option is not specified.",
     show_default=True,
 )
 @click.option(

--- a/server/cli/annotate.py
+++ b/server/cli/annotate.py
@@ -4,7 +4,7 @@ import os.path
 import shlex
 import shutil
 import subprocess
-import sys
+from os.path import isfile
 from subprocess import STDOUT, PIPE
 from tempfile import NamedTemporaryFile
 
@@ -27,22 +27,41 @@ def annotate_args(func):
 
 @sort_options
 @click.command(
-    short_help="Annotate H5AD file columns. Run `cellxgene annotation --help` for more information.",
+    short_help="Annotate H5AD file columns. Run `cellxgene annotate --help` for more information.",
     options_metavar="<options>",
 )
-@click.option(
-    "-i",
-    "--input-h5ad-file",
+@click.argument(
+    "input_h5ad_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    nargs=1,
+    metavar="<path to H5AD input file>",
     required=True,
-    type=str,
-    help="The input H5AD file containing the missing annotations.",
 )
 @click.option(
     "-m",
     "--model-url",
+    # Making this a required "option", rather than an "argument", since we support automatic model selection in the
+    # future, in which case the user would not need to specify this option at all and we can make it optional at
+    # that time.
     required=True,
     help="The URL of the model used to prediction annotated labels. May be a local filesystem directory "
     "or S3 path (s3://)",
+)
+@click.option(
+    "-o",
+    # "--output",
+    "--output-h5ad-file",
+    default="",
+    help="The output H5AD file that will contain the generated annotation values.",
+    metavar="<filename>",
+)
+@click.option(
+    "--overwrite",
+    default=False,
+    is_flag=True,
+    help="Overwrite the H5AD input file, adding the predicted annotation values. For safety, you must specify this "
+    "flag if the --output option is not specified.",
+    show_default=True,
 )
 @click.option(
     "-l",
@@ -53,8 +72,8 @@ def annotate_args(func):
 @click.option(
     "-g",
     "--gene-column-name",
-    help="The name of the `var` column that contains gene identifiers. The values in this column will be used to match "
-    "genes between the query and reference datasets. If not specified, the gene identifiers are expected to exist "
+    help="The name of the `var` column that contains gene names. The values in this column will be used to match "
+    "genes between the query and reference datasets. If not specified, the gene names are expected to exist "
     "in `var.index`.",
 )
 # TODO: Useful if we want to support discoverability of models
@@ -90,19 +109,6 @@ def annotate_args(func):
     help="An optional run name that will be used as a suffix to form the names of new `obs` annotation columns that "
     "will store the predicted annotation values and confidence scores. This can be used to allow multiple "
     "annotation predictions to be run on a single AnnData object.",
-)
-@click.option(
-    "-u",
-    "--update-h5ad-file",
-    is_flag=True,
-    help="Flag indicating whether to update the input h5ad file with annotation values.  This option is mutually "
-    "exclusive with --output-h5ad-file.",
-)
-@click.option(
-    "-o",
-    "--output-h5ad-file",
-    help="The output H5AD file that will contain the generated annotation values. This option is mutually "
-    "exclusive with --update-h5ad-file.",
 )
 @click.option("--use-model-cache/--no-use-model-cache", default=True)
 @click.option(
@@ -141,6 +147,9 @@ def annotate_args(func):
 )
 @click.help_option("--help", "-h", help="Show this message and exit.")
 def annotate(**cli_args):
+    """
+    BLARGH
+    """
     _validate_options(cli_args)
 
     print(f"Reading query dataset {cli_args['input_h5ad_file']}...")
@@ -149,7 +158,11 @@ def annotate(**cli_args):
         filter(None, [cli_args.get("annotation_prefix"), cli_args.get("annotation_type"), cli_args.get("run_name")])
     )
 
-    output_h5ad_file = cli_args["input_h5ad_file"] if cli_args["update_h5ad_file"] else cli_args["output_h5ad_file"]
+    output_h5ad_file = (
+        cli_args["input_h5ad_file"]
+        if cli_args["overwrite"] and not cli_args["output_h5ad_file"]
+        else cli_args["output_h5ad_file"]
+    )
 
     model_url = cli_args.get("model_url")
     local_model_path = _retrieve_model(cli_args.get("model_cache_dir"), model_url, cli_args.get("use_model_cache"))
@@ -196,7 +209,7 @@ def annotate(**cli_args):
 
             p.wait()
             if p.returncode == 0:
-                print(f"Wrote annotations to {cli_args.get('output_h5ad_file')}")
+                print(f"Wrote annotations to {output_h5ad_file}")
             else:
                 print("Annotation failed!")
     else:
@@ -218,13 +231,11 @@ def _retrieve_model(model_cache_dir, model_url, use_cache=True):
 
 
 def _validate_options(cli_args):
-    # TODO(atolopko): Use cloup library for this logic
-    if cli_args["update_h5ad_file"] and cli_args["output_h5ad_file"]:
-        click.echo("--update_h5ad_file and --output_h5ad_file are mutually exclusive")
-        sys.exit(1)
-    if not (cli_args["update_h5ad_file"] or cli_args["output_h5ad_file"]):
-        click.echo("--update_h5ad_file or --output_h5ad_file must be specified")
-        sys.exit(1)
+    output = cli_args["output_h5ad_file"]
+    overwrite = cli_args["overwrite"]
+
+    if isfile(output) and not overwrite:
+        raise click.UsageError(f"Cannot overwrite existing file {output}, try using the flag --overwrite")
 
 
 if __name__ == "__main__":

--- a/server/cli/annotate.py
+++ b/server/cli/annotate.py
@@ -27,8 +27,7 @@ def annotate_args(func):
 
 @sort_options
 @click.command(
-    short_help="Annotate H5AD file columns. Run `cellxgene annotate --help` for more information.",
-    options_metavar="<options>",
+    options_metavar="<options>"
 )
 @click.argument(
     "input_h5ad_file",
@@ -147,7 +146,7 @@ def annotate_args(func):
 @click.help_option("--help", "-h", help="Show this message and exit.")
 def annotate(**cli_args):
     """
-    BLARGH
+    Add predicted annotations to an H5AD file. Run `cellxgene annotate --help` for more information.
     """
     _validate_options(cli_args)
 

--- a/server/cli/annotate.py
+++ b/server/cli/annotate.py
@@ -50,15 +50,17 @@ def annotate_args(func):
     "-o",
     "--output-h5ad-file",
     default="",
-    help="The output H5AD file that will contain the generated annotation values.",
+    help="The output H5AD file that will contain the generated annotation values. If this option is not provided, "
+         "the input file will be overwritten to include the new annotations; in this case you must specify "
+         "--overwrite.",
     metavar="<filename>",
 )
 @click.option(
     "--overwrite",
     default=False,
     is_flag=True,
-    help="Overwrite the H5AD input file, adding the predicted annotation values. For safety, you must specify this "
-    "flag if the --output-h5ad-file option is not specified.",
+    help="Allow overwriting of the specified H5AD output file, if it exists. For safety, you must specify this "
+         "flag if the specified output file already exists or if the --output-h5ad-file option is not provided.",
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
#2566 

#### Reviewers
**Functional:** 
@seve 

**Readability:** 
@MaximilianLombardo: please review `cellxgene annotate --help` and review changes from UX perspective.


---

## Changes
* Replace --input-h5ad-file with a positional argument, for consistency with other CLI commands
* Replace --update-h5ad-file with --overwrite, for consistency with `prepare` command.
* Fix/clarify various help descriptions
* Fix final output message when input file is overwritten

The revised help output:
```
Usage: annotate.py <options> <path to H5AD input file>

  Add predicted annotations to an H5AD file. Run `cellxgene annotate --help`
  for more information.

Options:
  -c, --annotation-prefix TEXT    An optional prefix used to form the names
                                  of: 1) new `obs` annotation columns that
                                  will store the predicted annotation values
                                  and confidence scores, 2) `obsm` embeddings
                                  (reference and umap embedding), and 3) `uns`
                                  metadata for the prediction operation
                                  [default: cxg]
  --classifier TEXT               For cell type annotation, the classifier
                                  level to use. The classifier is model-
                                  dependent, so refer to documentation for the
                                  specified model for valid values.
  -l, --counts-layer TEXT         If specified, raw counts will be read from
                                  the AnnData layer of the specified name. If
                                  unspecified, raw counts will be read from
                                  `X` matrix, unless 'raw.X' exists, in which
                                  case that will be used.
  -g, --gene-column-name TEXT     The name of the `var` column that contains
                                  gene names. The values in this column will
                                  be used to match genes between the query and
                                  reference datasets. If not specified, the
                                  gene names are expected to exist in
                                  `var.index`.
  -h, --help                      Show this message and exit.
  --mlflow-env-manager [virtualenv|conda|local]
                                  Annotation model prediction will be
                                  installed and executed in the specified type
                                  of environment. MacOS users on Apple Silicon
                                  (arm64, M1, M2, etc.) are recommended to use
                                  'conda' to avoid Python package installation
                                  errors. If 'conda' is specified then
                                  cellxgene must also have been installed
                                  within a conda environment
  --model-cache-dir TEXT          Local directory used to store model files
                                  that are retrieved from a remote location.
                                  Model files will be read from this directory
                                  first, if they exist, to avoid repeating
                                  large downloads.
  -m, --model-url TEXT            The URL of the model used to prediction
                                  annotated labels. May be a local filesystem
                                  directory or S3 path (s3://)  [required]
  --organism [Homo sapiens|Mus musculus]
                                  For cell type annotation, the organism of
                                  the dataset. Used to normalize gene names to
                                  HGLC conventions when an annotation model
                                  has been trained using data from different
                                  organism.
  -o, --output-h5ad-file <filename>
                                  The output H5AD file that will contain the
                                  generated annotation values. If this option
                                  is not provided, the input file will be
                                  overwritten to include the new annotations;
                                  in this case you must specify --overwrite.
  --overwrite                     Allow overwriting of the specified H5AD
                                  output file, if it exists. For safety, you
                                  must specify this flag if the specified
                                  output file already exists or if the
                                  --output-h5ad-file option is not provided.
  -n, --run-name TEXT             An optional run name that will be used as a
                                  suffix to form the names of new `obs`
                                  annotation columns that will store the
                                  predicted annotation values and confidence
                                  scores. This can be used to allow multiple
                                  annotation predictions to be run on a single
                                  AnnData object.
  --use-gpu / --no-use-gpu        Whether to use a GPU for annotation
                                  operations (highly recommended, if
                                  available).
  --use-model-cache / --no-use-model-cache
```