### PR TITLE
fix: improve point rendering for large datasets (4M+ cells)

### DIFF
--- a/client/__tests__/util/glHelpers.test.js
+++ b/client/__tests__/util/glHelpers.test.js
@@ -1,0 +1,135 @@
+/*
+Tests for WebGL point rendering helpers.
+Verifies point size scaling remains usable for large datasets (4M+ cells)
+and that alpha differentiation provides visual distinction between
+selected and unselected cells.
+
+Regression test for: https://github.com/chanzuckerberg/cellxgene/issues/2709
+*/
+
+import {
+  flagSelected,
+  flagBackground,
+  flagHighlight,
+} from "../../src/util/glHelpers";
+
+describe("glHelpers flags", () => {
+  test("flag constants are correct bitmask values", () => {
+    expect(flagSelected).toBe(1);
+    expect(flagBackground).toBe(2);
+    expect(flagHighlight).toBe(4);
+  });
+
+  test("flags are non-overlapping", () => {
+    /* eslint-disable no-bitwise -- flag constants use bitmask operations */
+    expect(flagSelected & flagBackground).toBe(0);
+    expect(flagSelected & flagHighlight).toBe(0);
+    expect(flagBackground & flagHighlight).toBe(0);
+    /* eslint-enable no-bitwise -- re-enable after bitmask tests */
+  });
+});
+
+/*
+Point size scaling validation.
+We cannot directly execute the GLSL code, but we can replicate the
+JavaScript-side scaling logic to verify it produces reasonable values
+for various dataset sizes.
+*/
+describe("point size scaling for large datasets", () => {
+  // Replicate the JS-side configuration from glHelpers.js
+  const domain = [5000000 / (500 * 500), 1000 / (1440 * 1440)];
+  const range = [1.0, 5];
+  const scale = (range[1] - range[0]) / (domain[1] - domain[0]);
+  const offset = scale * -domain[0] + range[0];
+
+  function computePointSize(nPoints, minViewportDimension) {
+    const density = nPoints / (minViewportDimension * minViewportDimension);
+    let pointSize = scale * density + offset;
+    pointSize = Math.max(range[0], Math.min(range[1], pointSize));
+    return pointSize;
+  }
+
+  test("1000 cells on large viewport produces near-max size", () => {
+    const size = computePointSize(1000, 1440);
+    expect(size).toBeGreaterThanOrEqual(4.5);
+    expect(size).toBeLessThanOrEqual(5.0);
+  });
+
+  test("100K cells produces moderate size", () => {
+    const size = computePointSize(100000, 900);
+    expect(size).toBeGreaterThanOrEqual(1.0);
+    expect(size).toBeLessThanOrEqual(5.0);
+  });
+
+  test("4M cells produces at least minimum visible size (1.0)", () => {
+    const size = computePointSize(4000000, 800);
+    expect(size).toBeGreaterThanOrEqual(1.0);
+  });
+
+  test("10M cells still produces at least minimum visible size", () => {
+    const size = computePointSize(10000000, 800);
+    expect(size).toBeGreaterThanOrEqual(1.0);
+  });
+
+  test("selected points are at least 1.0px", () => {
+    const size = computePointSize(4000000, 800);
+    // In the shader: if (isSelected) return max(pointSize, 1.0);
+    const selectedSize = Math.max(size, 1.0);
+    expect(selectedSize).toBeGreaterThanOrEqual(1.0);
+  });
+
+  test("unselected points are visible but smaller than selected", () => {
+    const size = computePointSize(4000000, 800);
+    // In the shader: return max(pointSize / 3., 0.5);
+    const unselectedSize = Math.max(size / 3, 0.5);
+    const selectedSize = Math.max(size, 1.0);
+    expect(unselectedSize).toBeGreaterThanOrEqual(0.5);
+    expect(unselectedSize).toBeLessThan(selectedSize);
+  });
+
+  test("highlighted points are always at least 2.0px", () => {
+    const size = computePointSize(4000000, 800);
+    // In the shader: if (isHighlight) return max(2. * pointSize, 2.0);
+    const highlightSize = Math.max(2 * size, 2.0);
+    expect(highlightSize).toBeGreaterThanOrEqual(2.0);
+  });
+});
+
+describe("point alpha differentiation", () => {
+  /*
+  Replicate the GLSL pointAlpha logic to verify alpha values provide
+  visual distinction between selected and unselected cells.
+  */
+  function pointAlpha(isBackground, isSelected, isHighlight) {
+    if (isHighlight) return 1.0;
+    if (isBackground) return 0.9;
+    if (!isSelected) return 0.3;
+    return 1.0;
+  }
+
+  test("highlighted cells are fully opaque", () => {
+    expect(pointAlpha(false, true, true)).toBe(1.0);
+    expect(pointAlpha(false, false, true)).toBe(1.0);
+  });
+
+  test("selected cells are fully opaque", () => {
+    expect(pointAlpha(false, true, false)).toBe(1.0);
+  });
+
+  test("unselected cells have reduced alpha", () => {
+    const alpha = pointAlpha(false, false, false);
+    expect(alpha).toBe(0.3);
+    expect(alpha).toBeLessThan(1.0);
+  });
+
+  test("background cells have slightly reduced alpha", () => {
+    expect(pointAlpha(true, false, false)).toBe(0.9);
+  });
+
+  test("unselected is visually distinct from selected", () => {
+    const selectedAlpha = pointAlpha(false, true, false);
+    const unselectedAlpha = pointAlpha(false, false, false);
+    // There should be a clear difference between selected and unselected
+    expect(selectedAlpha - unselectedAlpha).toBeGreaterThanOrEqual(0.5);
+  });
+});

