### PR TITLE
fix: handle Unicode characters in h5ad metadata without misleading format error

### DIFF
--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -1,3 +1,4 @@
+import unicodedata
 import warnings
 import importlib.metadata
 
@@ -164,13 +165,23 @@ class AnndataAdaptor(DataAdaptor):
                 backed = "r" if self.server_config.adaptor__anndata_adaptor__backed else None
                 self.data = anndata.read_h5ad(lh, backed=backed)
 
-        except ValueError:
+        except ValueError as e:
+            error_msg = str(e)
+            # Check if the error is related to Unicode encoding issues in metadata
+            if any(term in error_msg.lower() for term in ["codec", "encode", "decode", "unicode", "utf"]):
+                raise DatasetAccessError(
+                    "Error reading h5ad file: the file contains characters in its metadata that "
+                    "could not be decoded. This can happen when annotation labels contain "
+                    "special Unicode characters (e.g. Greek letters like 'φ'). "
+                    f"The specific error was: {error_msg}. "
+                    "Please ensure all metadata strings use valid UTF-8 encoding."
+                )
             raise DatasetAccessError(
                 "File must be in the .h5ad format. Please read "
                 "https://github.com/theislab/scanpy_usage/blob/master/170505_seurat/info_h5ad.md to "
                 "learn more about this format. You may be able to convert your file into this format "
                 "using `cellxgene prepare`, please run `cellxgene prepare --help` for more "
-                "information."
+                f"information. (Original error: {error_msg})"
             )
         except MemoryError:
             raise DatasetAccessError("Out of memory - file is too large for available memory.")
@@ -196,6 +207,42 @@ class AnndataAdaptor(DataAdaptor):
                 message += f"\n{traceback.format_exc()}"
             raise DatasetAccessError(message)
 
