### PR TITLE
Dockerfile update ubuntu:bionic -> jammy (python3.6.9 -> python3.10.12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes

- modify

Changed the base image from ubuntu:bionic to ubuntu:jammy. This solves the compatibility issue with h5ad files created using newer anndata.