### PR TITLE
fix: Handle non-categorical columns with colors + update deprecated AnnData API

### DIFF
--- a/server/cli/prepare.py
+++ b/server/cli/prepare.py
@@ -128,12 +128,12 @@ def prepare(
             raise click.FileError(data, hint="not a valid file or path")
 
         if not set_obs_names == "":
-            if set_obs_names not in adata.obs_keys():
-                raise click.UsageError(f"obs {set_obs_names} not found, options are: {adata.obs_keys()}")
+            if set_obs_names not in list(adata.obs.keys()):
+                raise click.UsageError(f"obs {set_obs_names} not found, options are: {list(adata.obs.keys())}")
             adata.obs_names = adata.obs[set_obs_names]
         if not set_var_names == "":
-            if set_var_names not in adata.var_keys():
-                raise click.UsageError(f"var {set_var_names} not found, options are: {adata.var_keys()}")
+            if set_var_names not in list(adata.var.keys()):
+                raise click.UsageError(f"var {set_var_names} not found, options are: {list(adata.var.keys())}")
             adata.var_names = adata.var[set_var_names]
         if make_obs_names_unique:
             adata.obs.index = make_index_unique(adata.obs.index)

--- a/server/common/colors.py
+++ b/server/common/colors.py
@@ -228,6 +228,6 @@ def convert_anndata_category_colors_to_cxg_category_colors(data):
 
         # create the cellxgene color entry for this category
         cxg_colors[category_name] = dict(
-            zip(data.obs[category_name].cat.categories, [convert_color_to_hex_format(c) for c in data.uns[uns_key]])
+            zip(data.obs[category_name].astype('category').cat.categories, [convert_color_to_hex_format(c) for c in data.uns[uns_key]])
         )
     return cxg_colors

--- a/server/common/corpora.py
+++ b/server/common/corpora.py
@@ -22,7 +22,7 @@ def corpora_get_versions_from_anndata(adata):
     """
 
     # per Corpora AnnData spec, this is a corpora file if the following is true
-    if "version" not in adata.uns_keys():
+    if "version" not in list(adata.uns.keys()):
         return None
     version = adata.uns["version"]
     if not isinstance(version, collections.abc.Mapping) or "corpora_schema_version" not in version:

--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -1,4 +1,5 @@
 import warnings
+import importlib.metadata
 
 import anndata
 import numpy as np
@@ -16,7 +17,7 @@ from server.common.utils.type_conversion_utils import get_schema_type_hint_of_ar
 from server.data_common.data_adaptor import DataAdaptor
 from server.common.fbs.matrix import encode_matrix_fbs
 
-anndata_version = version.parse(str(anndata.__version__)).release
+anndata_version = version.parse(str(importlib.metadata.version('anndata'))).release
 
 
 def anndata_version_is_pre_070():
@@ -63,7 +64,7 @@ class AnndataAdaptor(DataAdaptor):
         return "cellxgene anndata adaptor version"
 
     def get_library_versions(self):
-        return dict(anndata=str(anndata.__version__))
+        return dict(anndata=str(importlib.metadata.version('anndata')))
 
     @staticmethod
     def _create_unique_column_name(df, col_name_prefix):
@@ -313,11 +314,11 @@ class AnndataAdaptor(DataAdaptor):
         layouts = self.dataset_config.embeddings__names
 
         if layouts is None or len(layouts) == 0:
-            layouts = [key[2:] for key in self.data.obsm_keys() if type(key) is str and key.startswith("X_")]
+            layouts = [key[2:] for key in list(self.data.obsm.keys()) if type(key) is str and key.startswith("X_")]
 
         # remove invalid layouts
         valid_layouts = []
-        obsm_keys = self.data.obsm_keys()
+        obsm_keys = list(self.data.obsm.keys())
         for layout in layouts:
             layout_name = f"X_{layout}"
             if layout_name not in obsm_keys:


### PR DESCRIPTION
### Problem

Cellxgene crashes when loading AnnData files with boolean (or other non-categorical) columns that have associated colors in `adata.uns`:

```
AttributeError: Can only use .cat accessor with a 'category' dtype. Did you mean: 'at'?
```

The color conversion code assumes all columns with colors are categorical and directly accesses `.cat.categories`, which fails for boolean dtypes (which are common for QC, like 'is_doublet' or similar).

### Solution

Updated color handling to convert non-categorical columns to categorical before accessing categories.

Also: replaced deprecated AnnData API calls with modern equivalents (supported since AnnData 0.7.0, deprecated in 0.12.3) to avoid warnings.

### Changes

**add:**
- Import `importlib.metadata` in `anndata_adaptor.py` to replace deprecated version checking

**remove:**
- Deprecated AnnData method calls: `.obsm_keys()`, `.obs_keys()`, `.var_keys()`, `.uns_keys()`, `.__version__`

**modify:**
- `server/data_common/colors.py`: Updated `convert_anndata_category_colors_to_cxg_category_colors()` to use `.astype('category')` for non-categorical columns before accessing categories
- `server/data_anndata/anndata_adaptor.py`: Replaced `.__version__` with `importlib.metadata.version('anndata')` and deprecated key methods with dictionary-style access
- `server/data_anndata/prepare.py`: Updated to use `.obs.keys()` and `.var.keys()` instead of deprecated methods
- `server/data_common/corpora.py`: Updated to use `.uns.keys()` instead of deprecated methods

### Testing

- Boolean column datasets now load without crashes
- Categorical column behavior unchanged
- All deprecation warnings eliminated