+    @staticmethod
+    def _normalize_unicode_strings(df):
+        """Normalize Unicode strings in a DataFrame to NFC form.
+
+        This prevents issues with non-ASCII characters (e.g. Greek letters
+        like 'φ') in annotation labels that can cause encoding errors
+        during serialization. See: https://github.com/chanzuckerberg/cellxgene/issues/2754
+        """
+        for col in df.columns:
+            if df[col].dtype == object or hasattr(df[col], 'cat'):
+                try:
+                    if hasattr(df[col], 'cat'):
+                        # For categorical columns, normalize the categories
+                        new_categories = [
+                            unicodedata.normalize("NFC", str(c)) if isinstance(c, str) else c
+                            for c in df[col].cat.categories
+                        ]
+                        df[col] = df[col].cat.rename_categories(
+                            dict(zip(df[col].cat.categories, new_categories))
+                        )
+                    else:
+                        df[col] = df[col].apply(
+                            lambda x: unicodedata.normalize("NFC", x) if isinstance(x, str) else x
+                        )
+                except Exception:
+                    # If normalization fails for a column, skip it
+                    pass
+        # Also normalize index if it contains strings
+        if df.index.dtype == object:
+            try:
+                df.index = df.index.map(
+                    lambda x: unicodedata.normalize("NFC", x) if isinstance(x, str) else x
+                )
+            except Exception:
+                pass
+
     def _validate_and_initialize(self):
         if anndata_version_is_pre_070():
             warnings.warn(
@@ -206,6 +253,11 @@ class AnndataAdaptor(DataAdaptor):
         # var and obs column names must be unique
         if not self.data.obs.columns.is_unique or not self.data.var.columns.is_unique:
             raise KeyError("All annotation column names must be unique.")
+
+        # Normalize Unicode strings in obs and var metadata to prevent
+        # encoding issues with special characters (fixes #2754)
+        self._normalize_unicode_strings(self.data.obs)
+        self._normalize_unicode_strings(self.data.var)
 
         self._alias_annotation_names()
         self._validate_data_types()

--- a/test/unit/data_anndata/test_unicode_metadata.py
+++ b/test/unit/data_anndata/test_unicode_metadata.py
@@ -1,0 +1,121 @@
+import os
+import tempfile
+import unittest
+import unicodedata
+
+import anndata
+import numpy as np
+import pandas as pd
+
+from server.common.utils.data_locator import DataLocator
+from server.data_anndata.anndata_adaptor import AnndataAdaptor
+from server.common.config.app_config import AppConfig
+
+
+class UnicodeMetadataTest(unittest.TestCase):
+    """
+    Test that h5ad files containing non-ASCII Unicode characters in metadata
+    (e.g. Greek letters like phi) can be loaded without error.
+
+    Regression test for: https://github.com/chanzuckerberg/cellxgene/issues/2754
+    """
+
+    def _create_h5ad_with_unicode_obs(self, obs_labels):
+        """Helper to create a minimal h5ad file with the given obs labels."""
+        n_obs = len(obs_labels)
+        n_var = 5
+        X = np.random.rand(n_obs, n_var).astype(np.float32)
+        obs = pd.DataFrame(
+            {"cell_type": pd.Categorical(obs_labels)},
+            index=[f"cell_{i}" for i in range(n_obs)],
+        )
+        var = pd.DataFrame(index=[f"gene_{i}" for i in range(n_var)])
+        # Create a minimal embedding so validation passes
+        obsm = {"X_umap": np.random.rand(n_obs, 2).astype(np.float32)}
+        adata = anndata.AnnData(X=X, obs=obs, var=var, obsm=obsm)
+        return adata
+
+    def _load_h5ad(self, filepath):
+        """Load an h5ad file via AnndataAdaptor with a minimal config."""
+        locator = DataLocator(filepath)
+        config = AppConfig()
+        config.update_server_config(
+            single_dataset__obs_names=None,
+            single_dataset__var_names=None,
+            single_dataset__datapath=locator.path,
+        )
+        config.update_server_config(app__flask_secret_key="secret")
+        config.update_dataset_config(
+            embeddings__names=["umap"],
+            presentation__max_categories=100,
+            diffexp__lfc_cutoff=0.01,
+        )
+        config.complete_config()
+        return AnndataAdaptor(locator, config)
+
+    def test_load_h5ad_with_greek_phi_in_metadata(self):
+        """Loading h5ad with Greek letter phi in cell labels should succeed."""
+        labels = [
+            "Interstitial M\u03c6 perivascular",
+            "T cell",
+            "B cell",
+            "Monocyte",
+        ]
+        adata = self._create_h5ad_with_unicode_obs(labels)
+        with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as f:
+            adata.write_h5ad(f.name)
+            tmppath = f.name
+        try:
+            data = self._load_h5ad(tmppath)
+            self.assertIsNotNone(data)
+            self.assertEqual(data.cell_count, 4)
+            self.assertEqual(data.gene_count, 5)
+        finally:
+            os.unlink(tmppath)
+
+    def test_load_h5ad_with_various_unicode_in_metadata(self):
+        """Loading h5ad with various Unicode characters should succeed."""
+        labels = [
+            "M\u03c6 perivascular",      # Greek phi
+            "\u03b1\u03b2 T cell",        # Greek alpha beta
+            "Na\u00efve B cell",          # Latin i with diaeresis
+            "Th\u00fcringen sample",      # u-umlaut
+            "caf\u00e9 sample",           # e-acute
+        ]
+        adata = self._create_h5ad_with_unicode_obs(labels)
+        with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as f:
+            adata.write_h5ad(f.name)
+            tmppath = f.name
+        try:
+            data = self._load_h5ad(tmppath)
+            self.assertIsNotNone(data)
+            self.assertEqual(data.cell_count, 5)
+        finally:
+            os.unlink(tmppath)
+
+    def test_unicode_normalization_applied(self):
+        """Verify that Unicode strings in obs are NFC-normalized after loading."""
+        # NFD form of e-acute (two code points: 'e' + combining acute accent)
+        nfd_label = "caf" + "\u0065\u0301" + " sample"
+        # NFC form (single code point)
+        nfc_label = "caf\u00e9 sample"
+
+        labels = [nfd_label, "T cell", "B cell"]
+        adata = self._create_h5ad_with_unicode_obs(labels)
+        with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as f:
+            adata.write_h5ad(f.name)
+            tmppath = f.name
+        try:
+            data = self._load_h5ad(tmppath)
+            cell_types = data.data.obs["cell_type"].tolist()
+            # After normalization, the NFD form should be converted to NFC
+            self.assertIn(nfc_label, cell_types)
+            for val in cell_types:
+                if isinstance(val, str):
+                    self.assertEqual(val, unicodedata.normalize("NFC", val))
+        finally:
+            os.unlink(tmppath)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #2754

Loading an h5ad file containing non-ASCII Unicode characters (e.g. Greek letter phi in cell labels like `Interstitial Mφ perivascular`) caused a misleading error: `File must be in the .h5ad format`. The actual file was valid h5ad, but the broad `except ValueError` handler in `_load_data()` discarded the original error context.

## Changes

### `server/data_anndata/anndata_adaptor.py`
- Improved `ValueError` handling in `_load_data()` to detect Unicode/encoding-related errors and display a meaningful message instead of the generic format error
- Appended the original error message to the generic format error for all other `ValueError` cases, aiding debugging
- Added `_normalize_unicode_strings()` static method that normalizes all string metadata in obs/var DataFrames to NFC form during `_validate_and_initialize()`, preventing encoding issues during serialization

### `test/unit/data_anndata/test_unicode_metadata.py`
- Added regression tests that load h5ad files containing Greek letters, accented characters, and other non-ASCII Unicode in metadata
- Added test verifying NFC normalization is applied to obs metadata strings

## Steps to reproduce the original bug

1. Create an h5ad file with a metadata column containing `φ` (or similar non-ASCII characters)
2. Run `cellxgene launch anndata.h5ad`
3. Observe misleading error: `File must be in the .h5ad format`

## Steps to verify the fix

```bash
python -m unittest test.unit.data_anndata.test_unicode_metadata -v
```

All 3 new tests pass, and existing data_anndata tests remain unaffected.