### PR TITLE
fix: underscore snakecase notation to hyphenated snakecase for diffexp-may-be-slow

### DIFF
--- a/server/common/config/dataset_config.py
+++ b/server/common/config/dataset_config.py
@@ -176,7 +176,7 @@ class DatasetConfig(BaseConfig):
         self.validate_correct_type_of_configuration_attribute("diffexp__top_n", int)
 
         data_adaptor = self.get_data_adaptor()
-        if self.diffexp__enable and data_adaptor.parameters.get("diffexp_may_be_slow", False):
+        if self.diffexp__enable and data_adaptor.parameters.get("diffexp-may-be-slow", False):
             context["messagefn"](
                 "CAUTION: due to the size of your dataset, " "running differential expression may take longer or fail."
             )

--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -211,7 +211,7 @@ class AnndataAdaptor(DataAdaptor):
         # heuristic
         n_values = self.data.shape[0] * self.data.shape[1]
         if (n_values > 1e8 and self.server_config.adaptor__anndata_adaptor__backed is True) or (n_values > 5e8):
-            self.parameters.update({"diffexp_may_be_slow": True})
+            self.parameters.update({"diffexp-may-be-slow": True})
 
     def _is_valid_layout(self, arr):
         """return True if this layout data is a valid array for front-end presentation:


### PR DESCRIPTION
The variable `diffexp_may_be_slow` is set within the python server and used within the javascript client as another variable `diffexp-may-be-slow`. This PR fixes this divergence and uses a single variable name. The introduced changes have been tested locally and indeed fix the issue that the warning when hovering the DEG button was not shown previously with large datasets.

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- Fix: see title
