### PR TITLE
fix: pin flask requirement to be less than 2.3

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,7 @@
 anndata>=0.7.6 # we need to_memory(), added in 0.7.6
 boto3>=1.12.18
 click>=7.1.2
-Flask>=1.0.2
+Flask>=1.0.2,<2.3.0
 Flask-Compress>=1.4.0
 Flask-Cors>=3.0.9  # CVE-2020-25032
 Flask-RESTful>=0.3.6


### PR DESCRIPTION
Reproduction:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/16548075/234662918-4a98b23b-04a8-4b4d-955c-6876bff375b0.png">


## Changes
- pinned flask to be < 2.3 to fix JSONEncoder import error.
