### PR TITLE
docs: README.md: Updating instructions for the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Whether you need to visualize one thousand cells or one million, CELLxGENE Annot
 
 ### Quick start
 
-To install CELLxGENE Annotate you need Python 3.6+. We recommend [installing Annotate into a conda or virtual environment.](https://github.com/chanzuckerberg/cellxgene-documentation/blob/main/desktop/install.md)
+To install CELLxGENE Annotate you need Python 3.6+ but no newer than Python 3.9. Additional installations of Python are fine. We recommend installing into a virtual environment, which is automated by using pipx, also see [installing Annotate into a conda or virtual environment.](https://github.com/chanzuckerberg/cellxgene-documentation/blob/main/desktop/install.md)
 
 Install the package.
 
 ```bash
-pip install cellxgene
+pipx install cellxgene --python python3.9 --pip-args="numpy==1.26.4"
 ```
 
 Launch Annotate with an example [anndata](https://anndata.readthedocs.io/en/latest/) file


### PR DESCRIPTION
The current numpy 2.0.0 is incompatible with the version of panda installing. Also the imp module (managing Python modules) was substituted with the importlib module and is no longer available since Python 3.10.

The readme should not describe how to install Python 3.9, I thought - brew or conda should both work - tested successfully with brew.

This PR should close https://github.com/chanzuckerberg/cellxgene/issues/2677 . The related issue https://github.com/chanzuckerberg/cellxgene/issues/2635 (that indeed requests support in installing Python) I suggest to close after a respective addition to the cellxgene documentation.

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- modify
