### PR TITLE
fix: Fix opacity of centroid labels

### DIFF
--- a/client/src/components/graph/overlays/centroidLabels.js
+++ b/client/src/components/graph/overlays/centroidLabels.js
@@ -150,7 +150,7 @@ class CentroidLabels extends PureComponent {
                   dilatedValue={dilatedValue}
                   coords={coords}
                   inverseTransform={inverseTransform}
-                  opactity={selected ? 1 : deselectOpacity}
+                  opacity={selected ? 1 : deselectOpacity}
                   colorAccessor={colorAccessor}
                   displayLabel={displayLabel}
                   onMouseEnter={this.handleMouseEnter}
@@ -205,7 +205,7 @@ const Label = ({
           fontWeight,
           fill: "black",
           userSelect: "none",
-          opacity: { opacity },
+          opacity,
         }}
         onMouseEnter={(e) => onMouseEnter(e, colorAccessor, label)}
         onMouseOut={(e) => onMouseOut(e, colorAccessor, label)}


### PR DESCRIPTION
## Summary

- Fix typo in prop name: `opactity` → `opacity` when passing the opacity value to the `Label` component (line 153)
- Fix extraneous brackets in style object: `opacity: { opacity }` → `opacity` shorthand property (line 208). The original code wraps `opacity` in object literal braces `{}` inside the style object, producing an object value instead of the numeric opacity value.

## Test plan

- [ ] Verify centroid labels render with correct opacity when categories are selected/deselected
- [ ] Verify deselected centroid labels appear semi-transparent rather than invisible