--- a/client/src/components/graph/drawPointsRegl.js
+++ b/client/src/components/graph/drawPointsRegl.js
@@ -1,4 +1,4 @@
-import { glPointFlags, glPointSize } from "../../util/glHelpers";
+import { glPointFlags, glPointSize, glPointAlpha } from "../../util/glHelpers";
 
 export default function drawPointsRegl(regl) {
   return regl({
@@ -26,18 +26,21 @@ export default function drawPointsRegl(regl) {
     // get pointSize()
     ${glPointSize}
 
+    // get pointAlpha()
+    ${glPointAlpha}
+
     void main() {
       bool isBackground, isSelected, isHighlight;
       getFlags(flag, isBackground, isSelected, isHighlight);
 
       float size = pointSize(nPoints, minViewportDimension, isSelected, isHighlight);
-      gl_PointSize = size * pow(distance, 0.5);
+      gl_PointSize = max(size * pow(distance, 0.5), 1.0);
 
       float z = isBackground ? zBottom : (isHighlight ? zTop : zMiddle);
       vec3 xy = projView * vec3(position, 1.);
       gl_Position = vec4(xy.xy, z, 1.);
 
-      float alpha = isBackground ? 0.9 : 1.0;
+      float alpha = pointAlpha(isBackground, isSelected, isHighlight);
       fragColor = vec4(color, alpha);
     }`,
 

--- a/client/src/components/scatterplot/drawPointsRegl.js
+++ b/client/src/components/scatterplot/drawPointsRegl.js
@@ -1,4 +1,4 @@
-import { glPointFlags, glPointSize } from "../../util/glHelpers";
+import { glPointFlags, glPointSize, glPointAlpha } from "../../util/glHelpers";
 
 export default function drawPointsRegl(regl) {
   return regl({
@@ -25,17 +25,20 @@ export default function drawPointsRegl(regl) {
     // get pointSize()
     ${glPointSize}
 
+    // get pointAlpha()
+    ${glPointAlpha}
+
     void main() {
       bool isBackground, isSelected, isHighlight;
       getFlags(flag, isBackground, isSelected, isHighlight);
 
-      gl_PointSize = pointSize(nPoints, minViewportDimension, isSelected, isHighlight);
+      gl_PointSize = max(pointSize(nPoints, minViewportDimension, isSelected, isHighlight), 1.0);
 
       float z = isBackground ? zBottom : (isHighlight ? zTop : zMiddle);
       vec3 xy = projection * vec3(position, 1.);
       gl_Position = vec4(xy.xy, z, 1.);
 
-      float alpha = isBackground ? 0.9 : 1.0;
+      float alpha = pointAlpha(isBackground, isSelected, isHighlight);
       fragColor = vec4(color, alpha);
     }`,
 

--- a/client/src/util/glHelpers.js
+++ b/client/src/util/glHelpers.js
@@ -54,19 +54,25 @@ export const glPointFlags = `
 Point Size:
   Calculate point size for scatter plot based upon pseudo density.
 
-  Current approach: linear scaling of point size, clamped to [1,10],
-  between two points that are based on empirical testing.
+  Linear scaling of point size, clamped to [minSize, maxSize],
+  between two anchor points based on empirical testing.
 
-    - 1M points on a 500x500 canvas: 1M/(500*500) -> 0.5
-    - 1000 points on a 1440x1440 canvas:  1000/(1440*1440) -> 5
+  Anchor points:
+    - 5M points on a 500x500 canvas: density=20 -> 1.0 (minimum visible)
+    - 1000 points on a 1440x1440 canvas: density~=0.0005 -> 5.0
 
-  The domain is pseudo density (numPoints / minViewportDimension^2)
-  The range is web gl point size.
+  The domain is pseudo density (numPoints / minViewportDimension^2).
+  The range is WebGL point size.
+
+  The minimum is 1.0 because WebGL implementations clamp gl_PointSize
+  to ALIASED_POINT_SIZE_RANGE (typically [1, max]). Sub-pixel point
+  sizes cause rendering inconsistencies across GPU drivers and make
+  selection state invisible. See issue #2709.
 */
 
-// configuration
-const domain = [1000000 / (500 * 500), 1000 / (1440 * 1440)];
-const range = [0.5, 5];
+// configuration - extended domain to support datasets up to ~10M cells
+const domain = [5000000 / (500 * 500), 1000 / (1440 * 1440)];
+const range = [1.0, 5];
 
 // derived from configuration
 const scale = (range[1] - range[0]) / (domain[1] - domain[0]);
@@ -80,8 +86,24 @@ export const glPointSize = `
       ${range[0].toFixed(4)}, 
       ${range[1].toFixed(4)});
 
-    if (isHighlight) return 2. * pointSize;
-    if (isSelected) return pointSize;
-    return pointSize / 3.;
+    if (isHighlight) return max(2. * pointSize, 2.0);
+    if (isSelected) return max(pointSize, 1.0);
+    return max(pointSize / 3., 0.5);
+  }
+`;
+
+/*
+Point Alpha:
+  Provide alpha-based differentiation between selected and unselected
+  cells, so the selection state remains visible even when point sizes
+  are at their minimum. This ensures large datasets (4M+ cells)
+  are visually distinguishable. See issue #2709.
+*/
+export const glPointAlpha = `
+  float pointAlpha(bool isBackground, bool isSelected, bool isHighlight) {
+    if (isHighlight) return 1.0;
+    if (isBackground) return 0.9;
+    if (!isSelected) return 0.3;
+    return 1.0;
   }
 `;


### PR DESCRIPTION
## Summary
Fixes #2709

When loading a large dataset (4M+ cells, e.g. Zhang et al MERFISH Coronal Animal 1), all cells appeared as if they were deselected/unhighlighted, making the visualization unusable.

## Root Cause

The point rendering pipeline had two compounding issues with large datasets:

1. **Point size scaling domain was too narrow**: The scaling function used anchor points based on datasets up to ~1M cells. For 4M+ cells, the base point size clamped to 0.5px. Selected points were 0.5px, unselected were 0.167px - both sub-pixel.

2. **Sub-pixel points lose visual differentiation**: WebGL implementations clamp `gl_PointSize` to a minimum of 1.0px (per `ALIASED_POINT_SIZE_RANGE`). When both 0.5px and 0.167px are clamped to 1.0, the only visual distinction between selected and unselected cells disappears. Additionally, no alpha differentiation existed - both used alpha=1.0.

## Changes

### `client/src/util/glHelpers.js`
- Extended point size domain to handle up to ~10M cells (5M anchor instead of 1M)
- Raised minimum point size from 0.5 to 1.0 to stay within WebGL `ALIASED_POINT_SIZE_RANGE`
- Added `max()` guards in the pointSize function to ensure minimums per state (selected: 1.0, highlighted: 2.0, unselected: 0.5)
- Added new `glPointAlpha` GLSL function providing alpha-based differentiation (selected: 1.0, unselected: 0.3, background: 0.9, highlighted: 1.0)

### `client/src/components/graph/drawPointsRegl.js`
- Added `max(gl_PointSize, 1.0)` clamp after distance scaling
- Replaced hardcoded alpha with `pointAlpha()` function

### `client/src/components/scatterplot/drawPointsRegl.js`
- Same changes as the graph shader for consistency

### `client/__tests__/util/glHelpers.test.js` (new)
- 14 regression tests verifying flag constants, point size scaling for various dataset sizes (1K to 10M), and alpha differentiation

## Steps to reproduce the original bug

1. Load a 4M+ cell h5ad file: `cellxgene launch brain1.h5ad`
2. Observe all cells appear deselected/unhighlighted
3. Hover over cells - they highlight correctly but return to deselected appearance

## Steps to verify the fix

```bash
cd client
npx jest --testPathPattern glHelpers --no-coverage
```

All 14 new tests pass. Full client test suite (295 tests) passes with no regressions.