### PR TITLE
Fix gene coloring 400 with pandas 3.0 string dtype var index

### DIFF
--- a/server/data_common/data_adaptor.py
+++ b/server/data_common/data_adaptor.py
@@ -180,7 +180,13 @@ class DataAdaptor(metaclass=ABCMeta):
             elif axis == Axis.OBS:
                 anno_data = self.query_obs_array(name)
 
-            if anno_data.dtype.name in ["boolean", "category", "object"]:
+            # Discrete/label columns are filtered by exact value. This must
+            # include the pandas string dtypes that modern anndata writes for
+            # gene names and obs labels: StringDtype ("string"/"string[pyarrow]")
+            # and, under pandas 3.0 (or pandas 2.x with future.infer_string), the
+            # NumPy-backed "str" dtype that replaces object for text. Otherwise
+            # the value filter is silently skipped and the whole axis is selected.
+            if anno_data.dtype.name in ["boolean", "category", "object"] or pd.api.types.is_string_dtype(anno_data):
                 values = v.get("values", [])
                 key_idx = np.in1d(anno_data, values)
                 mask = np.logical_and(mask, key_idx)

--- a/test/unit/data_anndata/test_anndata_adaptor.py
+++ b/test/unit/data_anndata/test_anndata_adaptor.py
@@ -8,6 +8,7 @@ import pytest
 from parameterized import parameterized_class
 
 import test.decode_fbs as decode_fbs
+from server.common.constants import Axis
 from server.common.utils.data_locator import DataLocator
 from server.common.errors import FilterError
 from server.data_anndata.anndata_adaptor import AnndataAdaptor
@@ -210,3 +211,34 @@ class AdaptorTest(unittest.TestCase):
         self.assertEqual(data["n_rows"], 2638)
         self.assertEqual(data["n_cols"], 3)
         self.assertTrue((data["col_idx"] == [15, 1818, 1837]).all())
+
+
+class StringDtypeFilterMaskTest(unittest.TestCase):
+    """Regression: value filters on pandas string columns (as modern anndata
+    writes for the gene-name index and obs labels) must select the matching
+    rows. Previously the dtype gate only allowed boolean/category/object, so a
+    string-typed column was skipped and the whole axis was selected — which for
+    a single gene fetch tripped the column-request limit and returned 400.
+
+    Covers both StringDtype ("string") and the pandas 3.0 NumPy-backed "str"
+    dtype (opted into here via future.infer_string) that replaces object."""
+
+    def _assert_value_filter(self, genes):
+        adaptor = AnndataAdaptor.__new__(AnndataAdaptor)  # no dataset needed
+        adaptor.query_var_array = lambda name: genes
+        mask = adaptor._annotation_filter_to_mask(
+            Axis.VAR, [{"name": "name_0", "values": ["Sox3"]}], len(genes)
+        )
+        self.assertEqual(mask.tolist(), [False, True, False])
+
+    def test_string_extension_dtype(self):
+        genes = pd.Series(["Xkr4", "Sox3", "Actb"], dtype="string")
+        self.assertEqual(genes.dtype.name, "string")
+        self._assert_value_filter(genes)
+
+    def test_pandas3_str_dtype(self):
+        with pd.option_context("future.infer_string", True):
+            genes = pd.Series(["Xkr4", "Sox3", "Actb"])
+            self.assertTrue(pd.api.types.is_string_dtype(genes))
+            self.assertNotIn(genes.dtype.name, ["object", "category", "boolean"])
+            self._assert_value_filter(genes)


### PR DESCRIPTION
## Problem

Fixes #2793.

Coloring by a gene returns **HTTP 400** for AnnData files whose `var` index (gene names) uses a pandas **string dtype** instead of `object` — the default for text columns under **pandas 3.0**, and under pandas 2.x with `future.infer_string`:

```
GET /api/v0.2/data/var?var:name_0=<gene>  ->  400
```

## Root cause

`DataAdaptor._annotation_filter_to_mask` chooses between an exact-value filter and a numeric min/max filter by dtype name:

```python
if anno_data.dtype.name in ["boolean", "category", "object"]:
    key_idx = np.in1d(anno_data, values)   # value filter
    ...
else:
    # numeric min/max — a no-op when only "values" is provided
```

A pandas string dtype (`"string"`, `"string[pyarrow]"`, or the pandas 3.0 NumPy-backed `"str"`) is not in the allow-list, so a gene-name value filter falls into the numeric branch and does nothing. The mask stays all-`True`, so *every* var column is selected; `data_frame_to_fbs_matrix` then exceeds `column_request_max` and raises `ExceedsLimitError` → 400. The same applies to obs categorical value filters stored as a string dtype.

## Fix

Route all pandas string dtypes through the value-equality branch via `pandas.api.types.is_string_dtype`:

```python
if anno_data.dtype.name in ["boolean", "category", "object"] or pd.api.types.is_string_dtype(anno_data):
```

## Tests

Adds `StringDtypeFilterMaskTest` covering both `StringDtype` (`"string"`) and the pandas 3.0 `"str"` dtype (via `future.infer_string`), asserting the value filter selects exactly the matching row.

## Reproduction

```python
import anndata, numpy as np, pandas as pd
pd.set_option("future.infer_string", True)  # pandas 3.0 default
adata = anndata.AnnData(
    X=np.random.default_rng(0).random((10, 2000), dtype=np.float32),
    var=pd.DataFrame(index=[f"gene{i}" for i in range(2000)]),
)
adata.write_h5ad("repro.h5ad")
# cellxgene launch repro.h5ad -> color by a gene -> 400 (before this fix)
```
